### PR TITLE
Fix invalid JavaScript emitted by UBTA build

### DIFF
--- a/UBTA/dist/index.html
+++ b/UBTA/dist/index.html
@@ -28,6 +28,59 @@
  * This constrained adapter implements the Previewer surface used here because the full upstream bundle was unavailable in the supplied materials. */
 window.Paged={Previewer:class{async preview(content,styles,target){target.replaceChildren();const nodes=[...content.children];for(const node of nodes){const page=document.createElement('div');page.className='pagedjs_page';page.tabIndex=-1;const box=document.createElement('div');box.className='pagedjs_pagebox';box.append(node.cloneNode(true));page.append(box);target.append(page)}return{total:target.children.length,pages:[...target.children]}}}};
 
+const FORMATS = new Set(['text', 'number', 'gbp']);
+const runsText = runs => (runs || []).map(run => run.text || '').join('');
+const plainRuns = text => text === '' ? [] : [{ text, highlight: false, link: null }];
+
+const tableColumnFormat = column => FORMATS.has(column?.format) ? column.format : column?.numeric === true ? 'number' : 'text';
+
+/** Blank and invalid values return null; arbitrary text is never coerced to zero. */
+function parseTableNumber(value) {
+  const compact = String(value ?? '').replace(/\s/g, '');
+  if (!compact) return null;
+  const match = compact.match(/^(?:£)?([+-]?)(?:£)?((?:\d{1,3}(?:,\d{3})+)|\d+)(\.\d+)?$/);
+  if (!match) return null;
+  const number = Number(`${match[1]}${match[2].replaceAll(',', '')}${match[3] || ''}`);
+  return Number.isFinite(number) ? number : null;
+}
+
+function formatTableNumber(value, format = 'number') {
+  if (!Number.isFinite(value)) return '';
+  if (format === 'gbp') return `${value < 0 ? '-' : ''}£${Math.abs(value).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  if (format === 'number') return value.toLocaleString('en-GB', { maximumFractionDigits: 20 });
+  return String(value);
+}
+
+function recalculateTableTotals(block) {
+  if (block?.type !== 'table') return block;
+  block.rows.forEach((row, rowIndex) => {
+    if (!row.isTotal) return;
+    block.columns.forEach((column, columnIndex) => {
+      const format = tableColumnFormat(column);
+      if (format === 'text') return;
+      const values = block.rows.slice(0, rowIndex).filter(candidate => !candidate.isTotal).map(candidate => parseTableNumber(runsText(candidate.cells?.[columnIndex]?.runs))).filter(value => value !== null);
+      const total = values.reduce((sum, value) => sum + value, 0);
+      if (row.cells?.[columnIndex]) row.cells[columnIndex].runs = plainRuns(formatTableNumber(total, format));
+    });
+  });
+  return block;
+}
+
+function moveTableRow(block, index, offset) {
+  const target = index + offset, row = block?.rows?.[index];
+  if (!row || target < 0 || target >= block.rows.length || block.rows[target].isTotal !== row.isTotal) return false;
+  [block.rows[index], block.rows[target]] = [block.rows[target], block.rows[index]];
+  return target;
+}
+
+function moveTableColumn(block, index, offset) {
+  const target = index + offset;
+  if (!block?.columns?.[index] || target < 0 || target >= block.columns.length) return false;
+  [block.columns[index], block.columns[target]] = [block.columns[target], block.columns[index]];
+  block.rows.forEach(row => { [row.cells[index], row.cells[target]] = [row.cells[target], row.cells[index]]; });
+  return target;
+}
+
 
 const SCHEMA_VERSION = 5;
 const METADATA_KEYS = ['clientName','projectTitle','documentType','date','version','subtitle','adviser','status'];
@@ -214,7 +267,6 @@ function transformRuns(runs, offsets, kind, value) {
 
 function insertPlainText(event, documentObject=document) { event.preventDefault();documentObject.execCommand('insertText',false,event.clipboardData.getData('text/plain')); }
 
-{ parseTableNumber, formatTableNumber, tableColumnFormat, recalculateTableTotals, moveTableRow, moveTableColumn } from './table-values.js';
 function validatedLink(external,internal){const candidate=String(external||'').trim();return safeHref(candidate||internal);}
 function confirmStepDeletion(steps,index,confirmAction){if(steps.length<=1||index<0||index>=steps.length)return false;return confirmAction(`Delete Step ${index+1}: ${steps[index].title}?`);}
 function splitListRuns(runs,offset){let position=0,before=[],after=[];for(const run of runs){const split=Math.max(0,Math.min(run.text.length,offset-position));if(split)before.push({...run,text:run.text.slice(0,split)});if(split<run.text.length)after.push({...run,text:run.text.slice(split)});position+=run.text.length}return [normaliseRuns(before),normaliseRuns(after)];}

--- a/UBTA/scripts/build.mjs
+++ b/UBTA/scripts/build.mjs
@@ -1,7 +1,7 @@
 import fs from 'node:fs';import path from 'node:path';
 const root=path.resolve(import.meta.dirname,'..'),read=file=>fs.readFileSync(path.join(root,file),'utf8');
-const bundle=file=>read(file).replace(/^import .*;\n/gm,'').replace(/export /g,'');
-const modules=['src/state/schema.js','src/state/history.js','src/state/persistence.js','src/editor/dom-runs.js','src/editor/interactions.js','src/editor/repagination.js','src/editor/command-routing.js','src/editor/list-rendering.js','src/editor/block-deletion.js','src/editor/insertion-context.js','src/main.js'];
+const bundle=file=>read(file).replace(/^import .*;\n/gm,'').replace(/^export \{[^}]+\} from ['"][^'"]+['"];\n?/gm,'').replace(/export /g,'');
+const modules=['src/editor/table-values.js','src/state/schema.js','src/state/history.js','src/state/persistence.js','src/editor/dom-runs.js','src/editor/interactions.js','src/editor/repagination.js','src/editor/command-routing.js','src/editor/list-rendering.js','src/editor/block-deletion.js','src/editor/insertion-context.js','src/main.js'];
 const css=['src/styles/app.css','src/styles/document.css'].map(read).join('\n'),vendor=read('src/vendor/paged.js'),body=read('src/index.html').match(/<body>([\s\S]*)<\/body>/)[1].replace(/<script[\s\S]*?<\/script>/g,'').trim();
 const html=`<!doctype html><html lang="en-GB"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>UBTA Steps Plan Editor</title><style>${css}</style></head><body>${body}<script>${vendor}\n${modules.map(bundle).join('\n')}<\/script></body></html>`;
 fs.mkdirSync(path.join(root,'dist'),{recursive:true});fs.writeFileSync(path.join(root,'dist/index.html'),html);console.log(`Built dist/index.html (${html.length} bytes)`);

--- a/UBTA/tests/build.test.js
+++ b/UBTA/tests/build.test.js
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import test from 'node:test';
+import vm from 'node:vm';
 import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
@@ -15,4 +16,16 @@ test('production bundle includes the blank-space insertion helper before its cal
 
   assert.notEqual(definition, -1, 'insertionContextFromPoint must be bundled');
   assert.ok(caller > definition, 'the helper must be defined before blankStepClick uses it');
+});
+
+test('production bundle contains valid JavaScript and resolves table re-exports', () => {
+  execFileSync(process.execPath, ['scripts/build.mjs'], { cwd: root });
+  const html = fs.readFileSync(path.join(root, 'dist/index.html'), 'utf8');
+  const scripts = [...html.matchAll(/<script>([\s\S]*?)<\/script>/g)];
+  const source = scripts.at(-1)?.[1];
+
+  assert.ok(source, 'the production bundle must contain an inline script');
+  assert.doesNotMatch(source, /\}\s+from\s+['"]\.\/table-values\.js['"]/, 're-export syntax must not be partially stripped');
+  assert.ok(source.indexOf('function parseTableNumber(') < source.indexOf('parseTableNumber(value)'), 'table helpers must be bundled before their callers');
+  assert.doesNotThrow(() => new vm.Script(source), 'the production bundle must parse as classic JavaScript');
 });


### PR DESCRIPTION
### Motivation
- A production `dist/index.html` contained a partial ES-module re-export fragment which produced a parser error `Unexpected string` in the browser at the quoted module path. 
- The build step stripped only the `export ` prefix leaving a malformed statement and also did not include the `table-values.js` implementation before consumers, risking runtime failures. 

### Description
- Update `UBTA/scripts/build.mjs` to remove whole re-export declarations with a targeted regex (`.replace(/^export \{[^}]+\} from ['"][^'"]+['"];\n?/gm,'')`) and continue to strip ordinary `export` prefixes, and add `src/editor/table-values.js` to the front of the `modules` list. 
- Rebuild and check in the generated `UBTA/dist/index.html` so table helpers like `parseTableNumber` are emitted as actual function declarations before their callers. 
- Add a regression test in `UBTA/tests/build.test.js` that extracts the inline production script, asserts the re-export fragment is not present, verifies the table helpers are ordered before their callers, and parses the bundle using `vm.Script` to ensure valid classic JS. 

### Testing
- Ran the full test suite with `npm test` and all tests including the new bundle-parsing regression passed. 
- Extracted the generated inline script from `dist/index.html` and validated it with `node --check` / `new vm.Script(...)` which succeeded without `Unexpected string` syntax errors. 
- Ran `git diff --check` to ensure no whitespace/patch issues and committed the regenerated `dist/index.html` and test changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a68afbceef883249c8d0585008bd7c0)