### PR TITLE
Improve share table keyboard editing

### DIFF
--- a/UBTA/dist/index.html
+++ b/UBTA/dist/index.html
@@ -1,49 +1,1557 @@
-<!doctype html><html lang="en-GB"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>UBTA Steps Plan Editor</title><style>:root{--lav:#8d8eb1;--coral:#f79097;--grey:#808080;--paper:#fffefa;--review:#ffe985;--ink:#343444;--toolbar-blue:#17365d;--toolbar-yellow:#ffd966;--font:"Century Gothic","Futura","Aptos","Segoe UI",sans-serif}*{box-sizing:border-box}body{margin:0;background:#e9e9ec;color:var(--ink);font-family:var(--font)}.editor-command-bars{position:sticky;top:0;z-index:20}.toolbar{min-height:126px;background:var(--toolbar-blue);border-bottom:3px solid #0d2747;display:grid;grid-template-columns:minmax(330px,1.45fr) minmax(180px,.8fr) minmax(260px,1.1fr) minmax(250px,1fr) minmax(390px,1.6fr) minmax(230px,.9fr);gap:4px;padding:6px;align-items:stretch;box-shadow:0 2px 8px #0005;overflow-x:auto}.brand{display:none}.toolbar-group,.nav{display:grid;grid-template-rows:23px repeat(2,34px) minmax(18px,auto);align-content:start;gap:3px;min-width:0;padding:0 5px 3px;border-right:1px solid #ffffff55}.group-label{display:flex;align-items:center;justify-content:center;margin:0 -5px;color:#17233a;background:var(--toolbar-yellow);font-size:.72rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase}.command-row{display:flex;align-items:center;gap:3px;min-width:0}.toolbar button,.toolbar select{height:31px;border:1px solid #b8bec7;border-radius:0;background:#fff;color:#26364b;padding:0 7px;font:inherit;white-space:nowrap}.toolbar button:hover{border-color:var(--toolbar-yellow);background:#fffbea}.toolbar button:focus-visible,.toolbar select:focus-visible{outline:3px solid var(--toolbar-yellow);outline-offset:1px}.toolbar button.active{background:var(--review)}.toolbar .danger{color:#8a2930}.document-group{grid-column:1}.text-group{grid-column:2}.step-group{grid-column:3}.appendix-group{grid-column:4}.table-group{grid-column:5}.nav{grid-column:6;border-right:0;background:#102b4e;padding-inline:7px;justify-self:stretch}.nav .command-row{justify-content:center}.nav span{color:#fff;white-space:nowrap}.save-state{align-self:center;color:#fff!important;overflow:hidden;text-overflow:ellipsis}.canvas{padding:24px 20px 70px;overflow:auto}.pagedjs_pages{display:flex;flex-direction:column;align-items:center;gap:22px}.pagedjs_page{width:297mm;height:210mm;background:var(--paper);box-shadow:0 3px 16px #0003;overflow:hidden}.pagedjs_pagebox{height:100%}@media(max-width:1500px){.toolbar{grid-template-columns:repeat(5,max-content) minmax(220px,1fr);font-size:13px}.toolbar button,.toolbar select{padding-inline:5px}.nav{position:sticky;right:0;box-shadow:-5px 0 7px #102b4e}}@media(max-width:1400px){.pagedjs_page{transform-origin:top center;zoom:.86}.toolbar{padding:5px;gap:3px;font-size:12px}.toolbar-group,.nav{padding-inline:3px}.group-label{margin-inline:-3px;font-size:.65rem}.save-state{max-width:94px}}@media(max-width:900px){.toolbar{grid-template-columns:repeat(5,max-content) minmax(205px,1fr);min-height:118px}.toolbar button,.toolbar select{height:29px}.toolbar-group,.nav{grid-template-rows:22px repeat(2,32px) minmax(18px,auto)}}
-.context-toolbar{display:flex;align-items:center;justify-content:center;gap:4px;padding:5px;background:#f4f4f7;border-bottom:1px solid #cfcfd7;box-shadow:0 2px 5px #0001;color:#666;font-size:.9rem}.context-label{margin-right:4px;font-size:.78rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase}.context-toolbar button,.context-toolbar select{height:29px;border:1px solid #ccc;background:white;color:#444;border-radius:3px;padding:3px 8px;font:inherit}.context-toolbar button:focus,.context-toolbar select:focus{border-color:var(--lav);outline:2px solid #8d8eb155}.toolbar button:disabled,.context-toolbar button:disabled,.context-toolbar select:disabled{opacity:.4;cursor:not-allowed}.visually-hidden{position:absolute!important;width:1px;height:1px;overflow:hidden;clip:rect(0 0 0 0)}dialog{border:1px solid var(--lav);border-radius:8px;box-shadow:0 8px 40px #0005}dialog form{display:grid;gap:14px;min-width:360px}dialog label{display:grid;gap:5px}.block-controls{float:right;opacity:.15;display:flex;gap:2px}.editable-block:hover>.block-controls,.editable-block:focus-within>.block-controls{opacity:1}.block-controls button{cursor:pointer}.block-controls .delete-block{color:#8a2930}
-.save-state{font-size:.8rem;white-space:nowrap;color:#fff}.save-state.dirty{color:#ffe985!important}.save-state.error{color:#ffb5ba!important}.toolbar select{height:31px;border:1px solid #b8bec7;border-radius:0;background:#fff;padding:0 7px;font:inherit}.versions-list{display:grid;gap:8px;max-height:50vh;overflow:auto}.version-row{display:grid;grid-template-columns:1fr auto auto;gap:8px;align-items:center;padding:8px;border:1px solid #ddd;border-radius:4px}.version-row small{display:block;color:#666}
-.properties-grid{display:grid;grid-template-columns:repeat(2,minmax(220px,1fr));gap:14px}.properties-grid label{display:grid;gap:5px}.properties-grid input,.properties-grid select{min-height:38px;padding:7px 9px;font:inherit}.dialog-actions{display:flex;justify-content:flex-end;gap:8px}
-.form-error{margin:0;color:#9a2630;font-weight:700}
-.insertion-chooser{width:min(430px,calc(100vw - 32px));padding:20px}.insertion-chooser::backdrop{background:#34344455}.insertion-chooser form{min-width:0}.insertion-chooser h2,.insertion-chooser p{margin:0}.insertion-choices{display:grid;grid-template-columns:1fr 1fr;gap:9px}.insertion-choices button{display:grid;gap:3px;text-align:left;padding:11px;border:1px solid #cfcfd7;border-radius:6px;background:#fff;color:var(--ink);font:inherit}.insertion-choices button:hover{border-color:var(--lav);background:#f7f7fb}.insertion-choices button:focus-visible{outline:3px solid var(--lav);outline-offset:2px}.insertion-choices span{font-size:.78rem;color:#666}
-.pagination-staging{position:absolute!important;left:-200vw;top:0;visibility:hidden;display:block!important}
-.link-context{display:flex;align-items:center;justify-content:center;gap:8px;padding:5px 12px;background:#f4f4f7;border-bottom:1px solid #cfcfd7;box-shadow:0 2px 5px #0001;font-size:.85rem}.link-context[hidden]{display:none}.link-context button{min-height:30px;border:1px solid var(--lav);border-radius:4px;background:#fff;color:var(--ink)}.link-context kbd{color:#666;font:inherit}
-@media print{@page{size:A4 landscape;margin:0}html,body{width:297mm!important;min-width:297mm!important;margin:0!important;padding:0!important;background:#fff!important;overflow:visible!important;zoom:1!important;transform:none!important}body>*:not(.canvas),.editor-command-bars,.toolbar,.link-context{display:none!important}.canvas{display:block!important;padding:0!important;margin:0!important;overflow:visible!important;background:#fff!important}#preview{display:block!important;margin:0!important;padding:0!important;zoom:1!important;transform:none!important}#preview .pagedjs_page{display:block!important;width:297mm!important;height:210mm!important;min-width:297mm!important;min-height:210mm!important;margin:0!important;gap:0!important;box-shadow:none!important;zoom:1!important;transform:none!important;overflow:hidden!important;break-after:page;page-break-after:always;-webkit-print-color-adjust:exact;print-color-adjust:exact}#preview .pagedjs_page:last-child{break-after:auto;page-break-after:auto}.pagedjs_pages{display:block!important;width:297mm!important;margin:0!important;gap:0!important;zoom:1!important;transform:none!important}#preview .pagedjs_pagebox,#preview .sheet-source{width:297mm!important;height:210mm!important;min-width:297mm!important;min-height:210mm!important;margin:0!important;zoom:1!important;transform:none!important}}
-.insertion-chooser [hidden]{display:none!important}.insertion-chooser section{display:grid;gap:14px}.insertion-chooser input{width:100%;min-height:42px;border:1px solid #aaa;border-radius:5px;padding:8px;font:inherit}.insertion-chooser label{font-weight:700}.insertion-chooser button[data-insertion-back]{justify-self:start;margin-top:4px}.insertion-chooser button:focus-visible,.insertion-chooser input:focus-visible{outline:3px solid var(--lav);outline-offset:2px}.insertion-chooser .form-error{padding:9px;border-left:4px solid #a4252e;background:#fff0f1;color:#7b1720}.insertion-chooser #default-unlock{display:grid;gap:8px}@media(max-width:520px){.insertion-chooser{width:calc(100vw - 16px);padding:14px}.insertion-choices{grid-template-columns:1fr}}
+<!doctype html><html lang="en-GB"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>UBTA Steps Plan Editor</title><style>:root {
+  --lav: #8d8eb1;
+  --coral: #f79097;
+  --grey: #808080;
+  --paper: #fffefa;
+  --review: #ffe985;
+  --ink: #343444;
+  --toolbar-blue: #17365d;
+  --toolbar-yellow: #ffd966;
+  --font: "Century Gothic", "Futura", "Aptos", "Segoe UI", sans-serif;
+}
+* {
+  box-sizing: border-box;
+}
+body {
+  margin: 0;
+  background: #e9e9ec;
+  color: var(--ink);
+  font-family: var(--font);
+}
+.editor-command-bars {
+  position: sticky;
+  top: 0;
+  z-index: 20;
+}
+.toolbar {
+  min-height: 126px;
+  background: var(--toolbar-blue);
+  border-bottom: 3px solid #0d2747;
+  display: grid;
+  grid-template-columns:
+    minmax(330px, 1.45fr) minmax(180px, 0.8fr) minmax(260px, 1.1fr)
+    minmax(250px, 1fr) minmax(390px, 1.6fr) minmax(230px, 0.9fr);
+  gap: 4px;
+  padding: 6px;
+  align-items: stretch;
+  box-shadow: 0 2px 8px #0005;
+  overflow-x: auto;
+}
+.brand {
+  display: none;
+}
+.toolbar-group,
+.nav {
+  display: grid;
+  grid-template-rows: 23px repeat(2, 34px) minmax(18px, auto);
+  align-content: start;
+  gap: 3px;
+  min-width: 0;
+  padding: 0 5px 3px;
+  border-right: 1px solid #ffffff55;
+}
+.group-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin: 0 -5px;
+  color: #17233a;
+  background: var(--toolbar-yellow);
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.command-row {
+  display: flex;
+  align-items: center;
+  gap: 3px;
+  min-width: 0;
+}
+.toolbar button,
+.toolbar select {
+  height: 31px;
+  border: 1px solid #b8bec7;
+  border-radius: 0;
+  background: #fff;
+  color: #26364b;
+  padding: 0 7px;
+  font: inherit;
+  white-space: nowrap;
+}
+.toolbar button:hover {
+  border-color: var(--toolbar-yellow);
+  background: #fffbea;
+}
+.toolbar button:focus-visible,
+.toolbar select:focus-visible {
+  outline: 3px solid var(--toolbar-yellow);
+  outline-offset: 1px;
+}
+.toolbar button.active {
+  background: var(--review);
+}
+.toolbar .danger {
+  color: #8a2930;
+}
+.document-group {
+  grid-column: 1;
+}
+.text-group {
+  grid-column: 2;
+}
+.step-group {
+  grid-column: 3;
+}
+.appendix-group {
+  grid-column: 4;
+}
+.table-group {
+  grid-column: 5;
+}
+.nav {
+  grid-column: 6;
+  border-right: 0;
+  background: #102b4e;
+  padding-inline: 7px;
+  justify-self: stretch;
+}
+.nav .command-row {
+  justify-content: center;
+}
+.nav span {
+  color: #fff;
+  white-space: nowrap;
+}
+.save-state {
+  align-self: center;
+  color: #fff !important;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.canvas {
+  padding: 24px 20px 70px;
+  overflow: auto;
+}
+.pagedjs_pages {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 22px;
+}
+.pagedjs_page {
+  width: 297mm;
+  height: 210mm;
+  background: var(--paper);
+  box-shadow: 0 3px 16px #0003;
+  overflow: hidden;
+}
+.pagedjs_pagebox {
+  height: 100%;
+}
+@media (max-width: 1500px) {
+  .toolbar {
+    grid-template-columns: repeat(5, max-content) minmax(220px, 1fr);
+    font-size: 13px;
+  }
+  .toolbar button,
+  .toolbar select {
+    padding-inline: 5px;
+  }
+  .nav {
+    position: sticky;
+    right: 0;
+    box-shadow: -5px 0 7px #102b4e;
+  }
+}
+@media (max-width: 1400px) {
+  .pagedjs_page {
+    transform-origin: top center;
+    zoom: 0.86;
+  }
+  .toolbar {
+    padding: 5px;
+    gap: 3px;
+    font-size: 12px;
+  }
+  .toolbar-group,
+  .nav {
+    padding-inline: 3px;
+  }
+  .group-label {
+    margin-inline: -3px;
+    font-size: 0.65rem;
+  }
+  .save-state {
+    max-width: 94px;
+  }
+}
+@media (max-width: 900px) {
+  .toolbar {
+    grid-template-columns: repeat(5, max-content) minmax(205px, 1fr);
+    min-height: 118px;
+  }
+  .toolbar button,
+  .toolbar select {
+    height: 29px;
+  }
+  .toolbar-group,
+  .nav {
+    grid-template-rows: 22px repeat(2, 32px) minmax(18px, auto);
+  }
+}
+.context-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 5px;
+  background: #f4f4f7;
+  border-bottom: 1px solid #cfcfd7;
+  box-shadow: 0 2px 5px #0001;
+  color: #666;
+  font-size: 0.9rem;
+}
+.context-label {
+  margin-right: 4px;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.context-toolbar button,
+.context-toolbar select {
+  height: 29px;
+  border: 1px solid #ccc;
+  background: white;
+  color: #444;
+  border-radius: 3px;
+  padding: 3px 8px;
+  font: inherit;
+}
+.context-toolbar button:focus,
+.context-toolbar select:focus {
+  border-color: var(--lav);
+  outline: 2px solid #8d8eb155;
+}
+.toolbar button:disabled,
+.context-toolbar button:disabled,
+.context-toolbar select:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+.visually-hidden {
+  position: absolute !important;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+}
+dialog {
+  border: 1px solid var(--lav);
+  border-radius: 8px;
+  box-shadow: 0 8px 40px #0005;
+}
+dialog form {
+  display: grid;
+  gap: 14px;
+  min-width: 360px;
+}
+dialog label {
+  display: grid;
+  gap: 5px;
+}
+.block-controls {
+  float: right;
+  opacity: 0.15;
+  display: flex;
+  gap: 2px;
+}
+.editable-block:hover > .block-controls,
+.editable-block:focus-within > .block-controls {
+  opacity: 1;
+}
+.block-controls button {
+  cursor: pointer;
+}
+.block-controls .delete-block {
+  color: #8a2930;
+}
+.save-state {
+  font-size: 0.8rem;
+  white-space: nowrap;
+  color: #fff;
+}
+.save-state.dirty {
+  color: #ffe985 !important;
+}
+.save-state.error {
+  color: #ffb5ba !important;
+}
+.toolbar select {
+  height: 31px;
+  border: 1px solid #b8bec7;
+  border-radius: 0;
+  background: #fff;
+  padding: 0 7px;
+  font: inherit;
+}
+.versions-list {
+  display: grid;
+  gap: 8px;
+  max-height: 50vh;
+  overflow: auto;
+}
+.version-row {
+  display: grid;
+  grid-template-columns: 1fr auto auto;
+  gap: 8px;
+  align-items: center;
+  padding: 8px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+.version-row small {
+  display: block;
+  color: #666;
+}
+.properties-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(220px, 1fr));
+  gap: 14px;
+}
+.properties-grid label {
+  display: grid;
+  gap: 5px;
+}
+.properties-grid input,
+.properties-grid select {
+  min-height: 38px;
+  padding: 7px 9px;
+  font: inherit;
+}
+.dialog-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.form-error {
+  margin: 0;
+  color: #9a2630;
+  font-weight: 700;
+}
+.insertion-chooser {
+  width: min(430px, calc(100vw - 32px));
+  padding: 20px;
+}
+.insertion-chooser::backdrop {
+  background: #34344455;
+}
+.insertion-chooser form {
+  min-width: 0;
+}
+.insertion-chooser h2,
+.insertion-chooser p {
+  margin: 0;
+}
+.insertion-choices {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 9px;
+}
+.insertion-choices button {
+  display: grid;
+  gap: 3px;
+  text-align: left;
+  padding: 11px;
+  border: 1px solid #cfcfd7;
+  border-radius: 6px;
+  background: #fff;
+  color: var(--ink);
+  font: inherit;
+}
+.insertion-choices button:hover {
+  border-color: var(--lav);
+  background: #f7f7fb;
+}
+.insertion-choices button:focus-visible {
+  outline: 3px solid var(--lav);
+  outline-offset: 2px;
+}
+.insertion-choices span {
+  font-size: 0.78rem;
+  color: #666;
+}
+.pagination-staging {
+  position: absolute !important;
+  left: -200vw;
+  top: 0;
+  visibility: hidden;
+  display: block !important;
+}
+.link-context {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 5px 12px;
+  background: #f4f4f7;
+  border-bottom: 1px solid #cfcfd7;
+  box-shadow: 0 2px 5px #0001;
+  font-size: 0.85rem;
+}
+.link-context[hidden] {
+  display: none;
+}
+.link-context button {
+  min-height: 30px;
+  border: 1px solid var(--lav);
+  border-radius: 4px;
+  background: #fff;
+  color: var(--ink);
+}
+.link-context kbd {
+  color: #666;
+  font: inherit;
+}
+@media print {
+  @page {
+    size: A4 landscape;
+    margin: 0;
+  }
+  html,
+  body {
+    width: 297mm !important;
+    min-width: 297mm !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    background: #fff !important;
+    overflow: visible !important;
+    zoom: 1 !important;
+    transform: none !important;
+  }
+  body > *:not(.canvas),
+  .editor-command-bars,
+  .toolbar,
+  .link-context {
+    display: none !important;
+  }
+  .canvas {
+    display: block !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    overflow: visible !important;
+    background: #fff !important;
+  }
+  #preview {
+    display: block !important;
+    margin: 0 !important;
+    padding: 0 !important;
+    zoom: 1 !important;
+    transform: none !important;
+  }
+  #preview .pagedjs_page {
+    display: block !important;
+    width: 297mm !important;
+    height: 210mm !important;
+    min-width: 297mm !important;
+    min-height: 210mm !important;
+    margin: 0 !important;
+    gap: 0 !important;
+    box-shadow: none !important;
+    zoom: 1 !important;
+    transform: none !important;
+    overflow: hidden !important;
+    break-after: page;
+    page-break-after: always;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  #preview .pagedjs_page:last-child {
+    break-after: auto;
+    page-break-after: auto;
+  }
+  .pagedjs_pages {
+    display: block !important;
+    width: 297mm !important;
+    margin: 0 !important;
+    gap: 0 !important;
+    zoom: 1 !important;
+    transform: none !important;
+  }
+  #preview .pagedjs_pagebox,
+  #preview .sheet-source {
+    width: 297mm !important;
+    height: 210mm !important;
+    min-width: 297mm !important;
+    min-height: 210mm !important;
+    margin: 0 !important;
+    zoom: 1 !important;
+    transform: none !important;
+  }
+}
+.insertion-chooser [hidden] {
+  display: none !important;
+}
+.insertion-chooser section {
+  display: grid;
+  gap: 14px;
+}
+.insertion-chooser input {
+  width: 100%;
+  min-height: 42px;
+  border: 1px solid #aaa;
+  border-radius: 5px;
+  padding: 8px;
+  font: inherit;
+}
+.insertion-chooser label {
+  font-weight: 700;
+}
+.insertion-chooser button[data-insertion-back] {
+  justify-self: start;
+  margin-top: 4px;
+}
+.insertion-chooser button:focus-visible,
+.insertion-chooser input:focus-visible {
+  outline: 3px solid var(--lav);
+  outline-offset: 2px;
+}
+.insertion-chooser .form-error {
+  padding: 9px;
+  border-left: 4px solid #a4252e;
+  background: #fff0f1;
+  color: #7b1720;
+}
+.insertion-chooser #default-unlock {
+  display: grid;
+  gap: 8px;
+}
+@media (max-width: 520px) {
+  .insertion-chooser {
+    width: calc(100vw - 16px);
+    padding: 14px;
+  }
+  .insertion-choices {
+    grid-template-columns: 1fr;
+  }
+}
 
-.page-jump-label{color:#fff;font-size:.68rem;text-align:center}.nav #page-jump{width:100%;height:27px}.total-toggle{display:flex;align-items:center;color:#fff;white-space:nowrap;font-size:.78rem}.total-toggle input{accent-color:var(--toolbar-yellow)}
-@media print{.list-trailing-hit-area{display:none!important}}
-.editor-switcher{position:fixed;bottom:0;left:0;right:0;z-index:30;display:flex;justify-content:center;gap:6px;padding:8px;background:#102b4e}.editor-switcher button{padding:9px 22px;border:1px solid #fff8;background:#fff;color:#17365d;font:inherit;font-weight:700}.editor-switcher button[aria-current=page]{background:var(--toolbar-yellow)}.excel-toolbar[hidden],#excel-editor[hidden],#preview[hidden]{display:none!important}.excel-toolbar{display:flex;gap:5px;align-items:center;padding:7px;background:#f5f5f7;overflow:auto}.excel-toolbar button{white-space:nowrap;padding:7px}#excel-editor{width:min(1500px,100%);margin:auto;background:#fff;padding:18px}.company-tabs{display:flex;gap:4px;border-bottom:2px solid #17365d;margin-bottom:15px}.company-tabs button{padding:10px 16px}.company-tabs button[aria-selected=true]{background:#17365d;color:#fff}.step-share-section{margin:15px 0;border:1px solid #b9bec6}.collapse-step{width:100%;padding:10px;text-align:left;border:0;background:#e9edf3;color:#17365d;font-weight:700}.share-table{padding:10px}.share-table h3{margin:3px 0 8px}.table-scroll{overflow:auto;max-height:65vh}.share-table table{border-collapse:separate;border-spacing:0;min-width:100%}.share-table th,.share-table td{min-width:105px;padding:6px;border-right:1px solid #bbb;border-bottom:1px solid #bbb;background:#fff}.share-table thead th{position:sticky;top:0;z-index:3;background:#dfe7f2}.share-table th:first-child{position:sticky;left:0;z-index:2}.share-table td:nth-child(2),.share-table th:nth-child(2){position:sticky;left:105px;z-index:2;background:#f7f7f7}.share-table input,.share-table select{width:100%}.share-table .number{text-align:right}.share-table .negative{color:#b00020}.share-table .total,.share-table .total-row>*{font-weight:700;background:#eef0f3}.share-table td[data-editable=true]:focus{outline:3px solid #3578bd;outline-offset:-3px}@media print{#excel-editor,.editor-switcher,.excel-toolbar{display:none!important}}
+.page-jump-label {
+  color: #fff;
+  font-size: 0.68rem;
+  text-align: center;
+}
+.nav #page-jump {
+  width: 100%;
+  height: 27px;
+}
+.total-toggle {
+  display: flex;
+  align-items: center;
+  color: #fff;
+  white-space: nowrap;
+  font-size: 0.78rem;
+}
+.total-toggle input {
+  accent-color: var(--toolbar-yellow);
+}
+@media print {
+  .list-trailing-hit-area {
+    display: none !important;
+  }
+}
+.editor-switcher {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 30;
+  display: flex;
+  justify-content: center;
+  gap: 6px;
+  padding: 8px;
+  background: #102b4e;
+}
+.editor-switcher button {
+  padding: 9px 22px;
+  border: 1px solid #fff8;
+  background: #fff;
+  color: #17365d;
+  font: inherit;
+  font-weight: 700;
+}
+.editor-switcher button[aria-current="page"] {
+  background: var(--toolbar-yellow);
+}
+.excel-toolbar[hidden],
+#excel-editor[hidden],
+#preview[hidden] {
+  display: none !important;
+}
+.excel-toolbar {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  padding: 7px;
+  background: #f5f5f7;
+  overflow: auto;
+}
+.excel-toolbar button {
+  white-space: nowrap;
+  padding: 7px;
+}
+#excel-editor {
+  width: min(1500px, 100%);
+  margin: auto;
+  background: #fff;
+  padding: 18px;
+}
+.company-tabs {
+  display: flex;
+  gap: 4px;
+  border-bottom: 2px solid #17365d;
+  margin-bottom: 15px;
+}
+.company-tabs button {
+  padding: 10px 16px;
+}
+.company-tabs button[aria-selected="true"] {
+  background: #17365d;
+  color: #fff;
+}
+.step-share-section {
+  margin: 15px 0;
+  border: 1px solid #b9bec6;
+}
+.collapse-step {
+  width: 100%;
+  padding: 10px;
+  text-align: left;
+  border: 0;
+  background: #e9edf3;
+  color: #17365d;
+  font-weight: 700;
+}
+.share-table {
+  padding: 10px;
+}
+.share-table h3 {
+  margin: 3px 0 8px;
+}
+.table-scroll {
+  overflow: auto;
+  max-height: 65vh;
+}
+.share-table table {
+  border-collapse: separate;
+  border-spacing: 0;
+  min-width: 100%;
+}
+.share-table th,
+.share-table td {
+  min-width: 105px;
+  padding: 6px;
+  border-right: 1px solid #bbb;
+  border-bottom: 1px solid #bbb;
+  background: #fff;
+}
+.share-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 3;
+  background: #dfe7f2;
+}
+.share-table th:first-child {
+  position: sticky;
+  left: 0;
+  z-index: 2;
+}
+.share-table td:nth-child(2),
+.share-table th:nth-child(2) {
+  position: sticky;
+  left: 105px;
+  z-index: 2;
+  background: #f7f7f7;
+}
+.share-table input,
+.share-table select {
+  width: 100%;
+}
+.share-table .number {
+  text-align: right;
+}
+.share-table .negative {
+  color: #b00020;
+}
+.share-table .total,
+.share-table .total-row > * {
+  font-weight: 700;
+  background: #eef0f3;
+}
+.share-table td[data-editable="true"]:focus {
+  outline: 3px solid #3578bd;
+  outline-offset: -3px;
+}
+@media print {
+  #excel-editor,
+  .editor-switcher,
+  .excel-toolbar {
+    display: none !important;
+  }
+}
 
-.sheet-source{width:297mm;height:210mm;position:relative;padding:42mm 24mm 18mm;background:var(--paper);overflow:hidden}.page-header{position:absolute;top:9mm;left:20mm;right:20mm;height:25mm;display:flex;align-items:center;border-bottom:.4mm solid #8d8eb155;padding-bottom:3mm}.header-brand{font-size:22pt;font-weight:700;letter-spacing:.04em;color:var(--lav)}.header-details{margin-left:auto;color:var(--grey);font-size:9.5pt}.header-details b{color:var(--coral);padding:0 2mm}.page-footer{position:absolute;bottom:7mm;left:20mm;right:20mm;text-align:center;color:var(--grey);font-size:9pt}.cover{padding-top:48mm}.cover-kicker{color:var(--coral);text-transform:uppercase;letter-spacing:.15em;font-size:11pt}.cover h1{font-size:30pt;line-height:1.08;color:var(--lav);margin:5mm 0 2mm;max-width:190mm}.cover h2{font-size:18pt;font-weight:400;margin:0 0 12mm}.meta-grid{display:grid;grid-template-columns:25mm 80mm 25mm 80mm;gap:3mm 5mm;border-top:.5mm solid var(--lav);padding-top:7mm;font-size:10pt}.meta-grid dt{color:var(--grey)}.meta-grid dd{margin:0}.doc-title{font-size:23pt;color:var(--lav);margin:0 0 9mm}.section-title,.step-title{font:700 18pt var(--font);color:var(--lav);border:0;border-bottom:.5mm solid var(--coral);background:transparent;padding:0 0 3mm;margin:0 0 7mm;width:100%}.step-title:focus{outline:2px solid #8d8eb166;background:#fff}.step-label{color:var(--coral);font-weight:700;text-transform:uppercase;letter-spacing:.08em;margin-bottom:2mm}.document-body{font-size:10.5pt;line-height:1.48}.editable-block{margin:0 0 4mm;padding:1mm;border-radius:2px}.editable-block:focus,.editable-runs:focus{outline:1px solid var(--lav);background:#fff}.editable-block[data-type=heading][data-level="1"]{font-size:20pt;color:var(--lav)}.editable-block[data-type=heading][data-level="2"]{font-size:16pt;color:var(--lav)}.editable-block[data-type=heading][data-level="3"]{font-size:13pt;color:#5e5f82}.editable-block[data-type=heading][data-level="4"]{font-size:11pt;font-weight:700}mark,.toc-review{background:var(--review);color:inherit;padding:0 .3mm}a{color:#6c6e9e;text-decoration-thickness:1px}.list-block{margin:1mm 0 4mm}.list-items{margin:0;padding-left:8mm}.list-item{margin:1.5mm 0;padding-left:2mm}.list-item[data-level="2"]{margin-left:9mm}.list-item[data-level="3"]{margin-left:18mm}.list-block[data-list-type="numberList"] .list-item[data-level="1"]{list-style-type:decimal}.list-block[data-list-type="numberList"] .list-item[data-level="2"]{list-style-type:lower-alpha}.list-block[data-list-type="numberList"] .list-item[data-level="3"]{list-style-type:lower-roman}.list-block[data-list-type="bulletList"] .list-item[data-level="1"]{list-style-type:disc}.list-block[data-list-type="bulletList"] .list-item[data-level="2"]{list-style-type:circle}.list-block[data-list-type="bulletList"] .list-item[data-level="3"]{list-style-type:square}.toc{list-style:none;padding:0;margin:0}.toc li{display:flex;align-items:baseline;margin:5mm 0}.toc a{color:var(--ink);text-decoration:none}.toc .dots{flex:1;border-bottom:.35mm dotted #aaa;margin:0 3mm}.toc-page{font-variant-numeric:tabular-nums}.toc-step{padding-left:9mm}.table-block table{width:100%;border-collapse:collapse;table-layout:fixed}.table-block caption{text-align:left;font-weight:700;margin-bottom:2mm}.table-block th,.table-block td{position:relative;border:1px solid #bcbcca;padding:2mm;vertical-align:top}.table-block th{background:#ececf3;text-align:left}.table-block :is(.format-number,.format-gbp){text-align:right;font-variant-numeric:tabular-nums}.table-block output{display:block;min-height:1.3em}.table-block .total-row{font-weight:700;border-top:2px solid var(--lav)}.editable-runs{display:block;min-height:1.3em}.column-resizer{position:absolute;z-index:2;right:-4px;top:0;width:8px;height:100%;padding:0;border:0;background:transparent;cursor:col-resize}.column-resizer:focus{outline:2px solid var(--coral)}.image-block figure{margin:0;text-align:center}.image-block img{display:block;max-height:85mm;object-fit:contain;margin:auto}.image-block figcaption{margin-top:2mm;color:var(--grey);font-size:9pt}.image-error{border:1px solid #a33;padding:3mm;color:#822}h1,h2,h3,h4,.editable-block[data-type=heading]{break-after:avoid;break-after:avoid-page}.editable-block[data-type=heading]+.editable-block[data-type=paragraph]{orphans:3}.page-break{break-before:page}
-.sheet-source:is(.step,.appendix).is-selected{background:#f2f2f2}.editable-block,.editable-runs{white-space:pre-wrap}:is(.step,.appendix).is-selected .step-heading{border-left:3px solid var(--lav);padding-left:3mm}
-.step-heading{display:block}.step-title-print{display:none;font:700 18pt var(--font);color:var(--lav);border:0;border-bottom:.5mm solid var(--coral);background:transparent;padding:0 0 3mm;margin:0 0 7mm;width:100%;min-height:0;white-space:normal;overflow-wrap:anywhere}.step-heading>.step-title{display:block;position:static}
-@media print{.sheet-source{width:297mm!important;height:210mm!important}.sheet-source,.sheet-source:is(.step,.appendix).is-selected{-webkit-print-color-adjust:exact;print-color-adjust:exact;background:var(--paper)}.step-title{display:none!important}.step-title-print{display:block}.step-title:focus,.editable-block:focus,.editable-runs:focus,.column-resizer:focus{outline:0!important;box-shadow:none!important}.editable-block:focus,.editable-runs:focus{background:transparent}.sheet-source:is(.step,.appendix).is-selected .step-heading{border-left:0;padding-left:0}.block-controls,.column-resizer{display:none!important}}
-.continuation-heading{font-size:12pt;font-weight:700;color:var(--lav);border-bottom:.35mm solid var(--coral);padding-bottom:2mm;margin-bottom:5mm}.fit-page figure{height:125mm;display:flex;flex-direction:column}.fit-page img{max-width:100%;max-height:112mm!important;flex:1;min-height:0}.toc-section{font-weight:600}.toc-appendix{padding-left:4mm}
+.sheet-source {
+  width: 297mm;
+  height: 210mm;
+  position: relative;
+  padding: 42mm 24mm 18mm;
+  background: var(--paper);
+  overflow: hidden;
+}
+.page-header {
+  position: absolute;
+  top: 9mm;
+  left: 20mm;
+  right: 20mm;
+  height: 25mm;
+  display: flex;
+  align-items: center;
+  border-bottom: 0.4mm solid #8d8eb155;
+  padding-bottom: 3mm;
+}
+.header-brand {
+  font-size: 22pt;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  color: var(--lav);
+}
+.header-details {
+  margin-left: auto;
+  color: var(--grey);
+  font-size: 9.5pt;
+}
+.header-details b {
+  color: var(--coral);
+  padding: 0 2mm;
+}
+.page-footer {
+  position: absolute;
+  bottom: 7mm;
+  left: 20mm;
+  right: 20mm;
+  text-align: center;
+  color: var(--grey);
+  font-size: 9pt;
+}
+.cover {
+  padding-top: 48mm;
+}
+.cover-kicker {
+  color: var(--coral);
+  text-transform: uppercase;
+  letter-spacing: 0.15em;
+  font-size: 11pt;
+}
+.cover h1 {
+  font-size: 30pt;
+  line-height: 1.08;
+  color: var(--lav);
+  margin: 5mm 0 2mm;
+  max-width: 190mm;
+}
+.cover h2 {
+  font-size: 18pt;
+  font-weight: 400;
+  margin: 0 0 12mm;
+}
+.meta-grid {
+  display: grid;
+  grid-template-columns: 25mm 80mm 25mm 80mm;
+  gap: 3mm 5mm;
+  border-top: 0.5mm solid var(--lav);
+  padding-top: 7mm;
+  font-size: 10pt;
+}
+.meta-grid dt {
+  color: var(--grey);
+}
+.meta-grid dd {
+  margin: 0;
+}
+.doc-title {
+  font-size: 23pt;
+  color: var(--lav);
+  margin: 0 0 9mm;
+}
+.section-title,
+.step-title {
+  font: 700 18pt var(--font);
+  color: var(--lav);
+  border: 0;
+  border-bottom: 0.5mm solid var(--coral);
+  background: transparent;
+  padding: 0 0 3mm;
+  margin: 0 0 7mm;
+  width: 100%;
+}
+.step-title:focus {
+  outline: 2px solid #8d8eb166;
+  background: #fff;
+}
+.step-label {
+  color: var(--coral);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 2mm;
+}
+.document-body {
+  font-size: 10.5pt;
+  line-height: 1.48;
+}
+.editable-block {
+  margin: 0 0 4mm;
+  padding: 1mm;
+  border-radius: 2px;
+}
+.editable-block:focus,
+.editable-runs:focus {
+  outline: 1px solid var(--lav);
+  background: #fff;
+}
+.editable-block[data-type="heading"][data-level="1"] {
+  font-size: 20pt;
+  color: var(--lav);
+}
+.editable-block[data-type="heading"][data-level="2"] {
+  font-size: 16pt;
+  color: var(--lav);
+}
+.editable-block[data-type="heading"][data-level="3"] {
+  font-size: 13pt;
+  color: #5e5f82;
+}
+.editable-block[data-type="heading"][data-level="4"] {
+  font-size: 11pt;
+  font-weight: 700;
+}
+mark,
+.toc-review {
+  background: var(--review);
+  color: inherit;
+  padding: 0 0.3mm;
+}
+a {
+  color: #6c6e9e;
+  text-decoration-thickness: 1px;
+}
+.list-block {
+  margin: 1mm 0 4mm;
+}
+.list-items {
+  margin: 0;
+  padding-left: 8mm;
+}
+.list-item {
+  margin: 1.5mm 0;
+  padding-left: 2mm;
+}
+.list-item[data-level="2"] {
+  margin-left: 9mm;
+}
+.list-item[data-level="3"] {
+  margin-left: 18mm;
+}
+.list-block[data-list-type="numberList"] .list-item[data-level="1"] {
+  list-style-type: decimal;
+}
+.list-block[data-list-type="numberList"] .list-item[data-level="2"] {
+  list-style-type: lower-alpha;
+}
+.list-block[data-list-type="numberList"] .list-item[data-level="3"] {
+  list-style-type: lower-roman;
+}
+.list-block[data-list-type="bulletList"] .list-item[data-level="1"] {
+  list-style-type: disc;
+}
+.list-block[data-list-type="bulletList"] .list-item[data-level="2"] {
+  list-style-type: circle;
+}
+.list-block[data-list-type="bulletList"] .list-item[data-level="3"] {
+  list-style-type: square;
+}
+.toc {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.toc li {
+  display: flex;
+  align-items: baseline;
+  margin: 5mm 0;
+}
+.toc a {
+  color: var(--ink);
+  text-decoration: none;
+}
+.toc .dots {
+  flex: 1;
+  border-bottom: 0.35mm dotted #aaa;
+  margin: 0 3mm;
+}
+.toc-page {
+  font-variant-numeric: tabular-nums;
+}
+.toc-step {
+  padding-left: 9mm;
+}
+.table-block table {
+  width: 100%;
+  border-collapse: collapse;
+  table-layout: fixed;
+}
+.table-block caption {
+  text-align: left;
+  font-weight: 700;
+  margin-bottom: 2mm;
+}
+.table-block th,
+.table-block td {
+  position: relative;
+  border: 1px solid #bcbcca;
+  padding: 2mm;
+  vertical-align: top;
+}
+.table-block th {
+  background: #ececf3;
+  text-align: left;
+}
+.table-block :is(.format-number, .format-gbp) {
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.table-block output {
+  display: block;
+  min-height: 1.3em;
+}
+.table-block .total-row {
+  font-weight: 700;
+  border-top: 2px solid var(--lav);
+}
+.editable-runs {
+  display: block;
+  min-height: 1.3em;
+}
+.column-resizer {
+  position: absolute;
+  z-index: 2;
+  right: -4px;
+  top: 0;
+  width: 8px;
+  height: 100%;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: col-resize;
+}
+.column-resizer:focus {
+  outline: 2px solid var(--coral);
+}
+.image-block figure {
+  margin: 0;
+  text-align: center;
+}
+.image-block img {
+  display: block;
+  max-height: 85mm;
+  object-fit: contain;
+  margin: auto;
+}
+.image-block figcaption {
+  margin-top: 2mm;
+  color: var(--grey);
+  font-size: 9pt;
+}
+.image-error {
+  border: 1px solid #a33;
+  padding: 3mm;
+  color: #822;
+}
+h1,
+h2,
+h3,
+h4,
+.editable-block[data-type="heading"] {
+  break-after: avoid;
+  break-after: avoid-page;
+}
+.editable-block[data-type="heading"] + .editable-block[data-type="paragraph"] {
+  orphans: 3;
+}
+.page-break {
+  break-before: page;
+}
+.sheet-source:is(.step, .appendix).is-selected {
+  background: #f2f2f2;
+}
+.editable-block,
+.editable-runs {
+  white-space: pre-wrap;
+}
+:is(.step, .appendix).is-selected .step-heading {
+  border-left: 3px solid var(--lav);
+  padding-left: 3mm;
+}
+.step-heading {
+  display: block;
+}
+.step-title-print {
+  display: none;
+  font: 700 18pt var(--font);
+  color: var(--lav);
+  border: 0;
+  border-bottom: 0.5mm solid var(--coral);
+  background: transparent;
+  padding: 0 0 3mm;
+  margin: 0 0 7mm;
+  width: 100%;
+  min-height: 0;
+  white-space: normal;
+  overflow-wrap: anywhere;
+}
+.step-heading > .step-title {
+  display: block;
+  position: static;
+}
+@media print {
+  .sheet-source {
+    width: 297mm !important;
+    height: 210mm !important;
+  }
+  .sheet-source,
+  .sheet-source:is(.step, .appendix).is-selected {
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+    background: var(--paper);
+  }
+  .step-title {
+    display: none !important;
+  }
+  .step-title-print {
+    display: block;
+  }
+  .step-title:focus,
+  .editable-block:focus,
+  .editable-runs:focus,
+  .column-resizer:focus {
+    outline: 0 !important;
+    box-shadow: none !important;
+  }
+  .editable-block:focus,
+  .editable-runs:focus {
+    background: transparent;
+  }
+  .sheet-source:is(.step, .appendix).is-selected .step-heading {
+    border-left: 0;
+    padding-left: 0;
+  }
+  .block-controls,
+  .column-resizer {
+    display: none !important;
+  }
+}
+.continuation-heading {
+  font-size: 12pt;
+  font-weight: 700;
+  color: var(--lav);
+  border-bottom: 0.35mm solid var(--coral);
+  padding-bottom: 2mm;
+  margin-bottom: 5mm;
+}
+.fit-page figure {
+  height: 125mm;
+  display: flex;
+  flex-direction: column;
+}
+.fit-page img {
+  max-width: 100%;
+  max-height: 112mm !important;
+  flex: 1;
+  min-height: 0;
+}
+.toc-section {
+  font-weight: 600;
+}
+.toc-appendix {
+  padding-left: 4mm;
+}
 
-.list-trailing-hit-area{display:block;width:100%;height:18px;margin:0;padding:0;border:0;background:transparent;cursor:text}.list-trailing-hit-area:hover,.list-trailing-hit-area:focus-visible{background:linear-gradient(90deg,transparent,#8d8eb115,transparent);outline:1px dashed #8d8eb155}
+.list-trailing-hit-area {
+  display: block;
+  width: 100%;
+  height: 18px;
+  margin: 0;
+  padding: 0;
+  border: 0;
+  background: transparent;
+  cursor: text;
+}
+.list-trailing-hit-area:hover,
+.list-trailing-hit-area:focus-visible {
+  background: linear-gradient(90deg, transparent, #8d8eb115, transparent);
+  outline: 1px dashed #8d8eb155;
+}
 </style></head><body><div class="editor-command-bars">
-  <header id="steps-toolbar" class="toolbar" aria-label="Steps Plan editing toolbar">
-    <span class="brand">UBTA Steps Plan</span>
-    <div class="toolbar-group document-group" role="group" aria-label="Document"><span class="group-label">Document</span><div class="command-row"><button id="document-properties" type="button">Properties</button><button id="save-draft" type="button">Save now</button><button id="save-version" type="button">Save version</button><button id="show-versions" type="button">Versions</button></div><div class="command-row"><button data-command="undo">Undo</button><button data-command="redo">Redo</button><button id="share-snapshot" type="button">Copy link</button><button id="print-document" type="button" aria-describedby="print-document-help">Print / Save PDF</button><button id="export-document" type="button">Export</button></div><span id="print-document-help" class="visually-hidden">Opens the browser print dialog, where this document can be saved as a PDF.</span><span id="save-state" class="save-state" role="status">Saved locally</span></div>
-    <div class="toolbar-group text-group" role="group" aria-label="Text formatting"><span class="group-label">Text</span><div class="command-row"><select id="style" data-text-command aria-label="Block style"><option value="body">Body text</option><option value="heading1">Heading 1</option><option value="heading2">Heading 2</option><option value="heading3">Heading 3</option><option value="heading4">Heading 4</option><option value="bulletList">Bulleted list</option><option value="numberList">Numbered list</option></select></div><div class="command-row"><button data-command="highlight" data-text-command>Highlight</button><button data-command="link" data-text-command>Add link</button><button data-command="unlink" data-text-command>Remove link</button></div></div>
-    <div class="toolbar-group step-group" role="group" aria-label="Step management"><span class="group-label">Step</span><div class="command-row"><button data-command="addStepBefore" data-requires-step>Add step before</button><button data-command="addStepAfter" data-requires-step>Add step after</button></div><div class="command-row"><button data-command="moveStepUp" aria-label="Move step up">Move up</button><button data-command="moveStepDown" aria-label="Move step down">Move down</button><button data-command="deleteStep" class="danger">Delete step</button></div></div>
-    <div class="toolbar-group appendix-group" role="group" aria-label="Appendix management"><span class="group-label">Appendix</span><div class="command-row"><button data-command="addAppendix">Add appendix</button></div><div class="command-row"><button data-command="moveAppendixUp" aria-label="Move appendix up">Move up</button><button data-command="moveAppendixDown" aria-label="Move appendix down">Move down</button><button data-command="deleteAppendix" class="danger">Delete appendix</button></div></div>
-    <div class="toolbar-group table-group" role="group" aria-label="Table tools" data-table-group><span class="group-label">Table</span><div class="command-row"><button data-command="addRow" data-table-command>Add row</button><button data-command="removeRow" data-table-command>Remove row</button><button data-command="moveRowUp" data-table-command aria-label="Move selected row up">Move row up</button><button data-command="moveRowDown" data-table-command aria-label="Move selected row down">Move row down</button></div><div class="command-row"><button data-command="addColumn" data-table-command>Add column</button><button data-command="removeColumn" data-table-command>Remove column</button><button data-command="moveColumnLeft" data-table-command aria-label="Move selected column left">Move column left</button><button data-command="moveColumnRight" data-table-command aria-label="Move selected column right">Move column right</button><label data-table-command>Format <select id="column-format" aria-label="Selected column format"><option value="text">Text</option><option value="number">Number</option><option value="gbp">Pounds sterling</option></select></label><label data-table-command class="total-toggle"><input id="column-total-enabled" type="checkbox"> Calculate total</label></div></div>
-    <nav class="nav" aria-label="Page navigation"><span class="group-label">Page</span><div class="command-row"><button id="prev" type="button" aria-label="Previous page">Previous</button><span>Page <b id="current">1</b> of <b id="total">—</b></span><button id="next" type="button" aria-label="Next page">Next</button></div><label class="page-jump-label" for="page-jump">Jump directly to page</label><select id="page-jump" aria-label="Jump directly to page"></select></nav>
-  </header>
-  <div id="excel-toolbar" class="excel-toolbar" hidden><b>Excel Shares</b><button data-excel-action="addShareholder">Add shareholder</button><button data-excel-action="removeShareholder">Remove shareholder</button><button data-excel-action="addClass">Add share class</button><button data-excel-action="removeClass">Remove share class</button><button data-excel-action="addGroup">Add share group</button><button data-excel-action="removeGroup">Remove share group</button><button data-excel-action="addCompany">Add company</button><button class="danger" data-excel-action="deleteCompany">Delete company</button></div>
-  <div id="link-context" class="link-context" role="toolbar" aria-label="Selected link actions" hidden><span>Linked text</span><button id="open-selected-link" type="button">Open link</button><span>Links open with one click</span></div>
-  </div>
-  <dialog id="properties-dialog"><form id="properties-form"><h2>Document properties</h2><div class="properties-grid"><label>Client name<input name="clientName" type="text" maxlength="120" required></label><label>Project title<input name="projectTitle" type="text" maxlength="120" required></label><label>Document type<input name="documentType" type="text" maxlength="80" required></label><label>Date<input name="date" type="date" required></label><label>Version<input name="version" type="text" maxlength="30" required></label><label>Subtitle<input name="subtitle" type="text" maxlength="160"></label><label>Adviser<input name="adviser" type="text" maxlength="120" required></label><label>Status<select name="status" required><option>Draft</option><option>For review</option><option>Final</option></select></label></div><div class="dialog-actions"><button type="button" data-dialog-cancel>Cancel</button><button type="submit">Update document</button></div></form></dialog>
-  <dialog id="image-dialog"><form id="image-form" novalidate><h2>Add a published image</h2><p>Enter the public HTTPS address of a PNG, JPEG, GIF or WebP image. The editor links to the image and does not copy it into the document.</p><label>Image URL<input name="src" type="text" inputmode="url" autocomplete="url" placeholder="https://example.com/image.png" required></label><label>Alternative text<input name="alt" type="text" maxlength="500" required></label><label>Caption (optional)<input name="caption" type="text" maxlength="500"></label><label>Width % (optional)<input name="width" type="number" min="20" max="100" step="1" placeholder="100"></label><p id="image-form-error" class="form-error" role="alert" hidden></p><div class="dialog-actions"><button type="button" data-dialog-cancel>Cancel</button><button type="submit">Add image</button></div></form></dialog>
-  <dialog id="insertion-chooser" class="insertion-chooser" aria-labelledby="insertion-chooser-title"><form method="dialog">
-    <section data-insertion-panel="main"><h2 id="insertion-chooser-title">Insert content</h2><p>Choose the type of content to add here.</p><div class="insertion-choices"><button type="button" data-insert-choice="paragraph" autofocus><b>Body text</b><span>Add a paragraph</span></button><button type="button" data-open-insertion-panel="heading"><b>Heading</b><span>Choose a heading level</span></button><button type="button" data-open-insertion-panel="list"><b>List</b><span>Bulleted or numbered</span></button><button type="button" data-open-insertion-panel="defaults"><b>Default update</b><span>Unlock reusable updates</span></button><button type="button" data-insert-choice="table"><b>Table</b><span>Add a two-column table</span></button><button type="button" data-insert-choice="image"><b>Image</b><span>Add an image from an HTTPS URL</span></button></div></section>
-    <section data-insertion-panel="heading" hidden aria-labelledby="heading-choice-title"><h2 id="heading-choice-title">Choose heading level</h2><div class="insertion-choices"><button type="button" data-insert-heading="1">Heading 1</button><button type="button" data-insert-heading="2">Heading 2</button><button type="button" data-insert-heading="3">Heading 3</button><button type="button" data-insert-heading="4">Heading 4</button></div><button type="button" data-insertion-back>Back</button></section>
-    <section data-insertion-panel="list" hidden aria-labelledby="list-choice-title"><h2 id="list-choice-title">Choose list type</h2><div class="insertion-choices"><button type="button" data-insert-choice="bulletList">Bulleted list</button><button type="button" data-insert-choice="numberList">Numbered list</button></div><button type="button" data-insertion-back>Back</button></section>
-    <section data-insertion-panel="defaults" hidden aria-labelledby="default-choice-title"><h2 id="default-choice-title">Default update</h2><div id="default-unlock"><p>Enter the vault password. Decryption happens locally.</p><label for="default-password">Vault password</label><input id="default-password" type="password" autocomplete="current-password" required><button id="unlock-defaults" type="button">Unlock templates</button></div><p id="default-error" class="form-error" role="alert" hidden></p><div id="default-template-choices" class="insertion-choices" aria-label="Available default updates"></div><button type="button" data-insertion-back>Back</button></section>
-    <div class="dialog-actions"><button type="button" data-dialog-cancel>Cancel</button></div></form></dialog>
-  <dialog id="versions-dialog"><form method="dialog"><h2>Local saved versions</h2><p>Up to 20 named versions are kept in this browser.</p><div id="versions-list" class="versions-list"></div><div><button type="button" data-dialog-cancel>Close</button></div></form></dialog><dialog id="link-picker"><form id="link-form"><h2>Choose a link destination</h2><label>Document destination<select id="link-destination"></select></label><span>or</span><label>External URL<input id="external-link" type="url" placeholder="https://example.com"></label><div><button type="button" data-dialog-cancel>Cancel</button><button type="submit">Apply link</button></div></form></dialog><div id="editor-status" class="visually-hidden" aria-live="polite"></div>
-  <div class="canvas"><div id="preview" class="pagedjs_pages" aria-live="polite"></div><main id="excel-editor" hidden></main></div>
-  <nav class="editor-switcher" aria-label="Editor navigation"><button data-editor="steps" aria-current="page">Steps Plan Editor</button><button data-editor="excel">Excel Shares Editor</button></nav><script>/*! Offline pagination engine for the UBTA editor.
+      <header
+        id="steps-toolbar"
+        class="toolbar"
+        aria-label="Steps Plan editing toolbar"
+      >
+        <span class="brand">UBTA Steps Plan</span>
+        <div
+          class="toolbar-group document-group"
+          role="group"
+          aria-label="Document"
+        >
+          <span class="group-label">Document</span>
+          <div class="command-row">
+            <button id="document-properties" type="button">Properties</button>
+            <button id="save-draft" type="button">Save now</button>
+            <button id="save-version" type="button">Save version</button>
+            <button id="show-versions" type="button">Versions</button>
+          </div>
+          <div class="command-row">
+            <button data-command="undo">Undo</button>
+            <button data-command="redo">Redo</button>
+            <button id="share-snapshot" type="button">Copy link</button>
+            <button
+              id="print-document"
+              type="button"
+              aria-describedby="print-document-help"
+            >
+              Print / Save PDF
+            </button>
+            <button id="export-document" type="button">Export</button>
+          </div>
+          <span id="print-document-help" class="visually-hidden">
+            Opens the browser print dialog, where this document can be saved as
+            a PDF.
+          </span>
+          <span id="save-state" class="save-state" role="status">
+            Saved locally
+          </span>
+        </div>
+        <div
+          class="toolbar-group text-group"
+          role="group"
+          aria-label="Text formatting"
+        >
+          <span class="group-label">Text</span>
+          <div class="command-row">
+            <select id="style" data-text-command aria-label="Block style">
+              <option value="body">Body text</option>
+              <option value="heading1">Heading 1</option>
+              <option value="heading2">Heading 2</option>
+              <option value="heading3">Heading 3</option>
+              <option value="heading4">Heading 4</option>
+              <option value="bulletList">Bulleted list</option>
+              <option value="numberList">Numbered list</option>
+            </select>
+          </div>
+          <div class="command-row">
+            <button data-command="highlight" data-text-command>
+              Highlight
+            </button>
+            <button data-command="link" data-text-command>Add link</button>
+            <button data-command="unlink" data-text-command>Remove link</button>
+          </div>
+        </div>
+        <div
+          class="toolbar-group step-group"
+          role="group"
+          aria-label="Step management"
+        >
+          <span class="group-label">Step</span>
+          <div class="command-row">
+            <button data-command="addStepBefore" data-requires-step>
+              Add step before
+            </button>
+            <button data-command="addStepAfter" data-requires-step>
+              Add step after
+            </button>
+          </div>
+          <div class="command-row">
+            <button data-command="moveStepUp" aria-label="Move step up">
+              Move up
+            </button>
+            <button data-command="moveStepDown" aria-label="Move step down">
+              Move down
+            </button>
+            <button data-command="deleteStep" class="danger">
+              Delete step
+            </button>
+          </div>
+        </div>
+        <div
+          class="toolbar-group appendix-group"
+          role="group"
+          aria-label="Appendix management"
+        >
+          <span class="group-label">Appendix</span>
+          <div class="command-row">
+            <button data-command="addAppendix">Add appendix</button>
+          </div>
+          <div class="command-row">
+            <button data-command="moveAppendixUp" aria-label="Move appendix up">
+              Move up
+            </button>
+            <button
+              data-command="moveAppendixDown"
+              aria-label="Move appendix down"
+            >
+              Move down
+            </button>
+            <button data-command="deleteAppendix" class="danger">
+              Delete appendix
+            </button>
+          </div>
+        </div>
+        <div
+          class="toolbar-group table-group"
+          role="group"
+          aria-label="Table tools"
+          data-table-group
+        >
+          <span class="group-label">Table</span>
+          <div class="command-row">
+            <button data-command="addRow" data-table-command>Add row</button>
+            <button data-command="removeRow" data-table-command>
+              Remove row
+            </button>
+            <button
+              data-command="moveRowUp"
+              data-table-command
+              aria-label="Move selected row up"
+            >
+              Move row up
+            </button>
+            <button
+              data-command="moveRowDown"
+              data-table-command
+              aria-label="Move selected row down"
+            >
+              Move row down
+            </button>
+          </div>
+          <div class="command-row">
+            <button data-command="addColumn" data-table-command>
+              Add column
+            </button>
+            <button data-command="removeColumn" data-table-command>
+              Remove column
+            </button>
+            <button
+              data-command="moveColumnLeft"
+              data-table-command
+              aria-label="Move selected column left"
+            >
+              Move column left
+            </button>
+            <button
+              data-command="moveColumnRight"
+              data-table-command
+              aria-label="Move selected column right"
+            >
+              Move column right
+            </button>
+            <label data-table-command>
+              Format
+              <select id="column-format" aria-label="Selected column format">
+                <option value="text">Text</option>
+                <option value="number">Number</option>
+                <option value="gbp">Pounds sterling</option>
+              </select>
+            </label>
+            <label data-table-command class="total-toggle">
+              <input id="column-total-enabled" type="checkbox" />
+              Calculate total
+            </label>
+          </div>
+        </div>
+        <nav class="nav" aria-label="Page navigation">
+          <span class="group-label">Page</span>
+          <div class="command-row">
+            <button id="prev" type="button" aria-label="Previous page">
+              Previous
+            </button>
+            <span>
+              Page
+              <b id="current">1</b>
+              of
+              <b id="total">—</b>
+            </span>
+            <button id="next" type="button" aria-label="Next page">Next</button>
+          </div>
+          <label class="page-jump-label" for="page-jump">
+            Jump directly to page
+          </label>
+          <select id="page-jump" aria-label="Jump directly to page"></select>
+        </nav>
+      </header>
+      <div id="excel-toolbar" class="excel-toolbar" hidden>
+        <b>Excel Shares</b>
+        <button data-excel-action="addShareholder">Add shareholder</button>
+        <button data-excel-action="removeShareholder">
+          Remove shareholder
+        </button>
+        <button data-excel-action="addClass">Add share class</button>
+        <button data-excel-action="removeClass">Remove share class</button>
+        <button data-excel-action="addGroup">Add share group</button>
+        <button data-excel-action="removeGroup">Remove share group</button>
+        <button data-excel-action="addCompany">Add company</button>
+        <button class="danger" data-excel-action="deleteCompany">
+          Delete company
+        </button>
+      </div>
+      <div
+        id="link-context"
+        class="link-context"
+        role="toolbar"
+        aria-label="Selected link actions"
+        hidden
+      >
+        <span>Linked text</span>
+        <button id="open-selected-link" type="button">Open link</button>
+        <span>Links open with one click</span>
+      </div>
+    </div>
+    <dialog id="properties-dialog">
+      <form id="properties-form">
+        <h2>Document properties</h2>
+        <div class="properties-grid">
+          <label>
+            Client name
+            <input name="clientName" type="text" maxlength="120" required />
+          </label>
+          <label>
+            Project title
+            <input name="projectTitle" type="text" maxlength="120" required />
+          </label>
+          <label>
+            Document type
+            <input name="documentType" type="text" maxlength="80" required />
+          </label>
+          <label>
+            Date
+            <input name="date" type="date" required />
+          </label>
+          <label>
+            Version
+            <input name="version" type="text" maxlength="30" required />
+          </label>
+          <label>
+            Subtitle
+            <input name="subtitle" type="text" maxlength="160" />
+          </label>
+          <label>
+            Adviser
+            <input name="adviser" type="text" maxlength="120" required />
+          </label>
+          <label>
+            Status
+            <select name="status" required>
+              <option>Draft</option>
+              <option>For review</option>
+              <option>Final</option>
+            </select>
+          </label>
+        </div>
+        <div class="dialog-actions">
+          <button type="button" data-dialog-cancel>Cancel</button>
+          <button type="submit">Update document</button>
+        </div>
+      </form>
+    </dialog>
+    <dialog id="image-dialog">
+      <form id="image-form" novalidate>
+        <h2>Add a published image</h2>
+        <p>
+          Enter the public HTTPS address of a PNG, JPEG, GIF or WebP image. The
+          editor links to the image and does not copy it into the document.
+        </p>
+        <label>
+          Image URL
+          <input
+            name="src"
+            type="text"
+            inputmode="url"
+            autocomplete="url"
+            placeholder="https://example.com/image.png"
+            required
+          />
+        </label>
+        <label>
+          Alternative text
+          <input name="alt" type="text" maxlength="500" required />
+        </label>
+        <label>
+          Caption (optional)
+          <input name="caption" type="text" maxlength="500" />
+        </label>
+        <label>
+          Width % (optional)
+          <input
+            name="width"
+            type="number"
+            min="20"
+            max="100"
+            step="1"
+            placeholder="100"
+          />
+        </label>
+        <p id="image-form-error" class="form-error" role="alert" hidden></p>
+        <div class="dialog-actions">
+          <button type="button" data-dialog-cancel>Cancel</button>
+          <button type="submit">Add image</button>
+        </div>
+      </form>
+    </dialog>
+    <dialog
+      id="insertion-chooser"
+      class="insertion-chooser"
+      aria-labelledby="insertion-chooser-title"
+    >
+      <form method="dialog">
+        <section data-insertion-panel="main">
+          <h2 id="insertion-chooser-title">Insert content</h2>
+          <p>Choose the type of content to add here.</p>
+          <div class="insertion-choices">
+            <button type="button" data-insert-choice="paragraph" autofocus>
+              <b>Body text</b>
+              <span>Add a paragraph</span>
+            </button>
+            <button type="button" data-open-insertion-panel="heading">
+              <b>Heading</b>
+              <span>Choose a heading level</span>
+            </button>
+            <button type="button" data-open-insertion-panel="list">
+              <b>List</b>
+              <span>Bulleted or numbered</span>
+            </button>
+            <button type="button" data-open-insertion-panel="defaults">
+              <b>Default update</b>
+              <span>Unlock reusable updates</span>
+            </button>
+            <button type="button" data-insert-choice="table">
+              <b>Table</b>
+              <span>Add a two-column table</span>
+            </button>
+            <button type="button" data-insert-choice="image">
+              <b>Image</b>
+              <span>Add an image from an HTTPS URL</span>
+            </button>
+          </div>
+        </section>
+        <section
+          data-insertion-panel="heading"
+          hidden
+          aria-labelledby="heading-choice-title"
+        >
+          <h2 id="heading-choice-title">Choose heading level</h2>
+          <div class="insertion-choices">
+            <button type="button" data-insert-heading="1">Heading 1</button>
+            <button type="button" data-insert-heading="2">Heading 2</button>
+            <button type="button" data-insert-heading="3">Heading 3</button>
+            <button type="button" data-insert-heading="4">Heading 4</button>
+          </div>
+          <button type="button" data-insertion-back>Back</button>
+        </section>
+        <section
+          data-insertion-panel="list"
+          hidden
+          aria-labelledby="list-choice-title"
+        >
+          <h2 id="list-choice-title">Choose list type</h2>
+          <div class="insertion-choices">
+            <button type="button" data-insert-choice="bulletList">
+              Bulleted list
+            </button>
+            <button type="button" data-insert-choice="numberList">
+              Numbered list
+            </button>
+          </div>
+          <button type="button" data-insertion-back>Back</button>
+        </section>
+        <section
+          data-insertion-panel="defaults"
+          hidden
+          aria-labelledby="default-choice-title"
+        >
+          <h2 id="default-choice-title">Default update</h2>
+          <div id="default-unlock">
+            <p>Enter the vault password. Decryption happens locally.</p>
+            <label for="default-password">Vault password</label>
+            <input
+              id="default-password"
+              type="password"
+              autocomplete="current-password"
+              required
+            />
+            <button id="unlock-defaults" type="button">Unlock templates</button>
+          </div>
+          <p id="default-error" class="form-error" role="alert" hidden></p>
+          <div
+            id="default-template-choices"
+            class="insertion-choices"
+            aria-label="Available default updates"
+          ></div>
+          <button type="button" data-insertion-back>Back</button>
+        </section>
+        <div class="dialog-actions">
+          <button type="button" data-dialog-cancel>Cancel</button>
+        </div>
+      </form>
+    </dialog>
+    <dialog id="versions-dialog">
+      <form method="dialog">
+        <h2>Local saved versions</h2>
+        <p>Up to 20 named versions are kept in this browser.</p>
+        <div id="versions-list" class="versions-list"></div>
+        <div><button type="button" data-dialog-cancel>Close</button></div>
+      </form>
+    </dialog>
+    <dialog id="link-picker">
+      <form id="link-form">
+        <h2>Choose a link destination</h2>
+        <label>
+          Document destination
+          <select id="link-destination"></select>
+        </label>
+        <span>or</span>
+        <label>
+          External URL
+          <input
+            id="external-link"
+            type="url"
+            placeholder="https://example.com"
+          />
+        </label>
+        <div>
+          <button type="button" data-dialog-cancel>Cancel</button>
+          <button type="submit">Apply link</button>
+        </div>
+      </form>
+    </dialog>
+    <div id="editor-status" class="visually-hidden" aria-live="polite"></div>
+    <div class="canvas">
+      <div id="preview" class="pagedjs_pages" aria-live="polite"></div>
+      <main id="excel-editor" hidden></main>
+    </div>
+    <nav class="editor-switcher" aria-label="Editor navigation">
+      <button data-editor="steps" aria-current="page">Steps Plan Editor</button>
+      <button data-editor="excel">Excel Shares Editor</button>
+    </nav><script>/*! Offline pagination engine for the UBTA editor.
  * The public surface deliberately matches the part of Paged.js used by the app.
  * Content is measured in a connected, hidden staging area and is fragmented into
  * editable page-sized DOM trees. */
@@ -1005,6 +2513,27 @@ class NavigationHistory {
 
 
 const escapeHtml = value => String(value).replace(/[&<>"']/g, character => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[character]));
+
+const gridSelector = '[data-grid-row][data-grid-column]';
+
+function gridDestination(targets, current, key, shiftKey = false) {
+  const row = Number(current.dataset.gridRow);
+  const column = Number(current.dataset.gridColumn);
+  const index = targets.indexOf(current);
+
+  if (key === 'Tab') {
+    return targets[(index + (shiftKey ? -1 : 1) + targets.length) % targets.length];
+  }
+
+  const rowChange = key === 'ArrowUp' || (key === 'Enter' && shiftKey) ? -1
+    : key === 'ArrowDown' || key === 'Enter' ? 1 : 0;
+  const columnChange = key === 'ArrowLeft' ? -1 : key === 'ArrowRight' ? 1 : 0;
+  return targets.find(target => (
+    Number(target.dataset.gridRow) === row + rowChange
+    && Number(target.dataset.gridColumn) === column + columnChange
+  )) || current;
+}
+
 class ExcelEditor {
   constructor({ root, toolbar, getDocument, updateDocument, report }) { this.root=root;this.toolbar=toolbar;this.getDocument=getDocument;this.updateDocument=updateDocument;this.report=report;this.history=new History(getDocument().excel);this.focus={};this.bindToolbar(); }
   get excel() { return this.getDocument().excel; }
@@ -1025,11 +2554,113 @@ class ExcelEditor {
   addClass() { if(!this.company)return;if(classesOf(this.company).length>=100)return this.report('The 100-share-class limit has been reached.');this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId),group=company.groups.find(item=>item.id===this.focus.groupId)||company.groups.at(-1);if(!group)return this.report('Add a share group first.');const at=this.focus.classId?group.classes.findIndex(item=>item.id===this.focus.classId)+1:group.classes.length;group.classes.splice(at,0,{id:`class-${crypto.randomUUID()}`,label:''});}); }
   removeClass() { const company=this.company,shareClass=classesOf(company||{groups:[]}).find(item=>item.id===this.focus.classId);if(!shareClass)return this.report('Focus a share-class header first.');const blocking=findBlocking(company,[shareClass.id],null,this.getDocument().steps);if(blocking)return this.blocked(blocking);this.mutate(excel=>{for(const group of excel.companies.find(item=>item.id===company.id).groups)group.classes=group.classes.filter(item=>item.id!==shareClass.id);}); }
   blocked(item) { this.report(`${this.company.name} — ${item.location}: ${item.holder.name}, ${item.shareClass.label||'unnamed share class'} contains data and blocks deletion.`); }
-  table(title, values, editable, stepId='') { const company=this.company,classes=classesOf(company),summary=totals(company,values);let groupHeaders='',classHeaders='';for(const group of company.groups){groupHeaders+=`<th class="group-head" data-group-id="${escapeHtml(group.id)}" colspan="${Math.max(1,group.classes.length)}"><input data-group-name value="${escapeHtml(group.name)}" aria-label="Share group"></th>`;for(const item of group.classes)classHeaders+=`<th data-group-id="${escapeHtml(group.id)}" data-class-id="${escapeHtml(item.id)}"><input data-class-label value="${escapeHtml(item.label)}" aria-label="Share class"></th>`;}const rows=company.shareholders.map((holder,row)=>`<tr><th><input data-holder-name data-holder-id="${escapeHtml(holder.id)}" value="${escapeHtml(holder.name)}"></th><td><select data-holder-type data-holder-id="${escapeHtml(holder.id)}">${TYPES.map(type=>`<option${type===holder.type?' selected':''}>${type}</option>`).join('')}</select></td>${classes.map((item,column)=>{const value=valueAt(values,holder.id,item.id),negative=value<0&&(editable==='opening'||!editable);return `<td class="number ${negative?'negative':''}" tabindex="0" ${editable?'contenteditable="true"':''} data-row="${row}" data-column="${column}" data-holder-id="${escapeHtml(holder.id)}" data-class-id="${escapeHtml(item.id)}" data-step-id="${escapeHtml(stepId)}" data-editable="${editable?'true':'false'}">${formatShares(value)}</td>`;}).join('')}<td class="number total" tabindex="0">${formatShares(summary.rows[holder.id])}</td></tr>`).join('');return `<section class="share-table"><h3>${escapeHtml(title)}</h3><div class="table-scroll"><table><thead><tr><th rowspan="2">Shareholder</th><th rowspan="2">Type</th>${groupHeaders}<th rowspan="2">Total</th></tr><tr>${classHeaders}</tr></thead><tbody>${rows}<tr class="total-row"><th colspan="2">Total</th>${classes.map(item=>`<td class="number">${formatShares(summary.columns[item.id])}</td>`).join('')}<td class="number">${formatShares(summary.grand)}</td></tr></tbody></table></div></section>`; }
+  table(title, values, editable, stepId='') {
+    const company = this.company;
+    const classes = classesOf(company);
+    const summary = totals(company, values);
+    let groupHeaders = '';
+    let classHeaders = '';
+
+    for (const group of company.groups) {
+      groupHeaders += `<th class="group-head" data-group-id="${escapeHtml(group.id)}" colspan="${Math.max(1, group.classes.length)}"><input data-group-name value="${escapeHtml(group.name)}" aria-label="Share group"></th>`;
+      for (const item of group.classes) {
+        const column = classes.findIndex(shareClass => shareClass.id === item.id) + 1;
+        classHeaders += `<th data-group-id="${escapeHtml(group.id)}" data-class-id="${escapeHtml(item.id)}"><input data-class-label data-grid-row="0" data-grid-column="${column}" value="${escapeHtml(item.label)}" aria-label="Share class"></th>`;
+      }
+    }
+
+    const rows = company.shareholders.map((holder, row) => {
+      const shareholder = `<th><input data-holder-name data-holder-id="${escapeHtml(holder.id)}" data-grid-row="${row + 1}" data-grid-column="0" value="${escapeHtml(holder.name)}" aria-label="Shareholder"></th>`;
+      const type = `<td><select data-holder-type data-holder-id="${escapeHtml(holder.id)}" tabindex="-1">${TYPES.map(item => `<option${item === holder.type ? ' selected' : ''}>${item}</option>`).join('')}</select></td>`;
+      const rowValues = classes.map((item, column) => {
+        const value = valueAt(values, holder.id, item.id);
+        const negative = value < 0 && (editable === 'opening' || !editable);
+        return `<td class="number ${negative ? 'negative' : ''}" tabindex="${editable ? '0' : '-1'}" ${editable ? 'contenteditable="true"' : ''} data-grid-row="${row + 1}" data-grid-column="${column + 1}" data-holder-id="${escapeHtml(holder.id)}" data-class-id="${escapeHtml(item.id)}" data-step-id="${escapeHtml(stepId)}" data-editable="${editable ? 'true' : 'false'}">${formatShares(value)}</td>`;
+      }).join('');
+      return `<tr>${shareholder}${type}${rowValues}<td class="number total">${formatShares(summary.rows[holder.id])}</td></tr>`;
+    }).join('');
+
+    const columnTotals = classes.map(item => `<td class="number">${formatShares(summary.columns[item.id])}</td>`).join('');
+    return `<section class="share-table"><h3>${escapeHtml(title)}</h3><div class="table-scroll"><table><thead><tr><th rowspan="2">Shareholder</th><th rowspan="2">Type</th>${groupHeaders}<th rowspan="2">Total</th></tr><tr>${classHeaders}</tr></thead><tbody>${rows}<tr class="total-row"><th colspan="2">Total</th>${columnTotals}<td class="number">${formatShares(summary.grand)}</td></tr></tbody></table></div></section>`;
+  }
   render() { const excel=this.excel,company=this.company;this.root.innerHTML=`<div class="company-tabs" role="tablist">${excel.companies.map(item=>`<button role="tab" aria-selected="${item.id===excel.selectedCompanyId}" data-company-id="${escapeHtml(item.id)}">${escapeHtml(item.name)}</button>`).join('')}</div>${company?this.table('Opening Position',company.opening,'opening')+this.getDocument().steps.map((step,index)=>`<section class="step-share-section"><button class="collapse-step" data-collapse="${escapeHtml(step.id)}" aria-expanded="${!company.collapsed[step.id]}">${company.collapsed[step.id]?'▸':'▾'} Step ${index+1}: ${escapeHtml(step.title)}</button><div ${company.collapsed[step.id]?'hidden':''}>${this.table(`Step ${index+1} Movement`,company.movements[step.id],true,step.id)}${this.table(`Step ${index+1} Resulting Position`,resultingValues(company,this.getDocument().steps,index),false,step.id)}</div></section>`).join(''):'<p>Add a company to begin.</p>'}`;this.bindGrid(); }
-  bindGrid() { this.root.querySelectorAll('[data-company-id]').forEach(button=>button.onclick=()=>this.mutate(excel=>excel.selectedCompanyId=button.dataset.companyId));this.root.querySelectorAll('[data-collapse]').forEach(button=>button.onclick=()=>this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId);company.collapsed[button.dataset.collapse]=!company.collapsed[button.dataset.collapse];}));this.root.querySelectorAll('[data-holder-id]').forEach(element=>element.onfocus=()=>{this.focus.holderId=element.dataset.holderId;});this.root.querySelectorAll('[data-group-id]').forEach(element=>element.onfocus=()=>{this.focus.groupId=element.dataset.groupId;this.focus.classId=element.dataset.classId;});this.root.querySelectorAll('td[data-editable=true]').forEach(cell=>{cell.onfocus=()=>{this.focus={holderId:cell.dataset.holderId,classId:cell.dataset.classId,groupId:cell.closest('table').querySelector(`[data-class-id="${CSS.escape(cell.dataset.classId)}"]`)?.dataset.groupId};};cell.onblur=()=>this.commitCell(cell);cell.onkeydown=event=>this.keydown(event,cell);});const companyOf=excel=>excel.companies.find(item=>item.id===excel.selectedCompanyId);this.root.querySelectorAll('[data-holder-name]').forEach(input=>input.onchange=()=>this.mutate(excel=>{const holder=companyOf(excel).shareholders.find(item=>item.id===input.dataset.holderId);if(holder)holder.name=input.value;}));this.root.querySelectorAll('[data-holder-type]').forEach(select=>select.onchange=()=>this.mutate(excel=>{const holder=companyOf(excel).shareholders.find(item=>item.id===select.dataset.holderId);if(holder)holder.type=select.value;}));this.root.querySelectorAll('[data-group-name]').forEach(input=>input.onchange=()=>this.mutate(excel=>{const group=companyOf(excel).groups.find(item=>item.id===input.closest('[data-group-id]').dataset.groupId);if(group)group.name=input.value;}));this.root.querySelectorAll('[data-class-label]').forEach(input=>input.onchange=()=>this.mutate(excel=>{const header=input.closest('[data-class-id]'),shareClass=classesOf(companyOf(excel)).find(item=>item.id===header.dataset.classId);if(shareClass)shareClass.label=input.value;})); }
+  bindGrid() {
+    this.root.querySelectorAll('[data-company-id]').forEach(button => button.onclick = () => this.mutate(excel => excel.selectedCompanyId = button.dataset.companyId));
+    this.root.querySelectorAll('[data-collapse]').forEach(button => button.onclick = () => this.mutate(excel => {
+      const company = excel.companies.find(item => item.id === excel.selectedCompanyId);
+      company.collapsed[button.dataset.collapse] = !company.collapsed[button.dataset.collapse];
+    }));
+    this.root.querySelectorAll('[data-holder-id]').forEach(element => element.onfocus = () => {
+      this.focus.holderId = element.dataset.holderId;
+    });
+    this.root.querySelectorAll('[data-group-id]').forEach(element => element.onfocus = () => {
+      this.focus.groupId = element.dataset.groupId;
+      this.focus.classId = element.dataset.classId;
+    });
+    this.root.querySelectorAll(gridSelector).forEach(target => target.onkeydown = event => this.keydown(event, target));
+    this.root.querySelectorAll('td[data-editable=true]').forEach(cell => {
+      cell.onfocus = () => {
+        const header = [...cell.closest('table').querySelectorAll('[data-class-id]')]
+          .find(item => item.dataset.classId === cell.dataset.classId);
+        this.focus = {holderId:cell.dataset.holderId, classId:cell.dataset.classId, groupId:header?.dataset.groupId};
+        if (cell.textContent.trim() === '0') cell.textContent = '';
+      };
+      cell.onblur = () => {
+        if (cell.dataset.skipBlur === 'true') return;
+        this.commitCell(cell);
+      };
+    });
+    const companyOf = excel => excel.companies.find(item => item.id === excel.selectedCompanyId);
+    this.root.querySelectorAll('[data-holder-name]').forEach(input => input.onchange = () => this.mutate(excel => {
+      const holder = companyOf(excel).shareholders.find(item => item.id === input.dataset.holderId);
+      if (holder) holder.name = input.value;
+    }));
+    this.root.querySelectorAll('[data-holder-type]').forEach(select => select.onchange = () => this.mutate(excel => {
+      const holder = companyOf(excel).shareholders.find(item => item.id === select.dataset.holderId);
+      if (holder) holder.type = select.value;
+    }));
+    this.root.querySelectorAll('[data-group-name]').forEach(input => input.onchange = () => this.mutate(excel => {
+      const group = companyOf(excel).groups.find(item => item.id === input.closest('[data-group-id]').dataset.groupId);
+      if (group) group.name = input.value;
+    }));
+    this.root.querySelectorAll('[data-class-label]').forEach(input => input.onchange = () => this.mutate(excel => {
+      const header = input.closest('[data-class-id]');
+      const shareClass = classesOf(companyOf(excel)).find(item => item.id === header.dataset.classId);
+      if (shareClass) shareClass.label = input.value;
+    }));
+  }
   commitCell(cell) { if(cell.contentEditable!=='true')return;const value=parseShares(cell.textContent);if(value===null){this.report('Only whole integers are permitted.');this.render();return;}this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId),values=cell.dataset.stepId?company.movements[cell.dataset.stepId]:company.opening;values[cellKey(cell.dataset.holderId,cell.dataset.classId)]=value;}); }
-  keydown(event,cell) { if(event.key==='Escape'){event.preventDefault();this.render();return;}if(['Delete','Backspace'].includes(event.key)&&cell.contentEditable!=='true')event.preventDefault();if(!['ArrowUp','ArrowDown','ArrowLeft','ArrowRight','Enter','Tab'].includes(event.key))return;event.preventDefault();this.commitCell(cell);const cells=[...this.root.querySelectorAll('td[data-editable=true]')],index=cells.findIndex(item=>item.dataset.holderId===cell.dataset.holderId&&item.dataset.classId===cell.dataset.classId&&item.dataset.stepId===cell.dataset.stepId),delta=(event.key==='ArrowUp'||(event.key==='Enter'&&event.shiftKey))?-classesOf(this.company).length:(event.key==='ArrowDown'||event.key==='Enter')?classesOf(this.company).length:(event.key==='ArrowLeft'||(event.key==='Tab'&&event.shiftKey))?-1:1;cells[(index+delta+cells.length)%cells.length]?.focus(); }
+  keydown(event, target) {
+    if (event.key === 'Escape' && target.matches('td[data-editable=true]')) {
+      event.preventDefault();
+      this.render();
+      return;
+    }
+    const navigationKeys = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Enter', 'Tab'];
+    if (!navigationKeys.includes(event.key)) return;
+
+    const table = target.closest('table');
+    const targets = [...table.querySelectorAll(gridSelector)].filter(item => (
+      !item.matches('td[data-editable=false]')
+    ));
+    const destination = gridDestination(targets, target, event.key, event.shiftKey);
+    const destinationPosition = {
+      row:destination.dataset.gridRow,
+      column:destination.dataset.gridColumn
+    };
+    const tables = [...this.root.querySelectorAll('.share-table table')];
+    const tableIndex = tables.indexOf(table);
+    event.preventDefault();
+
+    if (target.matches('td[data-editable=true]')) {
+      target.dataset.skipBlur = 'true';
+      this.commitCell(target);
+    } else if (target.matches('[data-holder-name], [data-class-label]')) {
+      target.onchange();
+    }
+    const currentTable = this.root.querySelectorAll('.share-table table')[tableIndex] || table;
+    currentTable.querySelector(`${gridSelector}[data-grid-row="${destinationPosition.row}"][data-grid-column="${destinationPosition.column}"]`)?.focus();
+  }
 }
 
 

--- a/UBTA/src/editor/excel-editor.js
+++ b/UBTA/src/editor/excel-editor.js
@@ -2,6 +2,27 @@ import { History } from '../state/history.js';
 import { TYPES, classesOf, createCompany, parseShares, formatShares, cellKey, valueAt, resultingValues, totals, findBlocking, syncSteps } from '../state/excel-model.js';
 
 const escapeHtml = value => String(value).replace(/[&<>"']/g, character => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[character]));
+
+const gridSelector = '[data-grid-row][data-grid-column]';
+
+export function gridDestination(targets, current, key, shiftKey = false) {
+  const row = Number(current.dataset.gridRow);
+  const column = Number(current.dataset.gridColumn);
+  const index = targets.indexOf(current);
+
+  if (key === 'Tab') {
+    return targets[(index + (shiftKey ? -1 : 1) + targets.length) % targets.length];
+  }
+
+  const rowChange = key === 'ArrowUp' || (key === 'Enter' && shiftKey) ? -1
+    : key === 'ArrowDown' || key === 'Enter' ? 1 : 0;
+  const columnChange = key === 'ArrowLeft' ? -1 : key === 'ArrowRight' ? 1 : 0;
+  return targets.find(target => (
+    Number(target.dataset.gridRow) === row + rowChange
+    && Number(target.dataset.gridColumn) === column + columnChange
+  )) || current;
+}
+
 export class ExcelEditor {
   constructor({ root, toolbar, getDocument, updateDocument, report }) { this.root=root;this.toolbar=toolbar;this.getDocument=getDocument;this.updateDocument=updateDocument;this.report=report;this.history=new History(getDocument().excel);this.focus={};this.bindToolbar(); }
   get excel() { return this.getDocument().excel; }
@@ -22,9 +43,111 @@ export class ExcelEditor {
   addClass() { if(!this.company)return;if(classesOf(this.company).length>=100)return this.report('The 100-share-class limit has been reached.');this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId),group=company.groups.find(item=>item.id===this.focus.groupId)||company.groups.at(-1);if(!group)return this.report('Add a share group first.');const at=this.focus.classId?group.classes.findIndex(item=>item.id===this.focus.classId)+1:group.classes.length;group.classes.splice(at,0,{id:`class-${crypto.randomUUID()}`,label:''});}); }
   removeClass() { const company=this.company,shareClass=classesOf(company||{groups:[]}).find(item=>item.id===this.focus.classId);if(!shareClass)return this.report('Focus a share-class header first.');const blocking=findBlocking(company,[shareClass.id],null,this.getDocument().steps);if(blocking)return this.blocked(blocking);this.mutate(excel=>{for(const group of excel.companies.find(item=>item.id===company.id).groups)group.classes=group.classes.filter(item=>item.id!==shareClass.id);}); }
   blocked(item) { this.report(`${this.company.name} — ${item.location}: ${item.holder.name}, ${item.shareClass.label||'unnamed share class'} contains data and blocks deletion.`); }
-  table(title, values, editable, stepId='') { const company=this.company,classes=classesOf(company),summary=totals(company,values);let groupHeaders='',classHeaders='';for(const group of company.groups){groupHeaders+=`<th class="group-head" data-group-id="${escapeHtml(group.id)}" colspan="${Math.max(1,group.classes.length)}"><input data-group-name value="${escapeHtml(group.name)}" aria-label="Share group"></th>`;for(const item of group.classes)classHeaders+=`<th data-group-id="${escapeHtml(group.id)}" data-class-id="${escapeHtml(item.id)}"><input data-class-label value="${escapeHtml(item.label)}" aria-label="Share class"></th>`;}const rows=company.shareholders.map((holder,row)=>`<tr><th><input data-holder-name data-holder-id="${escapeHtml(holder.id)}" value="${escapeHtml(holder.name)}"></th><td><select data-holder-type data-holder-id="${escapeHtml(holder.id)}">${TYPES.map(type=>`<option${type===holder.type?' selected':''}>${type}</option>`).join('')}</select></td>${classes.map((item,column)=>{const value=valueAt(values,holder.id,item.id),negative=value<0&&(editable==='opening'||!editable);return `<td class="number ${negative?'negative':''}" tabindex="0" ${editable?'contenteditable="true"':''} data-row="${row}" data-column="${column}" data-holder-id="${escapeHtml(holder.id)}" data-class-id="${escapeHtml(item.id)}" data-step-id="${escapeHtml(stepId)}" data-editable="${editable?'true':'false'}">${formatShares(value)}</td>`;}).join('')}<td class="number total" tabindex="0">${formatShares(summary.rows[holder.id])}</td></tr>`).join('');return `<section class="share-table"><h3>${escapeHtml(title)}</h3><div class="table-scroll"><table><thead><tr><th rowspan="2">Shareholder</th><th rowspan="2">Type</th>${groupHeaders}<th rowspan="2">Total</th></tr><tr>${classHeaders}</tr></thead><tbody>${rows}<tr class="total-row"><th colspan="2">Total</th>${classes.map(item=>`<td class="number">${formatShares(summary.columns[item.id])}</td>`).join('')}<td class="number">${formatShares(summary.grand)}</td></tr></tbody></table></div></section>`; }
+  table(title, values, editable, stepId='') {
+    const company = this.company;
+    const classes = classesOf(company);
+    const summary = totals(company, values);
+    let groupHeaders = '';
+    let classHeaders = '';
+
+    for (const group of company.groups) {
+      groupHeaders += `<th class="group-head" data-group-id="${escapeHtml(group.id)}" colspan="${Math.max(1, group.classes.length)}"><input data-group-name value="${escapeHtml(group.name)}" aria-label="Share group"></th>`;
+      for (const item of group.classes) {
+        const column = classes.findIndex(shareClass => shareClass.id === item.id) + 1;
+        classHeaders += `<th data-group-id="${escapeHtml(group.id)}" data-class-id="${escapeHtml(item.id)}"><input data-class-label data-grid-row="0" data-grid-column="${column}" value="${escapeHtml(item.label)}" aria-label="Share class"></th>`;
+      }
+    }
+
+    const rows = company.shareholders.map((holder, row) => {
+      const shareholder = `<th><input data-holder-name data-holder-id="${escapeHtml(holder.id)}" data-grid-row="${row + 1}" data-grid-column="0" value="${escapeHtml(holder.name)}" aria-label="Shareholder"></th>`;
+      const type = `<td><select data-holder-type data-holder-id="${escapeHtml(holder.id)}" tabindex="-1">${TYPES.map(item => `<option${item === holder.type ? ' selected' : ''}>${item}</option>`).join('')}</select></td>`;
+      const rowValues = classes.map((item, column) => {
+        const value = valueAt(values, holder.id, item.id);
+        const negative = value < 0 && (editable === 'opening' || !editable);
+        return `<td class="number ${negative ? 'negative' : ''}" tabindex="${editable ? '0' : '-1'}" ${editable ? 'contenteditable="true"' : ''} data-grid-row="${row + 1}" data-grid-column="${column + 1}" data-holder-id="${escapeHtml(holder.id)}" data-class-id="${escapeHtml(item.id)}" data-step-id="${escapeHtml(stepId)}" data-editable="${editable ? 'true' : 'false'}">${formatShares(value)}</td>`;
+      }).join('');
+      return `<tr>${shareholder}${type}${rowValues}<td class="number total">${formatShares(summary.rows[holder.id])}</td></tr>`;
+    }).join('');
+
+    const columnTotals = classes.map(item => `<td class="number">${formatShares(summary.columns[item.id])}</td>`).join('');
+    return `<section class="share-table"><h3>${escapeHtml(title)}</h3><div class="table-scroll"><table><thead><tr><th rowspan="2">Shareholder</th><th rowspan="2">Type</th>${groupHeaders}<th rowspan="2">Total</th></tr><tr>${classHeaders}</tr></thead><tbody>${rows}<tr class="total-row"><th colspan="2">Total</th>${columnTotals}<td class="number">${formatShares(summary.grand)}</td></tr></tbody></table></div></section>`;
+  }
   render() { const excel=this.excel,company=this.company;this.root.innerHTML=`<div class="company-tabs" role="tablist">${excel.companies.map(item=>`<button role="tab" aria-selected="${item.id===excel.selectedCompanyId}" data-company-id="${escapeHtml(item.id)}">${escapeHtml(item.name)}</button>`).join('')}</div>${company?this.table('Opening Position',company.opening,'opening')+this.getDocument().steps.map((step,index)=>`<section class="step-share-section"><button class="collapse-step" data-collapse="${escapeHtml(step.id)}" aria-expanded="${!company.collapsed[step.id]}">${company.collapsed[step.id]?'▸':'▾'} Step ${index+1}: ${escapeHtml(step.title)}</button><div ${company.collapsed[step.id]?'hidden':''}>${this.table(`Step ${index+1} Movement`,company.movements[step.id],true,step.id)}${this.table(`Step ${index+1} Resulting Position`,resultingValues(company,this.getDocument().steps,index),false,step.id)}</div></section>`).join(''):'<p>Add a company to begin.</p>'}`;this.bindGrid(); }
-  bindGrid() { this.root.querySelectorAll('[data-company-id]').forEach(button=>button.onclick=()=>this.mutate(excel=>excel.selectedCompanyId=button.dataset.companyId));this.root.querySelectorAll('[data-collapse]').forEach(button=>button.onclick=()=>this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId);company.collapsed[button.dataset.collapse]=!company.collapsed[button.dataset.collapse];}));this.root.querySelectorAll('[data-holder-id]').forEach(element=>element.onfocus=()=>{this.focus.holderId=element.dataset.holderId;});this.root.querySelectorAll('[data-group-id]').forEach(element=>element.onfocus=()=>{this.focus.groupId=element.dataset.groupId;this.focus.classId=element.dataset.classId;});this.root.querySelectorAll('td[data-editable=true]').forEach(cell=>{cell.onfocus=()=>{this.focus={holderId:cell.dataset.holderId,classId:cell.dataset.classId,groupId:cell.closest('table').querySelector(`[data-class-id="${CSS.escape(cell.dataset.classId)}"]`)?.dataset.groupId};};cell.onblur=()=>this.commitCell(cell);cell.onkeydown=event=>this.keydown(event,cell);});const companyOf=excel=>excel.companies.find(item=>item.id===excel.selectedCompanyId);this.root.querySelectorAll('[data-holder-name]').forEach(input=>input.onchange=()=>this.mutate(excel=>{const holder=companyOf(excel).shareholders.find(item=>item.id===input.dataset.holderId);if(holder)holder.name=input.value;}));this.root.querySelectorAll('[data-holder-type]').forEach(select=>select.onchange=()=>this.mutate(excel=>{const holder=companyOf(excel).shareholders.find(item=>item.id===select.dataset.holderId);if(holder)holder.type=select.value;}));this.root.querySelectorAll('[data-group-name]').forEach(input=>input.onchange=()=>this.mutate(excel=>{const group=companyOf(excel).groups.find(item=>item.id===input.closest('[data-group-id]').dataset.groupId);if(group)group.name=input.value;}));this.root.querySelectorAll('[data-class-label]').forEach(input=>input.onchange=()=>this.mutate(excel=>{const header=input.closest('[data-class-id]'),shareClass=classesOf(companyOf(excel)).find(item=>item.id===header.dataset.classId);if(shareClass)shareClass.label=input.value;})); }
+  bindGrid() {
+    this.root.querySelectorAll('[data-company-id]').forEach(button => button.onclick = () => this.mutate(excel => excel.selectedCompanyId = button.dataset.companyId));
+    this.root.querySelectorAll('[data-collapse]').forEach(button => button.onclick = () => this.mutate(excel => {
+      const company = excel.companies.find(item => item.id === excel.selectedCompanyId);
+      company.collapsed[button.dataset.collapse] = !company.collapsed[button.dataset.collapse];
+    }));
+    this.root.querySelectorAll('[data-holder-id]').forEach(element => element.onfocus = () => {
+      this.focus.holderId = element.dataset.holderId;
+    });
+    this.root.querySelectorAll('[data-group-id]').forEach(element => element.onfocus = () => {
+      this.focus.groupId = element.dataset.groupId;
+      this.focus.classId = element.dataset.classId;
+    });
+    this.root.querySelectorAll(gridSelector).forEach(target => target.onkeydown = event => this.keydown(event, target));
+    this.root.querySelectorAll('td[data-editable=true]').forEach(cell => {
+      cell.onfocus = () => {
+        const header = [...cell.closest('table').querySelectorAll('[data-class-id]')]
+          .find(item => item.dataset.classId === cell.dataset.classId);
+        this.focus = {holderId:cell.dataset.holderId, classId:cell.dataset.classId, groupId:header?.dataset.groupId};
+        if (cell.textContent.trim() === '0') cell.textContent = '';
+      };
+      cell.onblur = () => {
+        if (cell.dataset.skipBlur === 'true') return;
+        this.commitCell(cell);
+      };
+    });
+    const companyOf = excel => excel.companies.find(item => item.id === excel.selectedCompanyId);
+    this.root.querySelectorAll('[data-holder-name]').forEach(input => input.onchange = () => this.mutate(excel => {
+      const holder = companyOf(excel).shareholders.find(item => item.id === input.dataset.holderId);
+      if (holder) holder.name = input.value;
+    }));
+    this.root.querySelectorAll('[data-holder-type]').forEach(select => select.onchange = () => this.mutate(excel => {
+      const holder = companyOf(excel).shareholders.find(item => item.id === select.dataset.holderId);
+      if (holder) holder.type = select.value;
+    }));
+    this.root.querySelectorAll('[data-group-name]').forEach(input => input.onchange = () => this.mutate(excel => {
+      const group = companyOf(excel).groups.find(item => item.id === input.closest('[data-group-id]').dataset.groupId);
+      if (group) group.name = input.value;
+    }));
+    this.root.querySelectorAll('[data-class-label]').forEach(input => input.onchange = () => this.mutate(excel => {
+      const header = input.closest('[data-class-id]');
+      const shareClass = classesOf(companyOf(excel)).find(item => item.id === header.dataset.classId);
+      if (shareClass) shareClass.label = input.value;
+    }));
+  }
   commitCell(cell) { if(cell.contentEditable!=='true')return;const value=parseShares(cell.textContent);if(value===null){this.report('Only whole integers are permitted.');this.render();return;}this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId),values=cell.dataset.stepId?company.movements[cell.dataset.stepId]:company.opening;values[cellKey(cell.dataset.holderId,cell.dataset.classId)]=value;}); }
-  keydown(event,cell) { if(event.key==='Escape'){event.preventDefault();this.render();return;}if(['Delete','Backspace'].includes(event.key)&&cell.contentEditable!=='true')event.preventDefault();if(!['ArrowUp','ArrowDown','ArrowLeft','ArrowRight','Enter','Tab'].includes(event.key))return;event.preventDefault();this.commitCell(cell);const cells=[...this.root.querySelectorAll('td[data-editable=true]')],index=cells.findIndex(item=>item.dataset.holderId===cell.dataset.holderId&&item.dataset.classId===cell.dataset.classId&&item.dataset.stepId===cell.dataset.stepId),delta=(event.key==='ArrowUp'||(event.key==='Enter'&&event.shiftKey))?-classesOf(this.company).length:(event.key==='ArrowDown'||event.key==='Enter')?classesOf(this.company).length:(event.key==='ArrowLeft'||(event.key==='Tab'&&event.shiftKey))?-1:1;cells[(index+delta+cells.length)%cells.length]?.focus(); }
+  keydown(event, target) {
+    if (event.key === 'Escape' && target.matches('td[data-editable=true]')) {
+      event.preventDefault();
+      this.render();
+      return;
+    }
+    const navigationKeys = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Enter', 'Tab'];
+    if (!navigationKeys.includes(event.key)) return;
+
+    const table = target.closest('table');
+    const targets = [...table.querySelectorAll(gridSelector)].filter(item => (
+      !item.matches('td[data-editable=false]')
+    ));
+    const destination = gridDestination(targets, target, event.key, event.shiftKey);
+    const destinationPosition = {
+      row:destination.dataset.gridRow,
+      column:destination.dataset.gridColumn
+    };
+    const tables = [...this.root.querySelectorAll('.share-table table')];
+    const tableIndex = tables.indexOf(table);
+    event.preventDefault();
+
+    if (target.matches('td[data-editable=true]')) {
+      target.dataset.skipBlur = 'true';
+      this.commitCell(target);
+    } else if (target.matches('[data-holder-name], [data-class-label]')) {
+      target.onchange();
+    }
+    const currentTable = this.root.querySelectorAll('.share-table table')[tableIndex] || table;
+    currentTable.querySelector(`${gridSelector}[data-grid-row="${destinationPosition.row}"][data-grid-column="${destinationPosition.column}"]`)?.focus();
+  }
 }

--- a/UBTA/tests/excel-editor.test.js
+++ b/UBTA/tests/excel-editor.test.js
@@ -1,6 +1,6 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
-import { ExcelEditor } from '../src/editor/excel-editor.js';
+import { ExcelEditor, gridDestination } from '../src/editor/excel-editor.js';
 import { createExcel, syncSteps } from '../src/state/excel-model.js';
 
 const root = () => ({ innerHTML:'', querySelectorAll:() => [] });
@@ -45,6 +45,45 @@ test('opening and movement cells render as directly editable', () => {
 
   assert.match(document.element.innerHTML,/contenteditable="true"[^>]+data-step-id=""[^>]+data-editable="true"/);
   assert.match(document.element.innerHTML,/contenteditable="true"[^>]+data-step-id="step-1"[^>]+data-editable="true"/);
+  assert.match(document.element.innerHTML,/data-class-label data-grid-row="0" data-grid-column="1"/);
+  assert.match(document.element.innerHTML,/data-holder-name[^>]+data-grid-row="1" data-grid-column="0"/);
+});
+
+test('grid navigation includes shareholder and share class labels', () => {
+  const target = (row, column) => ({dataset:{gridRow:String(row), gridColumn:String(column)}});
+  const classLabel = target(0, 1);
+  const holderLabel = target(1, 0);
+  const firstValue = target(1, 1);
+  const secondValue = target(1, 2);
+  const targets = [classLabel, holderLabel, firstValue, secondValue];
+
+  assert.equal(gridDestination(targets, classLabel, 'ArrowDown'), firstValue);
+  assert.equal(gridDestination(targets, firstValue, 'ArrowLeft'), holderLabel);
+  assert.equal(gridDestination(targets, holderLabel, 'Tab'), firstValue);
+  assert.equal(gridDestination(targets, firstValue, 'Tab', true), holderLabel);
+  assert.equal(gridDestination(targets, firstValue, 'ArrowRight'), secondValue);
+});
+
+test('focusing a zero-valued share cell clears it ready for typing', () => {
+  const header = {dataset:{groupId:'group-1'}};
+  const table = {querySelectorAll:() => [header]};
+  const cell = {
+    dataset:{holderId:'holder-1', classId:'class-1'},
+    textContent:'0',
+    closest:() => table
+  };
+  const matches = {
+    '[data-grid-row][data-grid-column]':[cell],
+    'td[data-editable=true]':[cell]
+  };
+  const element = {querySelectorAll:selector => matches[selector] || []};
+  const document = {steps:[], excel:createExcel(), element};
+  const editor = new ExcelEditor({root:element, toolbar:toolbar(), getDocument:() => document, updateDocument:value => document.excel=value, report() {}});
+
+  editor.bindGrid();
+  cell.onfocus();
+
+  assert.equal(cell.textContent, '');
 });
 
 test('shareholder and header edits use stable row and column identities', () => {


### PR DESCRIPTION
### Motivation
- Make the share table behave like a spreadsheet so users can navigate cells, class labels and shareholder labels with arrow keys, Tab/Shift+Tab and Enter/Shift+Enter. 
- Let users begin typing immediately when focusing a numeric cell by clearing a lone `0` on first focus.

### Description
- Add grid coordinates and navigation helpers: introduce `gridSelector` and export `gridDestination` to compute keyboard destinations. 
- Annotate rendered table markup with `data-grid-row` and `data-grid-column` on share-class headers, shareholder name fields and value cells so labels participate in navigation. 
- Rework `table`, `bindGrid`, `keydown` and `commitCell` logic in `ExcelEditor` to: support Arrow/Tab/Enter navigation across headers, labels and editable cells, clear a single `0` on focus, and avoid spurious blur when moving focus programmatically. 
- Add regression tests in `UBTA/tests/excel-editor.test.js` for grid coordinates, `gridDestination` behavior and zero-value clearing. 
- Rebuild the standalone distribution and update `UBTA/dist/index.html` to include the editor changes.

### Testing
- Ran the full automated test suite with `npm test` and all tests passed (editor and model tests including the new navigation/zero-clear tests). 
- Built the production bundle with `npm run build` and the `dist/index.html` was produced successfully. 
- Verified repository state with `git diff --check` after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69f6188a988324a838aa0a8cb96c23)