### PR TITLE
Refactor UBTA JavaScript for readability

### DIFF
--- a/UBTA/.prettierrc.json
+++ b/UBTA/.prettierrc.json
@@ -1,0 +1,6 @@
+{
+  "printWidth": 80,
+  "singleQuote": true,
+  "tabWidth": 2,
+  "trailingComma": "all"
+}

--- a/UBTA/dist/index.html
+++ b/UBTA/dist/index.html
@@ -1574,7 +1574,8 @@ h4,
     const body = sheet.querySelector('.document-body');
     if (!body) return false;
     const style = getComputedStyle(sheet);
-    const limit = sheet.getBoundingClientRect().bottom - parseFloat(style.paddingBottom);
+    const limit =
+      sheet.getBoundingClientRect().bottom - parseFloat(style.paddingBottom);
     return body.getBoundingClientRect().bottom > limit + 0.5;
   }
 
@@ -1582,18 +1583,23 @@ h4,
     const sheet = document.createElement(source.tagName);
     sheet.className = source.className;
     sheet.tabIndex = -1;
-    for (const [key, value] of Object.entries(source.dataset)) sheet.dataset[key] = value;
+    for (const [key, value] of Object.entries(source.dataset))
+      sheet.dataset[key] = value;
     if (!continuation && source.id) sheet.id = source.id;
     else if (source.id) sheet.dataset.anchorId = source.id;
     const header = source.querySelector(':scope > .page-header');
     if (header) sheet.append(header.cloneNode(true));
-    const heading = source.querySelector(':scope > .step-heading, :scope > .section-title');
+    const heading = source.querySelector(
+      ':scope > .step-heading, :scope > .section-title',
+    );
     if (heading) {
       if (!continuation) sheet.append(heading.cloneNode(true));
       else {
         const continued = document.createElement('div');
         continued.className = 'continuation-heading';
-        const title = heading.querySelector('.step-title')?.value || heading.textContent.trim();
+        const title =
+          heading.querySelector('.step-title')?.value ||
+          heading.textContent.trim();
         continued.textContent = `${title} — continued`;
         sheet.append(continued);
       }
@@ -1605,7 +1611,10 @@ h4,
   }
 
   function textLength(root) {
-    return [...root.querySelectorAll('[contenteditable=true]')].reduce((n, el) => n + el.textContent.length, 0);
+    return [...root.querySelectorAll('[contenteditable=true]')].reduce(
+      (n, el) => n + el.textContent.length,
+      0,
+    );
   }
 
   function textBoundary(root, offset) {
@@ -1632,18 +1641,28 @@ h4,
     const original = editable.cloneNode(true);
     const text = original.textContent;
     if (text.length < 2) return null;
-    let low = 1, high = text.length - 1, best = 0;
+    let low = 1,
+      high = text.length - 1,
+      best = 0;
     while (low <= high) {
       const middle = (low + high) >> 1;
       editable.replaceChildren(richTextSlice(original, 0, middle));
-      if (fit()) { best = middle; low = middle + 1; } else high = middle - 1;
+      if (fit()) {
+        best = middle;
+        low = middle + 1;
+      } else high = middle - 1;
     }
-    if (!best) { editable.replaceChildren(...original.cloneNode(true).childNodes); return null; }
+    if (!best) {
+      editable.replaceChildren(...original.cloneNode(true).childNodes);
+      return null;
+    }
     const breakAt = text.lastIndexOf(' ', best);
     best = breakAt > best / 2 ? breakAt + 1 : best;
     editable.replaceChildren(richTextSlice(original, 0, best));
     const rest = block.cloneNode(true);
-    rest.querySelector('[contenteditable=true]').replaceChildren(richTextSlice(original, best, text.length));
+    rest
+      .querySelector('[contenteditable=true]')
+      .replaceChildren(richTextSlice(original, best, text.length));
     block.dataset.fragmentPart = 'true';
     rest.dataset.fragmentPart = 'true';
     return rest;
@@ -1657,11 +1676,14 @@ h4,
     let keep = items.length;
     while (keep > 1 && !fit()) items[--keep].remove();
     if (!fit()) {
-      list.replaceChildren(...rest.querySelector(':scope > ol, :scope > ul').cloneNode(true).children);
+      list.replaceChildren(
+        ...rest.querySelector(':scope > ol, :scope > ul').cloneNode(true)
+          .children,
+      );
       return null;
     }
     const restList = rest.querySelector(':scope > ol, :scope > ul');
-    [...restList.children].slice(0, keep).forEach(el => el.remove());
+    [...restList.children].slice(0, keep).forEach((el) => el.remove());
     block.querySelector(':scope > .list-trailing-hit-area')?.remove();
     block.dataset.fragmentPart = rest.dataset.fragmentPart = 'true';
     return rest;
@@ -1675,10 +1697,14 @@ h4,
     while (keep > 1 && !fit()) rows[--keep].remove();
     if (!fit()) {
       const sourceBody = rest.querySelector('tbody');
-      block.querySelector('tbody').replaceChildren(...sourceBody.cloneNode(true).children);
+      block
+        .querySelector('tbody')
+        .replaceChildren(...sourceBody.cloneNode(true).children);
       return null;
     }
-    [...rest.querySelectorAll('tbody > tr')].slice(0, keep).forEach(el => el.remove());
+    [...rest.querySelectorAll('tbody > tr')]
+      .slice(0, keep)
+      .forEach((el) => el.remove());
     block.dataset.fragmentPart = rest.dataset.fragmentPart = 'true';
     return rest;
   }
@@ -1691,14 +1717,18 @@ h4,
   }
 
   function fragmentGroup(source, target) {
-    const blocks = [...source.querySelectorAll(':scope > .document-body > .editable-block')].map(x => x.cloneNode(true));
+    const blocks = [
+      ...source.querySelectorAll(':scope > .document-body > .editable-block'),
+    ].map((x) => x.cloneNode(true));
     let fragment = 0;
     let sheet = cloneShell(source, false);
     let page = pageFor(sheet, target);
     const decorate = () => {
       page.dataset.pageFragment = String(fragment);
       page.dataset.groupId = source.dataset.editableGroupId || '';
-      page.dataset.groupType = source.dataset.groupType || (source.classList.contains('section') ? 'section' : '');
+      page.dataset.groupType =
+        source.dataset.groupType ||
+        (source.classList.contains('section') ? 'section' : '');
       page.dataset.anchorId = source.id || '';
       sheet.dataset.fragmentIndex = String(fragment);
     };
@@ -1717,7 +1747,11 @@ h4,
       if (!overflows(sheet)) continue;
       const hadPrevious = body.children.length > 1;
       if (hadPrevious) {
-        const heading = block.matches('[data-type="paragraph"]') && block.previousElementSibling?.matches('[data-type="heading"]') ? block.previousElementSibling : null;
+        const heading =
+          block.matches('[data-type="paragraph"]') &&
+          block.previousElementSibling?.matches('[data-type="heading"]')
+            ? block.previousElementSibling
+            : null;
         block.remove();
         heading?.remove();
         body = nextPage();
@@ -1727,7 +1761,8 @@ h4,
       if (overflows(sheet)) {
         const rest = fragmentBlock(block, sheet);
         if (rest) blocks.splice(index + 1, 0, rest);
-        else if (block.classList.contains('image-block')) block.classList.add('fit-page');
+        else if (block.classList.contains('image-block'))
+          block.classList.add('fit-page');
       }
     }
   }
@@ -1741,7 +1776,8 @@ h4,
         document.body.append(target);
       }
       for (const source of [...content.children]) {
-        if (source.querySelector(':scope > .document-body')) fragmentGroup(source, target);
+        if (source.querySelector(':scope > .document-body'))
+          fragmentGroup(source, target);
         else pageFor(source.cloneNode(true), target);
       }
       target.classList.remove('pagination-staging');
@@ -1751,49 +1787,172 @@ h4,
   }
 
   window.Paged = { Previewer };
-}());
+})();
 
 const DAMAGED_FILE_MESSAGE = 'Incorrect password or damaged file.';
-const invalid = () => Object.assign(new Error(DAMAGED_FILE_MESSAGE), { name:'EncryptedFileError' });
-function decodeBase64(value) { if(typeof value!=='string'||!value||!/^[A-Za-z0-9+/]*={0,2}$/.test(value)||value.length%4)throw invalid();try{return Uint8Array.from(atob(value),c=>c.charCodeAt(0))}catch{throw invalid()} }
-function validateEnvelope(e) { if(!e||e.version!==1||e.algorithm!=='AES-GCM'||e.kdf!=='PBKDF2-SHA-256'||!Number.isInteger(e.iterations)||e.iterations<100000||decodeBase64(e.salt).length!==16||decodeBase64(e.iv).length!==12||decodeBase64(e.ciphertext).length<17)throw invalid();return e }
-async function decryptEnvelope(e,password,subtle=crypto.subtle){try{validateEnvelope(e);const material=await subtle.importKey('raw',new TextEncoder().encode(String(password)),'PBKDF2',false,['deriveKey']);const key=await subtle.deriveKey({name:'PBKDF2',hash:'SHA-256',salt:decodeBase64(e.salt),iterations:e.iterations},material,{name:'AES-GCM',length:256},false,['decrypt']);const plain=await subtle.decrypt({name:'AES-GCM',iv:decodeBase64(e.iv)},key,decodeBase64(e.ciphertext));return JSON.parse(new TextDecoder().decode(plain))}catch{throw invalid()}}
+const invalid = () =>
+  Object.assign(new Error(DAMAGED_FILE_MESSAGE), {
+    name: 'EncryptedFileError',
+  });
+function decodeBase64(value) {
+  if (
+    typeof value !== 'string' ||
+    !value ||
+    !/^[A-Za-z0-9+/]*={0,2}$/.test(value) ||
+    value.length % 4
+  )
+    throw invalid();
+  try {
+    return Uint8Array.from(atob(value), (c) => c.charCodeAt(0));
+  } catch {
+    throw invalid();
+  }
+}
+function validateEnvelope(e) {
+  if (
+    !e ||
+    e.version !== 1 ||
+    e.algorithm !== 'AES-GCM' ||
+    e.kdf !== 'PBKDF2-SHA-256' ||
+    !Number.isInteger(e.iterations) ||
+    e.iterations < 100000 ||
+    decodeBase64(e.salt).length !== 16 ||
+    decodeBase64(e.iv).length !== 12 ||
+    decodeBase64(e.ciphertext).length < 17
+  )
+    throw invalid();
+  return e;
+}
+async function decryptEnvelope(e, password, subtle = crypto.subtle) {
+  try {
+    validateEnvelope(e);
+    const material = await subtle.importKey(
+      'raw',
+      new TextEncoder().encode(String(password)),
+      'PBKDF2',
+      false,
+      ['deriveKey'],
+    );
+    const key = await subtle.deriveKey(
+      {
+        name: 'PBKDF2',
+        hash: 'SHA-256',
+        salt: decodeBase64(e.salt),
+        iterations: e.iterations,
+      },
+      material,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['decrypt'],
+    );
+    const plain = await subtle.decrypt(
+      { name: 'AES-GCM', iv: decodeBase64(e.iv) },
+      key,
+      decodeBase64(e.ciphertext),
+    );
+    return JSON.parse(new TextDecoder().decode(plain));
+  } catch {
+    throw invalid();
+  }
+}
 
 // This ciphertext is deliberately shipped with the client so unlocking also works from file://.
-const defaultTemplateEnvelope=Object.freeze({
-  version:1,
-  algorithm:'AES-GCM',
-  kdf:'PBKDF2-SHA-256',
-  iterations:310000,
-  salt:'EG5326HC6gLkkN2TxPdodg==',
-  iv:'NyQQS8ak6Y2E3WUG',
-  ciphertext:'VgziFV2P5dlFyYaBY3+oN5RpUx+0nqoK1jty5JHHz40YRcVuqNk0zaxzGO582YayTTI7XLl8LayWCeZx7y7yB71xE4/68pa1vcZCqg97tJI8bqRnsTDoZIJWdg0Sr4iFX+xWxYgMWDCtq6KHAabu+couoqS3qZ0bmdBBphyUMEHvPo1RLdQOLIyPE6+xa05GEON7iwUD8MSNsLfbwU7Y3MLuJu6+SpPdnvhu3oB2SmwT6ub+aRK3cJQKfoUffFni6dR9zgL1jJesPeM4xHCeoBpM3/1PPsYcpwccbsbX+Z7Hkd6XItPS1FPWn2UclHtsUSvE0FmgWgHpBb9uv43WpGgtsndet83Q483EeqGFfzUTdjaFg9keoIWdB4vJb1saQ0iwPekp9NPMKNPk8BdC2X4d8c827CH5jMEHHOBhOrEfedNERWEVpZmg6A=='
+const defaultTemplateEnvelope = Object.freeze({
+  version: 1,
+  algorithm: 'AES-GCM',
+  kdf: 'PBKDF2-SHA-256',
+  iterations: 310000,
+  salt: 'EG5326HC6gLkkN2TxPdodg==',
+  iv: 'NyQQS8ak6Y2E3WUG',
+  ciphertext:
+    'VgziFV2P5dlFyYaBY3+oN5RpUx+0nqoK1jty5JHHz40YRcVuqNk0zaxzGO582YayTTI7XLl8LayWCeZx7y7yB71xE4/68pa1vcZCqg97tJI8bqRnsTDoZIJWdg0Sr4iFX+xWxYgMWDCtq6KHAabu+couoqS3qZ0bmdBBphyUMEHvPo1RLdQOLIyPE6+xa05GEON7iwUD8MSNsLfbwU7Y3MLuJu6+SpPdnvhu3oB2SmwT6ub+aRK3cJQKfoUffFni6dR9zgL1jJesPeM4xHCeoBpM3/1PPsYcpwccbsbX+Z7Hkd6XItPS1FPWn2UclHtsUSvE0FmgWgHpBb9uv43WpGgtsndet83Q483EeqGFfzUTdjaFg9keoIWdB4vJb1saQ0iwPekp9NPMKNPk8BdC2X4d8c827CH5jMEHHOBhOrEfedNERWEVpZmg6A==',
 });
 
-function validateTemplatePayload(payload){if(!payload||payload.type!=='editor-defaults'||!Array.isArray(payload.templates)||!payload.templates.length)throw Error('The decrypted template database is malformed.');const ids=new Set();return payload.templates.map(t=>{if(!t||typeof t.id!=='string'||!t.id.trim()||ids.has(t.id)||typeof t.header!=='string'||!t.header.trim()||typeof t.body!=='string'||!t.body.trim())throw Error('The decrypted template database is malformed.');ids.add(t.id);return Object.freeze({id:t.id,header:t.header.trim(),body:t.body})})}
-class EncryptedTemplateLoader{#templates=null;#decrypt;constructor({decrypt=decryptEnvelope}={}){this.#decrypt=decrypt}get cached(){return this.#templates!==null}async unlock(envelope,password){if(this.#templates)return this.#templates;const templates=validateTemplatePayload(await this.#decrypt(envelope,password));this.#templates=Object.freeze(templates);return this.#templates}}
-const templateBlocks=(template,newId)=>[{id:newId('block'),type:'heading',level:2,runs:[{text:template.header}]},{id:newId('block'),type:'paragraph',runs:[{text:template.body}]}];
+function validateTemplatePayload(payload) {
+  if (
+    !payload ||
+    payload.type !== 'editor-defaults' ||
+    !Array.isArray(payload.templates) ||
+    !payload.templates.length
+  )
+    throw Error('The decrypted template database is malformed.');
+  const ids = new Set();
+  return payload.templates.map((t) => {
+    if (
+      !t ||
+      typeof t.id !== 'string' ||
+      !t.id.trim() ||
+      ids.has(t.id) ||
+      typeof t.header !== 'string' ||
+      !t.header.trim() ||
+      typeof t.body !== 'string' ||
+      !t.body.trim()
+    )
+      throw Error('The decrypted template database is malformed.');
+    ids.add(t.id);
+    return Object.freeze({ id: t.id, header: t.header.trim(), body: t.body });
+  });
+}
+class EncryptedTemplateLoader {
+  #templates = null;
+  #decrypt;
+  constructor({ decrypt = decryptEnvelope } = {}) {
+    this.#decrypt = decrypt;
+  }
+  get cached() {
+    return this.#templates !== null;
+  }
+  async unlock(envelope, password) {
+    if (this.#templates) return this.#templates;
+    const templates = validateTemplatePayload(
+      await this.#decrypt(envelope, password),
+    );
+    this.#templates = Object.freeze(templates);
+    return this.#templates;
+  }
+}
+const templateBlocks = (template, newId) => [
+  {
+    id: newId('block'),
+    type: 'heading',
+    level: 2,
+    runs: [{ text: template.header }],
+  },
+  { id: newId('block'), type: 'paragraph', runs: [{ text: template.body }] },
+];
 
 const FORMATS = new Set(['text', 'number', 'gbp']);
-const runsText = runs => (runs || []).map(run => run.text || '').join('');
-const plainRuns = text => text === '' ? [] : [{ text, highlight: false, link: null }];
+const runsText = (runs) => (runs || []).map((run) => run.text || '').join('');
+const plainRuns = (text) =>
+  text === '' ? [] : [{ text, highlight: false, link: null }];
 
-const tableColumnFormat = column => FORMATS.has(column?.format) ? column.format : column?.numeric === true ? 'number' : 'text';
+const tableColumnFormat = (column) =>
+  FORMATS.has(column?.format)
+    ? column.format
+    : column?.numeric === true
+      ? 'number'
+      : 'text';
 
 /** Blank and invalid values return null; arbitrary text is never coerced to zero. */
 function parseTableNumber(value) {
   const compact = String(value ?? '').replace(/\s/g, '');
   if (!compact) return null;
-  const match = compact.match(/^(?:£)?([+-]?)(?:£)?((?:\d{1,3}(?:,\d{3})+)|\d+)(\.\d+)?$/);
+  const match = compact.match(
+    /^(?:£)?([+-]?)(?:£)?((?:\d{1,3}(?:,\d{3})+)|\d+)(\.\d+)?$/,
+  );
   if (!match) return null;
-  const number = Number(`${match[1]}${match[2].replaceAll(',', '')}${match[3] || ''}`);
+  const number = Number(
+    `${match[1]}${match[2].replaceAll(',', '')}${match[3] || ''}`,
+  );
   return Number.isFinite(number) ? number : null;
 }
 
 function formatTableNumber(value, format = 'number') {
   if (!Number.isFinite(value)) return '';
-  if (format === 'gbp') return `${value < 0 ? '-' : ''}£${Math.abs(value).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-  if (format === 'number') return value.toLocaleString('en-GB', { maximumFractionDigits: 20 });
+  if (format === 'gbp')
+    return `${value < 0 ? '-' : ''}£${Math.abs(value).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  if (format === 'number')
+    return value.toLocaleString('en-GB', { maximumFractionDigits: 20 });
   return String(value);
 }
 
@@ -1804,27 +1963,58 @@ function recalculateTableTotals(block) {
     block.columns.forEach((column, columnIndex) => {
       const format = tableColumnFormat(column);
       if (format === 'text') return;
-      if (column.totalEnabled === false) { if (row.cells?.[columnIndex]) row.cells[columnIndex].runs=[]; return; }
-      const values = block.rows.slice(0, rowIndex).filter(candidate => !candidate.isTotal).map(candidate => parseTableNumber(runsText(candidate.cells?.[columnIndex]?.runs))).filter(value => value !== null);
+      if (column.totalEnabled === false) {
+        if (row.cells?.[columnIndex]) row.cells[columnIndex].runs = [];
+        return;
+      }
+      const values = block.rows
+        .slice(0, rowIndex)
+        .filter((candidate) => !candidate.isTotal)
+        .map((candidate) =>
+          parseTableNumber(runsText(candidate.cells?.[columnIndex]?.runs)),
+        )
+        .filter((value) => value !== null);
       const total = values.reduce((sum, value) => sum + value, 0);
-      if (row.cells?.[columnIndex]) row.cells[columnIndex].runs = plainRuns(formatTableNumber(total, format));
+      if (row.cells?.[columnIndex])
+        row.cells[columnIndex].runs = plainRuns(
+          formatTableNumber(total, format),
+        );
     });
   });
   return block;
 }
 
 function moveTableRow(block, index, offset) {
-  const target = index + offset, row = block?.rows?.[index];
-  if (!row || target < 0 || target >= block.rows.length || block.rows[target].isTotal !== row.isTotal) return false;
-  [block.rows[index], block.rows[target]] = [block.rows[target], block.rows[index]];
+  const target = index + offset,
+    row = block?.rows?.[index];
+  if (
+    !row ||
+    target < 0 ||
+    target >= block.rows.length ||
+    block.rows[target].isTotal !== row.isTotal
+  )
+    return false;
+  [block.rows[index], block.rows[target]] = [
+    block.rows[target],
+    block.rows[index],
+  ];
   return target;
 }
 
 function moveTableColumn(block, index, offset) {
   const target = index + offset;
-  if (!block?.columns?.[index] || target < 0 || target >= block.columns.length) return false;
-  [block.columns[index], block.columns[target]] = [block.columns[target], block.columns[index]];
-  block.rows.forEach(row => { [row.cells[index], row.cells[target]] = [row.cells[target], row.cells[index]]; });
+  if (!block?.columns?.[index] || target < 0 || target >= block.columns.length)
+    return false;
+  [block.columns[index], block.columns[target]] = [
+    block.columns[target],
+    block.columns[index],
+  ];
+  block.rows.forEach((row) => {
+    [row.cells[index], row.cells[target]] = [
+      row.cells[target],
+      row.cells[index],
+    ];
+  });
   return target;
 }
 
@@ -1841,8 +2031,10 @@ function validateImageSource(value) {
     return { ok: false, error: 'malformed-source' };
   }
 
-  if (url.protocol !== 'https:') return { ok: false, error: 'unsupported-protocol' };
-  if (!SUPPORTED_IMAGE_PATH.test(url.pathname)) return { ok: false, error: 'unsupported-extension' };
+  if (url.protocol !== 'https:')
+    return { ok: false, error: 'unsupported-protocol' };
+  if (!SUPPORTED_IMAGE_PATH.test(url.pathname))
+    return { ok: false, error: 'unsupported-extension' };
   return { ok: true, url: url.href };
 }
 
@@ -1867,81 +2059,297 @@ function validateImageInput(input = {}) {
   };
 }
 
-const id = prefix => `${prefix}-${globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)}`;
+const id = (prefix) =>
+  `${prefix}-${globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)}`;
 const TYPES = ['Individual', 'Trust', 'Company'];
 const MAX_SHAREHOLDERS = 100;
 const MAX_CLASSES = 100;
-const integer = value => Number.isSafeInteger(value) ? value : 0;
+const integer = (value) => (Number.isSafeInteger(value) ? value : 0);
 
 function parseShares(value) {
-  if (typeof value === 'number') return Number.isSafeInteger(value) ? value : null;
-  const text = String(value ?? '').trim().replaceAll(',', '');
+  if (typeof value === 'number')
+    return Number.isSafeInteger(value) ? value : null;
+  const text = String(value ?? '')
+    .trim()
+    .replaceAll(',', '');
   if (!text) return 0;
-  const negative = text.match(/^\((\d+)\)$/), candidate = negative ? `-${negative[1]}` : text;
+  const negative = text.match(/^\((\d+)\)$/),
+    candidate = negative ? `-${negative[1]}` : text;
   const number = Number(candidate);
-  return /^-?\d+$/.test(candidate) && Number.isSafeInteger(number) ? number : null;
+  return /^-?\d+$/.test(candidate) && Number.isSafeInteger(number)
+    ? number
+    : null;
 }
-const formatShares = value => integer(value) < 0 ? `(${Math.abs(integer(value)).toLocaleString('en-GB')})` : integer(value).toLocaleString('en-GB');
+const formatShares = (value) =>
+  integer(value) < 0
+    ? `(${Math.abs(integer(value)).toLocaleString('en-GB')})`
+    : integer(value).toLocaleString('en-GB');
 const cellKey = (holderId, classId) => `${holderId}|${classId}`;
-const valueAt = (values, holderId, classId) => integer(values?.[cellKey(holderId, classId)]);
-const classesOf = company => company.groups.flatMap(group => group.classes);
+const valueAt = (values, holderId, classId) =>
+  integer(values?.[cellKey(holderId, classId)]);
+const classesOf = (company) =>
+  company.groups.flatMap((group) => group.classes);
 
 function createCompany(name = 'Company 1') {
-  const shareholders = TYPES.map((type, index) => ({ id:id('holder'), name:`Shareholder ${index + 1}`, type }));
-  const groups = ['Ordinary Shares', 'Preference Shares', 'Deferred Shares'].map(name => ({ id:id('group'), name, classes:[{ id:id('class'), label:'' }] }));
-  return { id:id('company'), name, shareholders, groups, opening:{}, movements:{}, collapsed:{} };
+  const shareholders = TYPES.map((type, index) => ({
+    id: id('holder'),
+    name: `Shareholder ${index + 1}`,
+    type,
+  }));
+  const groups = [
+    'Ordinary Shares',
+    'Preference Shares',
+    'Deferred Shares',
+  ].map((name) => ({
+    id: id('group'),
+    name,
+    classes: [{ id: id('class'), label: '' }],
+  }));
+  return {
+    id: id('company'),
+    name,
+    shareholders,
+    groups,
+    opening: {},
+    movements: {},
+    collapsed: {},
+  };
 }
-function createExcel() { const company=createCompany(); return { schemaVersion:1, companies:[company], selectedCompanyId:company.id, syncedSteps:[] }; }
+function createExcel() {
+  const company = createCompany();
+  return {
+    schemaVersion: 1,
+    companies: [company],
+    selectedCompanyId: company.id,
+    syncedSteps: [],
+  };
+}
 
 function normaliseExcel(source, steps = []) {
-  const input = source && Array.isArray(source.companies) ? source : createExcel();
-  const companies = input.companies.map(company => {
-    const shareholders = (Array.isArray(company.shareholders) ? company.shareholders : []).slice(0, 100).map(holder => ({ id:String(holder.id || id('holder')), name:String(holder.name ?? ''), type:TYPES.includes(holder.type) ? holder.type : 'Individual' }));
-    const groups = (Array.isArray(company.groups) ? company.groups : []).map(group => ({ id:String(group.id || id('group')), name:String(group.name ?? ''), classes:(Array.isArray(group.classes) ? group.classes : []).map(item => ({ id:String(item.id || id('class')), label:String(item.label ?? '') })) }));
-    let count=0; for (const group of groups) group.classes=group.classes.filter(() => ++count <= 100);
-    const classIds=new Set(classesOf({groups}).map(item=>item.id)), holderIds=new Set(shareholders.map(holder=>holder.id));
-    const clean = values => Object.fromEntries(Object.entries(values || {}).filter(([key]) => { const [holderId,classId]=key.split('|'); return holderIds.has(holderId)&&classIds.has(classId); }).map(([key,value])=>[key,integer(value)]));
-    const movements={}; for (const step of steps) movements[step.id]=clean(company.movements?.[step.id]);
-    return { id:String(company.id || id('company')), name:String(company.name || 'Untitled company'), shareholders, groups, opening:clean(company.opening), movements, collapsed:Object.fromEntries(steps.map(step=>[step.id,company.collapsed?.[step.id]===true])) };
+  const input =
+    source && Array.isArray(source.companies) ? source : createExcel();
+  const companies = input.companies.map((company) => {
+    const shareholders = (
+      Array.isArray(company.shareholders) ? company.shareholders : []
+    )
+      .slice(0, 100)
+      .map((holder) => ({
+        id: String(holder.id || id('holder')),
+        name: String(holder.name ?? ''),
+        type: TYPES.includes(holder.type) ? holder.type : 'Individual',
+      }));
+    const groups = (Array.isArray(company.groups) ? company.groups : []).map(
+      (group) => ({
+        id: String(group.id || id('group')),
+        name: String(group.name ?? ''),
+        classes: (Array.isArray(group.classes) ? group.classes : []).map(
+          (item) => ({
+            id: String(item.id || id('class')),
+            label: String(item.label ?? ''),
+          }),
+        ),
+      }),
+    );
+    let count = 0;
+    for (const group of groups)
+      group.classes = group.classes.filter(() => ++count <= 100);
+    const classIds = new Set(classesOf({ groups }).map((item) => item.id)),
+      holderIds = new Set(shareholders.map((holder) => holder.id));
+    const clean = (values) =>
+      Object.fromEntries(
+        Object.entries(values || {})
+          .filter(([key]) => {
+            const [holderId, classId] = key.split('|');
+            return holderIds.has(holderId) && classIds.has(classId);
+          })
+          .map(([key, value]) => [key, integer(value)]),
+      );
+    const movements = {};
+    for (const step of steps)
+      movements[step.id] = clean(company.movements?.[step.id]);
+    return {
+      id: String(company.id || id('company')),
+      name: String(company.name || 'Untitled company'),
+      shareholders,
+      groups,
+      opening: clean(company.opening),
+      movements,
+      collapsed: Object.fromEntries(
+        steps.map((step) => [step.id, company.collapsed?.[step.id] === true]),
+      ),
+    };
   });
-  const selectedCompanyId=companies.some(item=>item.id===input.selectedCompanyId)?input.selectedCompanyId:companies[0]?.id||null;
-  return { schemaVersion:1, companies, selectedCompanyId, syncedSteps:steps.map(step=>({id:step.id,label:step.title})) };
+  const selectedCompanyId = companies.some(
+    (item) => item.id === input.selectedCompanyId,
+  )
+    ? input.selectedCompanyId
+    : companies[0]?.id || null;
+  return {
+    schemaVersion: 1,
+    companies,
+    selectedCompanyId,
+    syncedSteps: steps.map((step) => ({ id: step.id, label: step.title })),
+  };
 }
 const syncSteps = (excel, steps) => normaliseExcel(excel, steps);
-const stepHasMovements = (excel, stepId) => excel.companies.some(company => Object.values(company.movements?.[stepId] || {}).some(value => value !== 0));
-function resultingValues(company, steps, throughIndex) { const result={...company.opening}; for(const step of steps.slice(0,throughIndex+1)) for(const holder of company.shareholders) for(const shareClass of classesOf(company)){const key=cellKey(holder.id,shareClass.id);result[key]=integer(result[key])+valueAt(company.movements[step.id],holder.id,shareClass.id);} return result; }
-function totals(company, values) { const classes=classesOf(company),rows=Object.fromEntries(company.shareholders.map(holder=>[holder.id,classes.reduce((sum,item)=>sum+valueAt(values,holder.id,item.id),0)])),columns=Object.fromEntries(classes.map(item=>[item.id,company.shareholders.reduce((sum,holder)=>sum+valueAt(values,holder.id,item.id),0)]));return {rows,columns,grand:Object.values(columns).reduce((sum,value)=>sum+value,0)}; }
-function findBlocking(company, classIds=null, holderId=null, steps=[]) { const wanted=new Set(classIds||classesOf(company).map(item=>item.id));for(const holder of company.shareholders)if(!holderId||holder.id===holderId)for(const shareClass of classesOf(company))if(wanted.has(shareClass.id)){if(valueAt(company.opening,holder.id,shareClass.id))return {location:'Opening Position',holder,shareClass};for(const step of steps)if(valueAt(company.movements[step.id],holder.id,shareClass.id))return {location:step.title,holder,shareClass};}return null; }
-function applyPaste(company, values, startRow, startColumn, range, mode='replace') { const classes=classesOf(company);if(!range.length||range.some(row=>row.length!==range[0].length))throw Error('The copied range must be rectangular.');if(startRow+range.length>company.shareholders.length||startColumn+range[0].length>classes.length)throw Error('The complete pasted range does not fit in the editable table.');const parsed=range.map(row=>row.map(parseShares));if(parsed.flat().some(value=>value===null))throw Error('Every pasted value must be a whole integer.');const output={...values};parsed.forEach((row,ri)=>row.forEach((value,ci)=>{const key=cellKey(company.shareholders[startRow+ri].id,classes[startColumn+ci].id),current=integer(output[key]);output[key]=mode==='negative'?-value:mode==='add'?current+value:mode==='subtract'?current-value:value;}));return output; }
+const stepHasMovements = (excel, stepId) =>
+  excel.companies.some((company) =>
+    Object.values(company.movements?.[stepId] || {}).some(
+      (value) => value !== 0,
+    ),
+  );
+function resultingValues(company, steps, throughIndex) {
+  const result = { ...company.opening };
+  for (const step of steps.slice(0, throughIndex + 1))
+    for (const holder of company.shareholders)
+      for (const shareClass of classesOf(company)) {
+        const key = cellKey(holder.id, shareClass.id);
+        result[key] =
+          integer(result[key]) +
+          valueAt(company.movements[step.id], holder.id, shareClass.id);
+      }
+  return result;
+}
+function totals(company, values) {
+  const classes = classesOf(company),
+    rows = Object.fromEntries(
+      company.shareholders.map((holder) => [
+        holder.id,
+        classes.reduce(
+          (sum, item) => sum + valueAt(values, holder.id, item.id),
+          0,
+        ),
+      ]),
+    ),
+    columns = Object.fromEntries(
+      classes.map((item) => [
+        item.id,
+        company.shareholders.reduce(
+          (sum, holder) => sum + valueAt(values, holder.id, item.id),
+          0,
+        ),
+      ]),
+    );
+  return {
+    rows,
+    columns,
+    grand: Object.values(columns).reduce((sum, value) => sum + value, 0),
+  };
+}
+function findBlocking(
+  company,
+  classIds = null,
+  holderId = null,
+  steps = [],
+) {
+  const wanted = new Set(classIds || classesOf(company).map((item) => item.id));
+  for (const holder of company.shareholders)
+    if (!holderId || holder.id === holderId)
+      for (const shareClass of classesOf(company))
+        if (wanted.has(shareClass.id)) {
+          if (valueAt(company.opening, holder.id, shareClass.id))
+            return { location: 'Opening Position', holder, shareClass };
+          for (const step of steps)
+            if (valueAt(company.movements[step.id], holder.id, shareClass.id))
+              return { location: step.title, holder, shareClass };
+        }
+  return null;
+}
+function applyPaste(
+  company,
+  values,
+  startRow,
+  startColumn,
+  range,
+  mode = 'replace',
+) {
+  const classes = classesOf(company);
+  if (!range.length || range.some((row) => row.length !== range[0].length))
+    throw Error('The copied range must be rectangular.');
+  if (
+    startRow + range.length > company.shareholders.length ||
+    startColumn + range[0].length > classes.length
+  )
+    throw Error(
+      'The complete pasted range does not fit in the editable table.',
+    );
+  const parsed = range.map((row) => row.map(parseShares));
+  if (parsed.flat().some((value) => value === null))
+    throw Error('Every pasted value must be a whole integer.');
+  const output = { ...values };
+  parsed.forEach((row, ri) =>
+    row.forEach((value, ci) => {
+      const key = cellKey(
+          company.shareholders[startRow + ri].id,
+          classes[startColumn + ci].id,
+        ),
+        current = integer(output[key]);
+      output[key] =
+        mode === 'negative'
+          ? -value
+          : mode === 'add'
+            ? current + value
+            : mode === 'subtract'
+              ? current - value
+              : value;
+    }),
+  );
+  return output;
+}
 
 
 const SCHEMA_VERSION = 6;
-const METADATA_KEYS = ['clientName','projectTitle','documentType','date','version','subtitle','adviser','status'];
-const DOCUMENT_STATUSES = ['Draft','For review','Final'];
+const METADATA_KEYS = [
+  'clientName',
+  'projectTitle',
+  'documentType',
+  'date',
+  'version',
+  'subtitle',
+  'adviser',
+  'status',
+];
+const DOCUMENT_STATUSES = ['Draft', 'For review', 'Final'];
 const TABLE_WIDTH_MIN = 8;
 const TABLE_WIDTH_MAX = 92;
 const IDENTIFIER = /^[A-Za-z][\w-]*$/;
 
-const newId = prefix => `${prefix}-${globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)}`;
-const makeId = (value, prefix = 'id') => IDENTIFIER.test(value || '') ? value : newId(prefix);
+const newId = (prefix) =>
+  `${prefix}-${globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)}`;
+const makeId = (value, prefix = 'id') =>
+  IDENTIFIER.test(value || '') ? value : newId(prefix);
 
-const safeHref = value => typeof value === 'string' && /^(https?:\/\/|mailto:|#[A-Za-z][\w:.-]*$)/i.test(value) ? value : null;
-const safeImageSrc = value => {
+const safeHref = (value) =>
+  typeof value === 'string' &&
+  /^(https?:\/\/|mailto:|#[A-Za-z][\w:.-]*$)/i.test(value)
+    ? value
+    : null;
+const safeImageSrc = (value) => {
   const result = validateImageSource(value);
   return result.ok ? result.url : null;
 };
 
 function normaliseRuns(runs) {
-  return (Array.isArray(runs) ? runs : []).map(run => ({
-    text: String(run?.text ?? '').replace(/\r\n?/g, '\n'),
-    highlight: run?.highlight === true,
-    link: safeHref(run?.link?.href) ? { href: safeHref(run.link.href) } : null,
-  })).filter(run => run.text).reduce((out, run) => {
-    const last = out.at(-1);
-    if (last && last.highlight === run.highlight && last.link?.href === run.link?.href) last.text += run.text;
-    else out.push(run);
-    return out;
-  }, []);
+  return (Array.isArray(runs) ? runs : [])
+    .map((run) => ({
+      text: String(run?.text ?? '').replace(/\r\n?/g, '\n'),
+      highlight: run?.highlight === true,
+      link: safeHref(run?.link?.href)
+        ? { href: safeHref(run.link.href) }
+        : null,
+    }))
+    .filter((run) => run.text)
+    .reduce((out, run) => {
+      const last = out.at(-1);
+      if (
+        last &&
+        last.highlight === run.highlight &&
+        last.link?.href === run.link?.href
+      )
+        last.text += run.text;
+      else out.push(run);
+      return out;
+    }, []);
 }
 
 /** Redistribute widths without ever pushing a bounded column outside 8–92%. */
@@ -1949,85 +2357,375 @@ function normaliseTableWidths(values, count = values?.length || 1) {
   count = Math.max(1, Math.min(8, Number(count) || 1));
   // More than twelve columns cannot total 100 at the declared minimum. The schema
   // caps tables at eight, but this defines deterministic behaviour for direct use.
-  if (count * TABLE_WIDTH_MIN > 100 || count * TABLE_WIDTH_MAX < 100) return Array(count).fill(100 / count);
+  if (count * TABLE_WIDTH_MIN > 100 || count * TABLE_WIDTH_MAX < 100)
+    return Array(count).fill(100 / count);
   const raw = Array.from({ length: count }, (_, i) => Number(values?.[i]));
-  let widths = raw.map(value => Number.isFinite(value) && value > 0 ? Math.min(TABLE_WIDTH_MAX, Math.max(TABLE_WIDTH_MIN, value)) : 100 / count);
+  let widths = raw.map((value) =>
+    Number.isFinite(value) && value > 0
+      ? Math.min(TABLE_WIDTH_MAX, Math.max(TABLE_WIDTH_MIN, value))
+      : 100 / count,
+  );
   for (let pass = 0; pass < 20; pass++) {
     const remainder = 100 - widths.reduce((a, b) => a + b, 0);
     if (Math.abs(remainder) < 1e-9) break;
-    const candidates = widths.map((width, i) => ({ i, capacity: remainder > 0 ? TABLE_WIDTH_MAX - width : width - TABLE_WIDTH_MIN })).filter(x => x.capacity > 1e-9);
+    const candidates = widths
+      .map((width, i) => ({
+        i,
+        capacity:
+          remainder > 0 ? TABLE_WIDTH_MAX - width : width - TABLE_WIDTH_MIN,
+      }))
+      .filter((x) => x.capacity > 1e-9);
     if (!candidates.length) break;
     const capacity = candidates.reduce((sum, x) => sum + x.capacity, 0);
-    candidates.forEach(x => { widths[x.i] += Math.sign(remainder) * Math.min(x.capacity, Math.abs(remainder) * x.capacity / capacity); });
+    candidates.forEach((x) => {
+      widths[x.i] +=
+        Math.sign(remainder) *
+        Math.min(x.capacity, (Math.abs(remainder) * x.capacity) / capacity);
+    });
   }
-  widths = widths.map(width => Math.round(width * 1000) / 1000);
-  let residue = Math.round((100 - widths.reduce((a, b) => a + b, 0)) * 1000) / 1000;
+  widths = widths.map((width) => Math.round(width * 1000) / 1000);
+  let residue =
+    Math.round((100 - widths.reduce((a, b) => a + b, 0)) * 1000) / 1000;
   for (const width of widths.map((value, i) => ({ value, i }))) {
-    const room = residue > 0 ? TABLE_WIDTH_MAX - width.value : width.value - TABLE_WIDTH_MIN;
+    const room =
+      residue > 0
+        ? TABLE_WIDTH_MAX - width.value
+        : width.value - TABLE_WIDTH_MIN;
     const amount = Math.sign(residue) * Math.min(Math.abs(residue), room);
-    widths[width.i] += amount; residue -= amount;
-    if (Math.abs(residue) < .0005) break;
+    widths[width.i] += amount;
+    residue -= amount;
+    if (Math.abs(residue) < 0.0005) break;
   }
   return widths;
 }
 
-const normaliseCell = (cell, prefix) => ({ id: makeId(cell?.id, prefix), runs: normaliseRuns(cell?.runs) });
+const normaliseCell = (cell, prefix) => ({
+  id: makeId(cell?.id, prefix),
+  runs: normaliseRuns(cell?.runs),
+});
 function normaliseBlock(block) {
-  const allowed = ['heading', 'paragraph', 'bulletList', 'numberList', 'table', 'image'];
+  const allowed = [
+    'heading',
+    'paragraph',
+    'bulletList',
+    'numberList',
+    'table',
+    'image',
+  ];
   const type = allowed.includes(block?.type) ? block.type : 'paragraph';
   const output = { id: makeId(block?.id, 'block'), type };
-  if (type === 'heading') { output.level = Math.min(4, Math.max(1, Number(block.level) || 1)); output.runs = normaliseRuns(block.runs); }
-  else if (type === 'paragraph') output.runs = normaliseRuns(block.runs);
-  else if (type.endsWith('List')) output.items = (Array.isArray(block.items) && block.items.length ? block.items : [{ runs: [] }]).map(item => ({ id: makeId(item?.id, 'item'), level: Math.min(3, Math.max(1, Number(item?.level) || 1)), runs: normaliseRuns(item?.runs) }));
+  if (type === 'heading') {
+    output.level = Math.min(4, Math.max(1, Number(block.level) || 1));
+    output.runs = normaliseRuns(block.runs);
+  } else if (type === 'paragraph') output.runs = normaliseRuns(block.runs);
+  else if (type.endsWith('List'))
+    output.items = (
+      Array.isArray(block.items) && block.items.length
+        ? block.items
+        : [{ runs: [] }]
+    ).map((item) => ({
+      id: makeId(item?.id, 'item'),
+      level: Math.min(3, Math.max(1, Number(item?.level) || 1)),
+      runs: normaliseRuns(item?.runs),
+    }));
   else if (type === 'table') {
-    const source = Array.isArray(block.columns) ? block.columns.slice(0, 8) : [];
-    const count = Math.max(1, source.length || 2), widths = normaliseTableWidths(source.map(x => x?.width), count);
-    output.captionRuns = normaliseRuns(block.captionRuns || [{ text: block.caption ?? '' }]);
-    output.columns = Array.from({ length: count }, (_, i) => { const format=tableColumnFormat(source[i]); return { id: makeId(source[i]?.id, 'column'), headingRuns: normaliseRuns(source[i]?.headingRuns || [{ text: source[i]?.heading ?? `Column ${i + 1}` }]), width: widths[i], format, totalEnabled: format!=='text' && source[i]?.totalEnabled !== false }; });
-    output.rows = (Array.isArray(block.rows) ? block.rows : []).map((row, ri) => ({ id: makeId(row?.id, 'row'), isTotal: row?.isTotal === true, cells: output.columns.map((column, ci) => normaliseCell(row?.cells?.[ci], `${output.id}-${ri}-${column.id}`)) }));
+    const source = Array.isArray(block.columns)
+      ? block.columns.slice(0, 8)
+      : [];
+    const count = Math.max(1, source.length || 2),
+      widths = normaliseTableWidths(
+        source.map((x) => x?.width),
+        count,
+      );
+    output.captionRuns = normaliseRuns(
+      block.captionRuns || [{ text: block.caption ?? '' }],
+    );
+    output.columns = Array.from({ length: count }, (_, i) => {
+      const format = tableColumnFormat(source[i]);
+      return {
+        id: makeId(source[i]?.id, 'column'),
+        headingRuns: normaliseRuns(
+          source[i]?.headingRuns || [
+            { text: source[i]?.heading ?? `Column ${i + 1}` },
+          ],
+        ),
+        width: widths[i],
+        format,
+        totalEnabled: format !== 'text' && source[i]?.totalEnabled !== false,
+      };
+    });
+    output.rows = (Array.isArray(block.rows) ? block.rows : []).map(
+      (row, ri) => ({
+        id: makeId(row?.id, 'row'),
+        isTotal: row?.isTotal === true,
+        cells: output.columns.map((column, ci) =>
+          normaliseCell(row?.cells?.[ci], `${output.id}-${ri}-${column.id}`),
+        ),
+      }),
+    );
     recalculateTableTotals(output);
   } else {
-    output.src = safeImageSrc(block.src); output.alt = String(block.alt ?? ''); output.captionRuns = normaliseRuns(block.captionRuns || [{ text: block.caption ?? '' }]); output.width = normalizeImageWidth(block.width);
+    output.src = safeImageSrc(block.src);
+    output.alt = String(block.alt ?? '');
+    output.captionRuns = normaliseRuns(
+      block.captionRuns || [{ text: block.caption ?? '' }],
+    );
+    output.width = normalizeImageWidth(block.width);
   }
   return output;
 }
 
-const normaliseGroup = (group, prefix, ensureBlock = false) => ({ id: makeId(group?.id, prefix), title: String(group?.title ?? ''), summary: String(group?.summary ?? ''), blocks: (Array.isArray(group?.blocks) && group.blocks.length ? group.blocks : ensureBlock ? [{ id: newId('block'), type: 'paragraph', runs: [] }] : []).map(normaliseBlock) });
+const normaliseGroup = (group, prefix, ensureBlock = false) => ({
+  id: makeId(group?.id, prefix),
+  title: String(group?.title ?? ''),
+  summary: String(group?.summary ?? ''),
+  blocks: (Array.isArray(group?.blocks) && group.blocks.length
+    ? group.blocks
+    : ensureBlock
+      ? [{ id: newId('block'), type: 'paragraph', runs: [] }]
+      : []
+  ).map(normaliseBlock),
+});
 function normaliseDocument(document) {
-  const meta = {}; for (const key of METADATA_KEYS) { const value=document?.meta?.[key];meta[key]=['string','number','boolean'].includes(typeof value)?String(value).trim():''; }
-  if(meta.date&&!/^\d{4}-\d{2}-\d{2}$/.test(meta.date))meta.date='';else if(meta.date){const [year,month,day]=meta.date.split('-').map(Number),date=new Date(Date.UTC(year,month-1,day));if(date.getUTCFullYear()!==year||date.getUTCMonth()!==month-1||date.getUTCDate()!==day)meta.date=''}
-  if(meta.status&&!DOCUMENT_STATUSES.includes(meta.status))meta.status='';
-  const steps = (Array.isArray(document?.steps) ? document.steps : []).map(x => normaliseGroup(x, 'step', true));
-  return { schemaVersion: SCHEMA_VERSION, meta, sections: (Array.isArray(document?.sections) ? document.sections : []).map(x => normaliseGroup(x, 'section')), steps, appendices: (Array.isArray(document?.appendices) ? document.appendices : []).map(x => normaliseGroup(x, 'appendix')), excel:normaliseExcel(document?.excel, steps) };
+  const meta = {};
+  for (const key of METADATA_KEYS) {
+    const value = document?.meta?.[key];
+    meta[key] = ['string', 'number', 'boolean'].includes(typeof value)
+      ? String(value).trim()
+      : '';
+  }
+  if (meta.date && !/^\d{4}-\d{2}-\d{2}$/.test(meta.date)) meta.date = '';
+  else if (meta.date) {
+    const [year, month, day] = meta.date.split('-').map(Number),
+      date = new Date(Date.UTC(year, month - 1, day));
+    if (
+      date.getUTCFullYear() !== year ||
+      date.getUTCMonth() !== month - 1 ||
+      date.getUTCDate() !== day
+    )
+      meta.date = '';
+  }
+  if (meta.status && !DOCUMENT_STATUSES.includes(meta.status)) meta.status = '';
+  const steps = (Array.isArray(document?.steps) ? document.steps : []).map(
+    (x) => normaliseGroup(x, 'step', true),
+  );
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    meta,
+    sections: (Array.isArray(document?.sections) ? document.sections : []).map(
+      (x) => normaliseGroup(x, 'section'),
+    ),
+    steps,
+    appendices: (Array.isArray(document?.appendices)
+      ? document.appendices
+      : []
+    ).map((x) => normaliseGroup(x, 'appendix')),
+    excel: normaliseExcel(document?.excel, steps),
+  };
 }
 
-function *runContainers(group) {
+function* runContainers(group) {
   for (const block of group?.blocks || []) {
     if (block.runs) yield { block, kind: 'block', runs: block.runs };
-    for (const item of block.items || []) yield { block, item, kind: 'listItem', runs: item.runs };
-    if (block.captionRuns) yield { block, kind: block.type === 'image' ? 'imageCaption' : 'tableCaption', runs: block.captionRuns };
-    for (const column of block.columns || []) yield { block, column, kind: 'tableHeading', runs: column.headingRuns };
-    for (const row of block.rows || []) for (const cell of row.cells || []) yield { block, row, cell, kind: 'tableCell', runs: cell.runs };
+    for (const item of block.items || [])
+      yield { block, item, kind: 'listItem', runs: item.runs };
+    if (block.captionRuns)
+      yield {
+        block,
+        kind: block.type === 'image' ? 'imageCaption' : 'tableCaption',
+        runs: block.captionRuns,
+      };
+    for (const column of block.columns || [])
+      yield { block, column, kind: 'tableHeading', runs: column.headingRuns };
+    for (const row of block.rows || [])
+      for (const cell of row.cells || [])
+        yield { block, row, cell, kind: 'tableCell', runs: cell.runs };
   }
 }
-const hasReview = group => [...runContainers(group)].some(container => container.runs.some(run => run.highlight));
-const stableAnchor = entity => `anchor-${entity.id}`;
-function validateDocument(document) { if (![1,2,3,4,5,SCHEMA_VERSION].includes(document?.schemaVersion)) throw Error('Unsupported schema version'); for (const group of [...(document?.sections || []),...(document?.steps || []),...(document?.appendices || [])]) for (const block of group?.blocks || []) if (block?.type === 'image' && /^data:/i.test(block.src || '')) throw Error('Legacy embedded data-URL images are no longer supported; publish the image over HTTPS and replace its source'); const result = normaliseDocument(document); for (const group of [...result.sections,...result.steps,...result.appendices]) for (const block of group.blocks) if (block.type === 'image' && !validateImageInput({ source: block.src, altText: block.alt, width: block.width }).ok) throw Error('Images require a supported PNG, JPEG, GIF or WebP HTTPS source and alternative text'); return result; }
+const hasReview = (group) =>
+  [...runContainers(group)].some((container) =>
+    container.runs.some((run) => run.highlight),
+  );
+const stableAnchor = (entity) => `anchor-${entity.id}`;
+function validateDocument(document) {
+  if (![1, 2, 3, 4, 5, SCHEMA_VERSION].includes(document?.schemaVersion))
+    throw Error('Unsupported schema version');
+  for (const group of [
+    ...(document?.sections || []),
+    ...(document?.steps || []),
+    ...(document?.appendices || []),
+  ])
+    for (const block of group?.blocks || [])
+      if (block?.type === 'image' && /^data:/i.test(block.src || ''))
+        throw Error(
+          'Legacy embedded data-URL images are no longer supported; publish the image over HTTPS and replace its source',
+        );
+  const result = normaliseDocument(document);
+  for (const group of [
+    ...result.sections,
+    ...result.steps,
+    ...result.appendices,
+  ])
+    for (const block of group.blocks)
+      if (
+        block.type === 'image' &&
+        !validateImageInput({
+          source: block.src,
+          altText: block.alt,
+          width: block.width,
+        }).ok
+      )
+        throw Error(
+          'Images require a supported PNG, JPEG, GIF or WebP HTTPS source and alternative text',
+        );
+  return result;
+}
 
-const eligibleText = step => [...runContainers(step)].filter(x => (x.kind === 'block' && x.block.type === 'paragraph') || ['listItem','tableCaption','imageCaption'].includes(x.kind)).map(x => x.runs.map(r => r.text).join('').trim()).find(Boolean) || '';
-function transactionProposals(document) { return normaliseDocument(document).steps.map((step, index) => ({ id:`proposal-${step.id}`, stepId:step.id, title:`Step ${index+1}. ${step.title}`, anchor:stableAnchor(step), summary:step.summary.trim() || eligibleText(step) })); }
+const eligibleText = (step) =>
+  [...runContainers(step)]
+    .filter(
+      (x) =>
+        (x.kind === 'block' && x.block.type === 'paragraph') ||
+        ['listItem', 'tableCaption', 'imageCaption'].includes(x.kind),
+    )
+    .map((x) =>
+      x.runs
+        .map((r) => r.text)
+        .join('')
+        .trim(),
+    )
+    .find(Boolean) || '';
+function transactionProposals(document) {
+  return normaliseDocument(document).steps.map((step, index) => ({
+    id: `proposal-${step.id}`,
+    stepId: step.id,
+    title: `Step ${index + 1}. ${step.title}`,
+    anchor: stableAnchor(step),
+    summary: step.summary.trim() || eligibleText(step),
+  }));
+}
 
-const seedDocument = normaliseDocument({ schemaVersion: SCHEMA_VERSION, meta:{clientName:'Example Client Ltd',projectTitle:'Corporate Restructure',documentType:'Steps Plan',subtitle:'Detailed Steps Plan',date:'2026-07-25',version:'v1',adviser:'UBTA Accountants Ltd',status:'Draft'}, sections:[{id:'scope',title:'Scope of works',blocks:[{id:'scope-h',type:'heading',level:2,runs:[{text:'Purpose and scope'}]},{id:'scope-p1',type:'paragraph',runs:[{text:'This plan outlines the principal implementation steps for a proposed corporate restructure.'}]}]}], steps:[{id:'share-restructure',title:'Implement the corporate share restructure',blocks:[{id:'step-h',type:'heading',level:2,runs:[{text:'Implementation'}]},{id:'step-p1',type:'paragraph',runs:[{text:'The directors will approve the proposed corporate restructure and authorise the required documentation.'}]},{id:'step-list',type:'numberList',items:[{id:'st1',level:1,runs:[{text:'Prepare board minutes and resolutions.'}]}]},{id:'consideration',type:'table',caption:'Illustrative consideration',columns:[{id:'detail',heading:'Detail',width:70,format:'text'},{id:'amount',heading:'Amount (£)',width:30,format:'gbp'}],rows:[{id:'ordinary-shares',cells:[{runs:[{text:'Ordinary shares'}]},{runs:[{text:'10,000'}]}]},{id:'total',isTotal:true,cells:[{runs:[{text:'Total'}]},{runs:[{text:'10,000'}]}]}]}]}], appendices:[] });
+const seedDocument = normaliseDocument({
+  schemaVersion: SCHEMA_VERSION,
+  meta: {
+    clientName: 'Example Client Ltd',
+    projectTitle: 'Corporate Restructure',
+    documentType: 'Steps Plan',
+    subtitle: 'Detailed Steps Plan',
+    date: '2026-07-25',
+    version: 'v1',
+    adviser: 'UBTA Accountants Ltd',
+    status: 'Draft',
+  },
+  sections: [
+    {
+      id: 'scope',
+      title: 'Scope of works',
+      blocks: [
+        {
+          id: 'scope-h',
+          type: 'heading',
+          level: 2,
+          runs: [{ text: 'Purpose and scope' }],
+        },
+        {
+          id: 'scope-p1',
+          type: 'paragraph',
+          runs: [
+            {
+              text: 'This plan outlines the principal implementation steps for a proposed corporate restructure.',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  steps: [
+    {
+      id: 'share-restructure',
+      title: 'Implement the corporate share restructure',
+      blocks: [
+        {
+          id: 'step-h',
+          type: 'heading',
+          level: 2,
+          runs: [{ text: 'Implementation' }],
+        },
+        {
+          id: 'step-p1',
+          type: 'paragraph',
+          runs: [
+            {
+              text: 'The directors will approve the proposed corporate restructure and authorise the required documentation.',
+            },
+          ],
+        },
+        {
+          id: 'step-list',
+          type: 'numberList',
+          items: [
+            {
+              id: 'st1',
+              level: 1,
+              runs: [{ text: 'Prepare board minutes and resolutions.' }],
+            },
+          ],
+        },
+        {
+          id: 'consideration',
+          type: 'table',
+          caption: 'Illustrative consideration',
+          columns: [
+            { id: 'detail', heading: 'Detail', width: 70, format: 'text' },
+            { id: 'amount', heading: 'Amount (£)', width: 30, format: 'gbp' },
+          ],
+          rows: [
+            {
+              id: 'ordinary-shares',
+              cells: [
+                { runs: [{ text: 'Ordinary shares' }] },
+                { runs: [{ text: '10,000' }] },
+              ],
+            },
+            {
+              id: 'total',
+              isTotal: true,
+              cells: [
+                { runs: [{ text: 'Total' }] },
+                { runs: [{ text: '10,000' }] },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  appendices: [],
+});
 
 
 const unchanged = (document, reason) => ({ changed: false, document, reason });
-const changed = (document, details = {}) => ({ changed: true, document: normaliseDocument(document), ...details });
-const copy = document => structuredClone(document);
-const directionOffset = direction => direction === 'before' || direction === 'up' || direction === 'left' ? -1 : direction === 'after' || direction === 'down' || direction === 'right' ? 1 : Number(direction);
-const groups = document => [...(document.sections || []), ...(document.steps || []), ...(document.appendices || [])];
+const changed = (document, details = {}) => ({
+  changed: true,
+  document: normaliseDocument(document),
+  ...details,
+});
+const copy = (document) => structuredClone(document);
+const directionOffset = (direction) =>
+  direction === 'before' || direction === 'up' || direction === 'left'
+    ? -1
+    : direction === 'after' || direction === 'down' || direction === 'right'
+      ? 1
+      : Number(direction);
+const groups = (document) => [
+  ...(document.sections || []),
+  ...(document.steps || []),
+  ...(document.appendices || []),
+];
 const locateBlock = (document, blockId) => {
   for (const group of groups(document)) {
-    const index = group.blocks?.findIndex(block => block.id === blockId) ?? -1;
+    const index =
+      group.blocks?.findIndex((block) => block.id === blockId) ?? -1;
     if (index >= 0) return { group, index, block: group.blocks[index] };
   }
   return null;
@@ -2040,83 +2738,165 @@ const locateTable = (document, blockId) => {
 function addGroup(document, collection, options = {}) {
   const noun = collection === 'appendices' ? 'appendix' : 'step';
   const source = document[collection] || [];
-  const referenceIndex = options.referenceId == null ? source.length - 1 : source.findIndex(group => group.id === options.referenceId);
-  if (options.referenceId != null && referenceIndex < 0) return unchanged(document, `${noun}-not-found`);
+  const referenceIndex =
+    options.referenceId == null
+      ? source.length - 1
+      : source.findIndex((group) => group.id === options.referenceId);
+  if (options.referenceId != null && referenceIndex < 0)
+    return unchanged(document, `${noun}-not-found`);
   const makeId = options.idFactory || newId;
   const id = options.id || makeId(noun);
   const blockId = options.blockId || makeId('block');
   const next = copy(document);
-  const index = options.referenceId == null ? source.length : referenceIndex + (options.position === 'before' ? 0 : 1);
-  next[collection].splice(index, 0, { id, title: options.title || (collection === 'steps' ? 'New transaction step' : 'New appendix'), blocks: [{ id: blockId, type: 'paragraph', runs: [] }] });
-  return changed(next, { selectedGroupId: id, selectedBlockId: blockId, index });
+  const index =
+    options.referenceId == null
+      ? source.length
+      : referenceIndex + (options.position === 'before' ? 0 : 1);
+  next[collection].splice(index, 0, {
+    id,
+    title:
+      options.title ||
+      (collection === 'steps' ? 'New transaction step' : 'New appendix'),
+    blocks: [{ id: blockId, type: 'paragraph', runs: [] }],
+  });
+  return changed(next, {
+    selectedGroupId: id,
+    selectedBlockId: blockId,
+    index,
+  });
 }
 
 function moveGroup(document, collection, id, direction) {
   const noun = collection === 'appendices' ? 'appendix' : 'step';
-  const currentIndex = (document[collection] || []).findIndex(group => group.id === id);
+  const currentIndex = (document[collection] || []).findIndex(
+    (group) => group.id === id,
+  );
   if (currentIndex < 0) return unchanged(document, `${noun}-not-found`);
   const nextIndex = currentIndex + directionOffset(direction);
-  if (nextIndex < 0 || nextIndex >= document[collection].length) return unchanged(document, `${noun}-cannot-move`);
+  if (nextIndex < 0 || nextIndex >= document[collection].length)
+    return unchanged(document, `${noun}-cannot-move`);
   const next = copy(document);
-  [next[collection][currentIndex], next[collection][nextIndex]] = [next[collection][nextIndex], next[collection][currentIndex]];
+  [next[collection][currentIndex], next[collection][nextIndex]] = [
+    next[collection][nextIndex],
+    next[collection][currentIndex],
+  ];
   return changed(next, { selectedGroupId: id, index: nextIndex });
 }
 
 function deleteGroup(document, collection, id) {
   const noun = collection === 'appendices' ? 'appendix' : 'step';
-  const index = (document[collection] || []).findIndex(group => group.id === id);
+  const index = (document[collection] || []).findIndex(
+    (group) => group.id === id,
+  );
   if (index < 0) return unchanged(document, `${noun}-not-found`);
   const next = copy(document);
   next[collection].splice(index, 1);
-  const selected = next[collection][Math.min(index, next[collection].length - 1)];
+  const selected =
+    next[collection][Math.min(index, next[collection].length - 1)];
   return changed(next, { selectedGroupId: selected?.id || null, index });
 }
 
-const addStepOperation = (document, options) => addGroup(document, 'steps', options);
-const moveStepOperation = (document, stepId, direction) => moveGroup(document, 'steps', stepId, direction);
-const deleteStepOperation = (document, stepId) => deleteGroup(document, 'steps', stepId);
-const addAppendixOperation = (document, options) => addGroup(document, 'appendices', options);
-const moveAppendixOperation = (document, appendixId, direction) => moveGroup(document, 'appendices', appendixId, direction);
-const deleteAppendixOperation = (document, appendixId) => deleteGroup(document, 'appendices', appendixId);
+const addStepOperation = (document, options) =>
+  addGroup(document, 'steps', options);
+const moveStepOperation = (document, stepId, direction) =>
+  moveGroup(document, 'steps', stepId, direction);
+const deleteStepOperation = (document, stepId) =>
+  deleteGroup(document, 'steps', stepId);
+const addAppendixOperation = (document, options) =>
+  addGroup(document, 'appendices', options);
+const moveAppendixOperation = (document, appendixId, direction) =>
+  moveGroup(document, 'appendices', appendixId, direction);
+const deleteAppendixOperation = (document, appendixId) =>
+  deleteGroup(document, 'appendices', appendixId);
 
 function insertBlockOperation(document, groupId, block, index) {
-  const original = groups(document).find(group => group.id === groupId);
+  const original = groups(document).find((group) => group.id === groupId);
   if (!original) return unchanged(document, 'group-not-found');
-  if (!Number.isInteger(index) || index < 0 || index > original.blocks.length) return unchanged(document, 'block-index-invalid');
-  const next = copy(document), group = groups(next).find(item => item.id === groupId);
+  if (!Number.isInteger(index) || index < 0 || index > original.blocks.length)
+    return unchanged(document, 'block-index-invalid');
+  const next = copy(document),
+    group = groups(next).find((item) => item.id === groupId);
   const value = normaliseBlock(block);
   group.blocks.splice(index, 0, value);
-  return changed(next, { selectedGroupId: groupId, selectedBlockId: value.id, index });
+  return changed(next, {
+    selectedGroupId: groupId,
+    selectedBlockId: value.id,
+    index,
+  });
 }
 
 function moveBlockOperation(document, blockId, direction) {
   const found = locateBlock(document, blockId);
   if (!found) return unchanged(document, 'block-not-found');
   const nextIndex = found.index + directionOffset(direction);
-  if (nextIndex < 0 || nextIndex >= found.group.blocks.length) return unchanged(document, 'block-cannot-move');
-  const next = copy(document), target = locateBlock(next, blockId);
-  [target.group.blocks[target.index], target.group.blocks[nextIndex]] = [target.group.blocks[nextIndex], target.group.blocks[target.index]];
-  return changed(next, { selectedGroupId: target.group.id, selectedBlockId: blockId, index: nextIndex });
+  if (nextIndex < 0 || nextIndex >= found.group.blocks.length)
+    return unchanged(document, 'block-cannot-move');
+  const next = copy(document),
+    target = locateBlock(next, blockId);
+  [target.group.blocks[target.index], target.group.blocks[nextIndex]] = [
+    target.group.blocks[nextIndex],
+    target.group.blocks[target.index],
+  ];
+  return changed(next, {
+    selectedGroupId: target.group.id,
+    selectedBlockId: blockId,
+    index: nextIndex,
+  });
 }
 
 function deleteBlockOperation(document, blockId, options = {}) {
   const found = locateBlock(document, blockId);
   if (!found) return unchanged(document, 'block-not-found');
-  const next = copy(document), target = locateBlock(next, blockId);
+  const next = copy(document),
+    target = locateBlock(next, blockId);
   target.group.blocks.splice(target.index, 1);
-  if (!target.group.blocks.length) target.group.blocks.push({ id: (options.idFactory || newId)('block'), type: 'paragraph', runs: [] });
-  const selected = target.group.blocks[Math.min(target.index, target.group.blocks.length - 1)];
-  return changed(next, { selectedGroupId: target.group.id, selectedBlockId: selected.id, selectedBlockType: selected.type, index: target.index });
+  if (!target.group.blocks.length)
+    target.group.blocks.push({
+      id: (options.idFactory || newId)('block'),
+      type: 'paragraph',
+      runs: [],
+    });
+  const selected =
+    target.group.blocks[Math.min(target.index, target.group.blocks.length - 1)];
+  return changed(next, {
+    selectedGroupId: target.group.id,
+    selectedBlockId: selected.id,
+    selectedBlockType: selected.type,
+    index: target.index,
+  });
 }
 
-function insertTableRowOperation(document, blockId, afterRowId = null, options = {}) {
+function insertTableRowOperation(
+  document,
+  blockId,
+  afterRowId = null,
+  options = {},
+) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  const rowIndex = afterRowId == null ? found.block.rows.findIndex(row => row.isTotal) - 1 : found.block.rows.findIndex(row => row.id === afterRowId);
-  if (afterRowId != null && rowIndex < 0) return unchanged(document, 'row-not-found');
-  const next = copy(document), block = locateTable(next, blockId).block, makeId = options.idFactory || newId;
-  const totalIndex = block.rows.findIndex(row => row.isTotal), index = afterRowId == null ? (totalIndex < 0 ? block.rows.length : totalIndex) : Math.min(rowIndex + 1, totalIndex < 0 ? block.rows.length : totalIndex);
-  block.rows.splice(index, 0, { id: options.id || makeId('row'), cells: block.columns.map(() => ({ id: makeId('cell'), runs: [] })) });
+  const rowIndex =
+    afterRowId == null
+      ? found.block.rows.findIndex((row) => row.isTotal) - 1
+      : found.block.rows.findIndex((row) => row.id === afterRowId);
+  if (afterRowId != null && rowIndex < 0)
+    return unchanged(document, 'row-not-found');
+  const next = copy(document),
+    block = locateTable(next, blockId).block,
+    makeId = options.idFactory || newId;
+  const totalIndex = block.rows.findIndex((row) => row.isTotal),
+    index =
+      afterRowId == null
+        ? totalIndex < 0
+          ? block.rows.length
+          : totalIndex
+        : Math.min(
+            rowIndex + 1,
+            totalIndex < 0 ? block.rows.length : totalIndex,
+          );
+  block.rows.splice(index, 0, {
+    id: options.id || makeId('row'),
+    cells: block.columns.map(() => ({ id: makeId('cell'), runs: [] })),
+  });
   recalculateTableTotals(block);
   return changed(next, { selectedBlockId: blockId, rowIndex: index });
 }
@@ -2124,11 +2904,17 @@ function insertTableRowOperation(document, blockId, afterRowId = null, options =
 function moveTableRowOperation(document, blockId, rowId, direction) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  const index = found.block.rows.findIndex(row => row.id === rowId);
+  const index = found.block.rows.findIndex((row) => row.id === rowId);
   if (index < 0) return unchanged(document, 'row-not-found');
   const target = index + directionOffset(direction);
-  if (target < 0 || target >= found.block.rows.length || found.block.rows[target].isTotal !== found.block.rows[index].isTotal) return unchanged(document, 'row-cannot-move');
-  const next = copy(document), rows = locateTable(next, blockId).block.rows;
+  if (
+    target < 0 ||
+    target >= found.block.rows.length ||
+    found.block.rows[target].isTotal !== found.block.rows[index].isTotal
+  )
+    return unchanged(document, 'row-cannot-move');
+  const next = copy(document),
+    rows = locateTable(next, blockId).block.rows;
   [rows[index], rows[target]] = [rows[target], rows[index]];
   recalculateTableTotals(locateTable(next, blockId).block);
   return changed(next, { selectedBlockId: blockId, rowIndex: target });
@@ -2137,37 +2923,80 @@ function moveTableRowOperation(document, blockId, rowId, direction) {
 function deleteTableRowOperation(document, blockId, rowId) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  const index = found.block.rows.findIndex(row => row.id === rowId);
+  const index = found.block.rows.findIndex((row) => row.id === rowId);
   if (index < 0) return unchanged(document, 'row-not-found');
-  const next = copy(document), block = locateTable(next, blockId).block;
-  block.rows.splice(index, 1); recalculateTableTotals(block);
-  return changed(next, { selectedBlockId: blockId, rowIndex: block.rows.length ? Math.min(index, block.rows.length - 1) : null });
+  const next = copy(document),
+    block = locateTable(next, blockId).block;
+  block.rows.splice(index, 1);
+  recalculateTableTotals(block);
+  return changed(next, {
+    selectedBlockId: blockId,
+    rowIndex: block.rows.length ? Math.min(index, block.rows.length - 1) : null,
+  });
 }
 
-function insertTableColumnOperation(document, blockId, afterColumnId = null, options = {}) {
+function insertTableColumnOperation(
+  document,
+  blockId,
+  afterColumnId = null,
+  options = {},
+) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  if (found.block.columns.length >= 8) return unchanged(document, 'column-limit-reached');
-  const previous = afterColumnId == null ? found.block.columns.length - 1 : found.block.columns.findIndex(column => column.id === afterColumnId);
-  if (afterColumnId != null && previous < 0) return unchanged(document, 'column-not-found');
-  const next = copy(document), block = locateTable(next, blockId).block, makeId = options.idFactory || newId, index = previous + 1;
-  block.columns.splice(index, 0, { id: options.id || makeId('column'), headingRuns: [{ text: `Column ${index + 1}` }], width: 100 / (block.columns.length + 1), format: 'text', totalEnabled: false });
-  block.rows.forEach(row => row.cells.splice(index, 0, { id: makeId('cell'), runs: [] }));
-  const widths = normaliseTableWidths(block.columns.map(() => 100 / block.columns.length), block.columns.length);
-  block.columns.forEach((column, columnIndex) => { column.width = widths[columnIndex]; });
+  if (found.block.columns.length >= 8)
+    return unchanged(document, 'column-limit-reached');
+  const previous =
+    afterColumnId == null
+      ? found.block.columns.length - 1
+      : found.block.columns.findIndex((column) => column.id === afterColumnId);
+  if (afterColumnId != null && previous < 0)
+    return unchanged(document, 'column-not-found');
+  const next = copy(document),
+    block = locateTable(next, blockId).block,
+    makeId = options.idFactory || newId,
+    index = previous + 1;
+  block.columns.splice(index, 0, {
+    id: options.id || makeId('column'),
+    headingRuns: [{ text: `Column ${index + 1}` }],
+    width: 100 / (block.columns.length + 1),
+    format: 'text',
+    totalEnabled: false,
+  });
+  block.rows.forEach((row) =>
+    row.cells.splice(index, 0, { id: makeId('cell'), runs: [] }),
+  );
+  const widths = normaliseTableWidths(
+    block.columns.map(() => 100 / block.columns.length),
+    block.columns.length,
+  );
+  block.columns.forEach((column, columnIndex) => {
+    column.width = widths[columnIndex];
+  });
   return changed(next, { selectedBlockId: blockId, columnIndex: index });
 }
 
 function moveTableColumnOperation(document, blockId, columnId, direction) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  const index = found.block.columns.findIndex(column => column.id === columnId);
+  const index = found.block.columns.findIndex(
+    (column) => column.id === columnId,
+  );
   if (index < 0) return unchanged(document, 'column-not-found');
   const target = index + directionOffset(direction);
-  if (target < 0 || target >= found.block.columns.length) return unchanged(document, 'column-cannot-move');
-  const next = copy(document), block = locateTable(next, blockId).block;
-  [block.columns[index], block.columns[target]] = [block.columns[target], block.columns[index]];
-  block.rows.forEach(row => { [row.cells[index], row.cells[target]] = [row.cells[target], row.cells[index]]; });
+  if (target < 0 || target >= found.block.columns.length)
+    return unchanged(document, 'column-cannot-move');
+  const next = copy(document),
+    block = locateTable(next, blockId).block;
+  [block.columns[index], block.columns[target]] = [
+    block.columns[target],
+    block.columns[index],
+  ];
+  block.rows.forEach((row) => {
+    [row.cells[index], row.cells[target]] = [
+      row.cells[target],
+      row.cells[index],
+    ];
+  });
   recalculateTableTotals(block);
   return changed(next, { selectedBlockId: blockId, columnIndex: target });
 }
@@ -2175,52 +3004,94 @@ function moveTableColumnOperation(document, blockId, columnId, direction) {
 function deleteTableColumnOperation(document, blockId, columnId) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  const index = found.block.columns.findIndex(column => column.id === columnId);
+  const index = found.block.columns.findIndex(
+    (column) => column.id === columnId,
+  );
   if (index < 0) return unchanged(document, 'column-not-found');
-  if (found.block.columns.length <= 1) return unchanged(document, 'column-cannot-delete');
-  const next = copy(document), block = locateTable(next, blockId).block;
-  block.columns.splice(index, 1); block.rows.forEach(row => row.cells.splice(index, 1)); recalculateTableTotals(block);
-  return changed(next, { selectedBlockId: blockId, columnIndex: Math.min(index, block.columns.length - 1) });
+  if (found.block.columns.length <= 1)
+    return unchanged(document, 'column-cannot-delete');
+  const next = copy(document),
+    block = locateTable(next, blockId).block;
+  block.columns.splice(index, 1);
+  block.rows.forEach((row) => row.cells.splice(index, 1));
+  recalculateTableTotals(block);
+  return changed(next, {
+    selectedBlockId: blockId,
+    columnIndex: Math.min(index, block.columns.length - 1),
+  });
 }
 
 function setTableColumnFormatOperation(document, blockId, columnId, format) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  const index = found.block.columns.findIndex(column => column.id === columnId);
+  const index = found.block.columns.findIndex(
+    (column) => column.id === columnId,
+  );
   if (index < 0) return unchanged(document, 'column-not-found');
-  if (!['text', 'number', 'gbp'].includes(format)) return unchanged(document, 'column-format-unsupported');
-  if (tableColumnFormat(found.block.columns[index]) === format) return unchanged(document, 'column-format-unchanged');
-  const next = copy(document), block = locateTable(next, blockId).block;
-  block.columns[index].format = format; delete block.columns[index].numeric; recalculateTableTotals(block);
+  if (!['text', 'number', 'gbp'].includes(format))
+    return unchanged(document, 'column-format-unsupported');
+  if (tableColumnFormat(found.block.columns[index]) === format)
+    return unchanged(document, 'column-format-unchanged');
+  const next = copy(document),
+    block = locateTable(next, blockId).block;
+  block.columns[index].format = format;
+  delete block.columns[index].numeric;
+  recalculateTableTotals(block);
   return changed(next, { selectedBlockId: blockId, columnIndex: index });
 }
 
 function setTableColumnTotalOperation(document, blockId, columnId, enabled) {
-  const found=locateTable(document,blockId);
-  if(!found)return unchanged(document,'table-not-found');
-  const index=found.block.columns.findIndex(column=>column.id===columnId);
-  if(index<0)return unchanged(document,'column-not-found');
-  if(tableColumnFormat(found.block.columns[index])==='text')return unchanged(document,'column-total-not-numeric');
-  if(found.block.columns[index].totalEnabled===(enabled===true))return unchanged(document,'column-total-unchanged');
-  const next=copy(document),block=locateTable(next,blockId).block;
-  block.columns[index].totalEnabled=enabled===true;recalculateTableTotals(block);
-  return changed(next,{selectedBlockId:blockId,columnIndex:index});
+  const found = locateTable(document, blockId);
+  if (!found) return unchanged(document, 'table-not-found');
+  const index = found.block.columns.findIndex(
+    (column) => column.id === columnId,
+  );
+  if (index < 0) return unchanged(document, 'column-not-found');
+  if (tableColumnFormat(found.block.columns[index]) === 'text')
+    return unchanged(document, 'column-total-not-numeric');
+  if (found.block.columns[index].totalEnabled === (enabled === true))
+    return unchanged(document, 'column-total-unchanged');
+  const next = copy(document),
+    block = locateTable(next, blockId).block;
+  block.columns[index].totalEnabled = enabled === true;
+  recalculateTableTotals(block);
+  return changed(next, { selectedBlockId: blockId, columnIndex: index });
 }
 
 function convertBlockStyleOperation(document, blockId, style, options = {}) {
   const found = locateBlock(document, blockId);
   if (!found) return unchanged(document, 'block-not-found');
-  if (!['heading', 'paragraph', 'bulletList', 'numberList'].includes(found.block.type)) return unchanged(document, 'block-type-unsupported');
-  const heading = /^heading([1-4])$/.exec(style), type = heading ? 'heading' : style === 'body' ? 'paragraph' : ['bulletList', 'numberList'].includes(style) ? style : null;
+  if (
+    !['heading', 'paragraph', 'bulletList', 'numberList'].includes(
+      found.block.type,
+    )
+  )
+    return unchanged(document, 'block-type-unsupported');
+  const heading = /^heading([1-4])$/.exec(style),
+    type = heading
+      ? 'heading'
+      : style === 'body'
+        ? 'paragraph'
+        : ['bulletList', 'numberList'].includes(style)
+          ? style
+          : null;
   if (!type) return unchanged(document, 'block-style-unsupported');
-  const next = copy(document), block = locateBlock(next, blockId).block, makeId = options.idFactory || newId;
+  const next = copy(document),
+    block = locateBlock(next, blockId).block,
+    makeId = options.idFactory || newId;
   if (type === 'heading' || type === 'paragraph') {
-    block.runs = block.runs || block.items?.flatMap(item => item.runs) || [];
-    delete block.items; block.type = type;
-    if (heading) block.level = Number(heading[1]); else delete block.level;
+    block.runs = block.runs || block.items?.flatMap((item) => item.runs) || [];
+    delete block.items;
+    block.type = type;
+    if (heading) block.level = Number(heading[1]);
+    else delete block.level;
   } else {
-    block.items = block.items || [{ id: makeId('item'), level: 1, runs: block.runs || [] }];
-    delete block.runs; delete block.level; block.type = type;
+    block.items = block.items || [
+      { id: makeId('item'), level: 1, runs: block.runs || [] },
+    ];
+    delete block.runs;
+    delete block.level;
+    block.type = type;
   }
   return changed(next, { selectedBlockId: blockId, selectedBlockType: type });
 }
@@ -2228,55 +3099,140 @@ function convertBlockStyleOperation(document, blockId, style, options = {}) {
 
 const same = (a, b) => JSON.stringify(a) === JSON.stringify(b);
 class History {
-  constructor(value) { this.past = []; this.future = []; this.value = structuredClone(value); }
-  checkout() { return structuredClone(this.value); }
-  commit(value) { const next = structuredClone(value); if (same(this.value, next)) return false; this.past.push(structuredClone(this.value)); this.value = next; this.future = []; return true; }
-  replace(value) { this.value = structuredClone(value); }
-  peekUndo() { return this.past.length ? structuredClone(this.past.at(-1)) : null; }
-  peekRedo() { return this.future.length ? structuredClone(this.future.at(-1)) : null; }
-  undo() { if (!this.past.length) return this.value; this.future.push(structuredClone(this.value)); this.value = this.past.pop(); return structuredClone(this.value); }
-  redo() { if (!this.future.length) return this.value; this.past.push(structuredClone(this.value)); this.value = this.future.pop(); return structuredClone(this.value); }
+  constructor(value) {
+    this.past = [];
+    this.future = [];
+    this.value = structuredClone(value);
+  }
+  checkout() {
+    return structuredClone(this.value);
+  }
+  commit(value) {
+    const next = structuredClone(value);
+    if (same(this.value, next)) return false;
+    this.past.push(structuredClone(this.value));
+    this.value = next;
+    this.future = [];
+    return true;
+  }
+  replace(value) {
+    this.value = structuredClone(value);
+  }
+  peekUndo() {
+    return this.past.length ? structuredClone(this.past.at(-1)) : null;
+  }
+  peekRedo() {
+    return this.future.length ? structuredClone(this.future.at(-1)) : null;
+  }
+  undo() {
+    if (!this.past.length) return this.value;
+    this.future.push(structuredClone(this.value));
+    this.value = this.past.pop();
+    return structuredClone(this.value);
+  }
+  redo() {
+    if (!this.future.length) return this.value;
+    this.past.push(structuredClone(this.value));
+    this.value = this.future.pop();
+    return structuredClone(this.value);
+  }
 }
 
 
 const STORAGE_VERSION = 1;
-const STORAGE_KEYS = { draft:'ubta:draft', recovery:'ubta:recovery', versions:'ubta:versions' };
+const STORAGE_KEYS = {
+  draft: 'ubta:draft',
+  recovery: 'ubta:recovery',
+  versions: 'ubta:versions',
+};
 const VERSION_LIMIT = 20;
-const parse = value => { try { return value ? JSON.parse(value) : null; } catch { return null; } };
-const validRecord = record => record?.storageVersion === STORAGE_VERSION && Number.isInteger(record.revision) && record.revision >= 0 && record.document;
-const checkedDocument = value => validateDocument(value);
+const parse = (value) => {
+  try {
+    return value ? JSON.parse(value) : null;
+  } catch {
+    return null;
+  }
+};
+const validRecord = (record) =>
+  record?.storageVersion === STORAGE_VERSION &&
+  Number.isInteger(record.revision) &&
+  record.revision >= 0 &&
+  record.document;
+const checkedDocument = (value) => validateDocument(value);
 
 function readDraft(storage = localStorage) {
   const record = parse(storage.getItem(STORAGE_KEYS.draft));
   if (!validRecord(record)) return null;
-  try { return { ...record, document:checkedDocument(record.document) }; } catch { return null; }
+  try {
+    return { ...record, document: checkedDocument(record.document) };
+  } catch {
+    return null;
+  }
 }
 
 /** A save is compare-and-swap: another tab can never have its draft or recovery overwritten. */
-function saveDraft(document, expectedRevision, storage = localStorage, now = Date.now()) {
-  const current = readDraft(storage), actualRevision = current?.revision ?? 0;
-  if (actualRevision !== expectedRevision) return { ok:false, stale:true, revision:actualRevision };
-  const clean = checkedDocument(document), next = { storageVersion:STORAGE_VERSION, revision:actualRevision + 1, savedAt:now, document:clean };
+function saveDraft(
+  document,
+  expectedRevision,
+  storage = localStorage,
+  now = Date.now(),
+) {
+  const current = readDraft(storage),
+    actualRevision = current?.revision ?? 0;
+  if (actualRevision !== expectedRevision)
+    return { ok: false, stale: true, revision: actualRevision };
+  const clean = checkedDocument(document),
+    next = {
+      storageVersion: STORAGE_VERSION,
+      revision: actualRevision + 1,
+      savedAt: now,
+      document: clean,
+    };
   // Do not rotate recovery until after the stale-tab check above.
   if (current) storage.setItem(STORAGE_KEYS.recovery, JSON.stringify(current));
   storage.setItem(STORAGE_KEYS.draft, JSON.stringify(next));
-  return { ok:true, stale:false, revision:next.revision, record:next };
+  return { ok: true, stale: false, revision: next.revision, record: next };
 }
 
 function readRecovery(storage = localStorage) {
   const record = parse(storage.getItem(STORAGE_KEYS.recovery));
   if (!validRecord(record)) return null;
-  try { return { ...record, document:checkedDocument(record.document) }; } catch { return null; }
+  try {
+    return { ...record, document: checkedDocument(record.document) };
+  } catch {
+    return null;
+  }
 }
 
 function listVersions(storage = localStorage) {
   const records = parse(storage.getItem(STORAGE_KEYS.versions));
   if (!Array.isArray(records)) return [];
-  return records.filter(validRecord).flatMap(record => { try { return [{ ...record, document:checkedDocument(record.document) }]; } catch { return []; } }).slice(0, VERSION_LIMIT);
+  return records
+    .filter(validRecord)
+    .flatMap((record) => {
+      try {
+        return [{ ...record, document: checkedDocument(record.document) }];
+      } catch {
+        return [];
+      }
+    })
+    .slice(0, VERSION_LIMIT);
 }
 
-function saveVersion(document, label, storage = localStorage, now = Date.now()) {
-  const record = { storageVersion:STORAGE_VERSION, revision:0, id:`version-${now}-${Math.random().toString(36).slice(2)}`, savedAt:now, label:String(label || '').trim() || 'Saved version', document:checkedDocument(document) };
+function saveVersion(
+  document,
+  label,
+  storage = localStorage,
+  now = Date.now(),
+) {
+  const record = {
+    storageVersion: STORAGE_VERSION,
+    revision: 0,
+    id: `version-${now}-${Math.random().toString(36).slice(2)}`,
+    savedAt: now,
+    label: String(label || '').trim() || 'Saved version',
+    document: checkedDocument(document),
+  };
   const versions = [record, ...listVersions(storage)].slice(0, VERSION_LIMIT);
   storage.setItem(STORAGE_KEYS.versions, JSON.stringify(versions));
   return record;
@@ -2285,99 +3241,408 @@ function saveVersion(document, label, storage = localStorage, now = Date.now()) 
 function nextAvailableVersion(currentVersion, versions = []) {
   const current = String(currentVersion || '').trim();
   const match = current.match(/^(.*?)(\d+)([^\d]*)$/);
-  const prefix = match?.[1] ?? 'v', suffix = match?.[3] ?? '';
-  const candidates = [current, ...versions.map(version => version?.document?.meta?.version)];
-  const numbers = candidates.flatMap(value => {
-    const candidate = String(value || '').trim().match(/^(.*?)(\d+)([^\d]*)$/);
-    return candidate && candidate[1] === prefix && candidate[3] === suffix ? [Number(candidate[2])] : [];
+  const prefix = match?.[1] ?? 'v',
+    suffix = match?.[3] ?? '';
+  const candidates = [
+    current,
+    ...versions.map((version) => version?.document?.meta?.version),
+  ];
+  const numbers = candidates.flatMap((value) => {
+    const candidate = String(value || '')
+      .trim()
+      .match(/^(.*?)(\d+)([^\d]*)$/);
+    return candidate && candidate[1] === prefix && candidate[3] === suffix
+      ? [Number(candidate[2])]
+      : [];
   });
   return `${prefix}${Math.max(0, ...numbers) + 1}${suffix}`;
 }
 
 function deleteVersion(id, storage = localStorage) {
-  storage.setItem(STORAGE_KEYS.versions, JSON.stringify(listVersions(storage).filter(version => version.id !== id)));
+  storage.setItem(
+    STORAGE_KEYS.versions,
+    JSON.stringify(
+      listVersions(storage).filter((version) => version.id !== id),
+    ),
+  );
 }
 
-const toBase64 = text => { const bytes = new TextEncoder().encode(text); let binary=''; bytes.forEach(byte => binary += String.fromCharCode(byte)); return btoa(binary).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,''); };
-const fromBase64 = value => { const base64=value.replace(/-/g,'+').replace(/_/g,'/'); const binary=atob(base64 + '='.repeat((4-base64.length%4)%4)); return new TextDecoder().decode(Uint8Array.from(binary, char => char.charCodeAt(0))); };
-function encodeSnapshot(document) { return toBase64(JSON.stringify({ snapshotVersion:1, document:checkedDocument(document) })); }
-function decodeSnapshot(value) {
-  try { const envelope=JSON.parse(fromBase64(value)); if (envelope?.snapshotVersion !== 1) throw Error('Unsupported snapshot version'); return checkedDocument(envelope.document); }
-  catch (error) { throw Error(`Invalid UBTA snapshot: ${error.message}`); }
+const toBase64 = (text) => {
+  const bytes = new TextEncoder().encode(text);
+  let binary = '';
+  bytes.forEach((byte) => (binary += String.fromCharCode(byte)));
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+};
+const fromBase64 = (value) => {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(base64 + '='.repeat((4 - (base64.length % 4)) % 4));
+  return new TextDecoder().decode(
+    Uint8Array.from(binary, (char) => char.charCodeAt(0)),
+  );
+};
+function encodeSnapshot(document) {
+  return toBase64(
+    JSON.stringify({ snapshotVersion: 1, document: checkedDocument(document) }),
+  );
 }
-function snapshotFromLocation(location = globalThis.location) { const match=location.hash.match(/^#snapshot=([A-Za-z0-9_-]+)$/); return match ? decodeSnapshot(match[1]) : null; }
-function updateSnapshotUrl(document, location = globalThis.location, browserHistory = globalThis.history) { const url=`${location.href.split('#')[0]}#snapshot=${encodeSnapshot(document)}`;browserHistory.replaceState(browserHistory.state,'',url);return url; }
+function decodeSnapshot(value) {
+  try {
+    const envelope = JSON.parse(fromBase64(value));
+    if (envelope?.snapshotVersion !== 1)
+      throw Error('Unsupported snapshot version');
+    return checkedDocument(envelope.document);
+  } catch (error) {
+    throw Error(`Invalid UBTA snapshot: ${error.message}`);
+  }
+}
+function snapshotFromLocation(location = globalThis.location) {
+  const match = location.hash.match(/^#snapshot=([A-Za-z0-9_-]+)$/);
+  return match ? decodeSnapshot(match[1]) : null;
+}
+function updateSnapshotUrl(
+  document,
+  location = globalThis.location,
+  browserHistory = globalThis.history,
+) {
+  const url = `${location.href.split('#')[0]}#snapshot=${encodeSnapshot(document)}`;
+  browserHistory.replaceState(browserHistory.state, '', url);
+  return url;
+}
 
 
 function runsFromElement(element) {
-  const runs=[];
-  const visit=(node,highlight=false,link=null)=>{if(node.nodeType===3){runs.push({text:node.nodeValue||'',highlight,link:link?{href:link}:null});return}if(node.nodeType!==1)return;const tag=node.tagName.toLowerCase();if(tag==='br'){runs.push({text:'\n',highlight,link:link?{href:link}:null});return}const nextHighlight=highlight||tag==='mark',nextLink=tag==='a'?(safeHref(node.getAttribute('href'))||link):link;[...node.childNodes].forEach(child=>visit(child,nextHighlight,nextLink));if(['div','p'].includes(tag)&&node.nextSibling&&runs.at(-1)?.text?.at(-1)!=='\n')runs.push({text:'\n',highlight:nextHighlight,link:nextLink?{href:nextLink}:null});};
-  [...element.childNodes].forEach(node=>visit(node));return normaliseRuns(runs);
+  const runs = [];
+  const visit = (node, highlight = false, link = null) => {
+    if (node.nodeType === 3) {
+      runs.push({
+        text: node.nodeValue || '',
+        highlight,
+        link: link ? { href: link } : null,
+      });
+      return;
+    }
+    if (node.nodeType !== 1) return;
+    const tag = node.tagName.toLowerCase();
+    if (tag === 'br') {
+      runs.push({ text: '\n', highlight, link: link ? { href: link } : null });
+      return;
+    }
+    const nextHighlight = highlight || tag === 'mark',
+      nextLink =
+        tag === 'a' ? safeHref(node.getAttribute('href')) || link : link;
+    [...node.childNodes].forEach((child) =>
+      visit(child, nextHighlight, nextLink),
+    );
+    if (
+      ['div', 'p'].includes(tag) &&
+      node.nextSibling &&
+      runs.at(-1)?.text?.at(-1) !== '\n'
+    )
+      runs.push({
+        text: '\n',
+        highlight: nextHighlight,
+        link: nextLink ? { href: nextLink } : null,
+      });
+  };
+  [...element.childNodes].forEach((node) => visit(node));
+  return normaliseRuns(runs);
 }
 
 function transformRuns(runs, offsets, kind, value) {
-  if(!offsets)return runs;const collapsed=offsets[0]===offsets[1];if(collapsed&&kind!=='highlight')return runs;const [start,end]=collapsed?[0,runs.reduce((length,run)=>length+run.text.length,0)]:offsets;if(start===end)return runs;let position=0;const selected=runs.filter(run=>{const from=position,until=position+=run.text.length;return from<end&&until>start});const highlight=kind==='highlight'?!selected.every(run=>run.highlight):null;position=0;const output=[];
-  for(const run of runs){const from=position,until=position+run.text.length,a=Math.max(start,from),b=Math.min(end,until);if(from<a)output.push({...run,text:run.text.slice(0,a-from)});if(b>a){const part={...run,text:run.text.slice(a-from,b-from)};if(kind==='highlight')part.highlight=highlight;if(kind==='link')part.link={href:value};if(kind==='unlink')part.link=null;output.push(part)}if(b<until)output.push({...run,text:run.text.slice(Math.max(0,b-from))});position=until}return normaliseRuns(output);
+  if (!offsets) return runs;
+  const collapsed = offsets[0] === offsets[1];
+  if (collapsed && kind !== 'highlight') return runs;
+  const [start, end] = collapsed
+    ? [0, runs.reduce((length, run) => length + run.text.length, 0)]
+    : offsets;
+  if (start === end) return runs;
+  let position = 0;
+  const selected = runs.filter((run) => {
+    const from = position,
+      until = (position += run.text.length);
+    return from < end && until > start;
+  });
+  const highlight =
+    kind === 'highlight' ? !selected.every((run) => run.highlight) : null;
+  position = 0;
+  const output = [];
+  for (const run of runs) {
+    const from = position,
+      until = position + run.text.length,
+      a = Math.max(start, from),
+      b = Math.min(end, until);
+    if (from < a) output.push({ ...run, text: run.text.slice(0, a - from) });
+    if (b > a) {
+      const part = { ...run, text: run.text.slice(a - from, b - from) };
+      if (kind === 'highlight') part.highlight = highlight;
+      if (kind === 'link') part.link = { href: value };
+      if (kind === 'unlink') part.link = null;
+      output.push(part);
+    }
+    if (b < until)
+      output.push({ ...run, text: run.text.slice(Math.max(0, b - from)) });
+    position = until;
+  }
+  return normaliseRuns(output);
 }
 
-function insertPlainText(event, documentObject=document) { event.preventDefault();documentObject.execCommand('insertText',false,event.clipboardData.getData('text/plain')); }
-
-function validatedLink(external,internal){const candidate=String(external||'').trim();return safeHref(candidate||internal);}
-function containedSelectionOffsets(element,selection,documentObject=document){
-  if(!element||!selection?.rangeCount)return null;
-  const range=selection.getRangeAt(0);
-  if(!element.contains(range.startContainer)||!element.contains(range.endContainer))return null;
-  const before=documentObject.createRange();before.selectNodeContents(element);before.setEnd(range.startContainer,range.startOffset);
-  return [before.toString().length,before.toString().length+range.toString().length];
+function insertPlainText(event, documentObject = document) {
+  event.preventDefault();
+  documentObject.execCommand(
+    'insertText',
+    false,
+    event.clipboardData.getData('text/plain'),
+  );
 }
-function confirmStepDeletion(steps,index,confirmAction){if(steps.length<=1||index<0||index>=steps.length)return false;return confirmAction(`Delete Step ${index+1}: ${steps[index].title}?`);}
-function splitListRuns(runs,offset){let position=0,before=[],after=[];for(const run of runs){const split=Math.max(0,Math.min(run.text.length,offset-position));if(split)before.push({...run,text:run.text.slice(0,split)});if(split<run.text.length)after.push({...run,text:run.text.slice(split)});position+=run.text.length}return [normaliseRuns(before),normaliseRuns(after)];}
-function removeEmptyListItem(block,index){const item=block?.items?.[index];if(!item||index<1||item.runs?.some(run=>run.text))return null;block.items.splice(index,1);const previous=block.items[index-1];return {itemId:previous.id,offset:(previous.runs||[]).reduce((length,run)=>length+run.text.length,0)};}
-function insertTableRowBeforeTotals(block,makeId){let index=block.rows.reduce((last,row,i)=>row.isTotal?last:i,-1)+1;block.rows.splice(index,0,{id:makeId('row'),isTotal:false,cells:block.columns.map(()=>({id:makeId('cell'),runs:[]}))});return index;}
-function insertTableRowAfter(block,rowIndex,makeId){const index=Number.isInteger(rowIndex)&&rowIndex>=0&&rowIndex<block.rows.length?rowIndex+1:block.rows.length;block.rows.splice(index,0,{id:makeId('row'),isTotal:false,cells:block.columns.map(()=>({id:makeId('cell'),runs:[]}))});return index;}
-function insertTableColumnAfter(block,columnIndex,makeId){const index=Number.isInteger(columnIndex)&&columnIndex>=0&&columnIndex<block.columns.length?columnIndex+1:block.columns.length;block.columns.splice(index,0,{id:makeId('column'),headingRuns:[{text:`Column ${index+1}`}],width:100/(block.columns.length+1),format:'text',totalEnabled:false});block.rows.forEach(row=>row.cells.splice(index,0,{id:makeId('cell'),runs:[]}));return index;}
-class GenerationGate{generation=0;next(){return ++this.generation}isCurrent(value){return value===this.generation}cancel(){this.generation++}}
-function restoreTextSelection(element,offsets,environment=globalThis){if(!element||!offsets)return false;element.focus({preventScroll:true});const walker=environment.document.createTreeWalker(element,environment.NodeFilter.SHOW_TEXT);let position=0,start,end,node;while(node=walker.nextNode()){if(!start&&offsets[0]<=position+node.length)start=[node,offsets[0]-position];if(offsets[1]<=position+node.length){end=[node,offsets[1]-position];break}position+=node.length}if(!start)return false;const range=environment.document.createRange();range.setStart(...start);range.setEnd(...(end||start));const selection=environment.getSelection();selection.removeAllRanges();selection.addRange(range);return true;}
+
+function validatedLink(external, internal) {
+  const candidate = String(external || '').trim();
+  return safeHref(candidate || internal);
+}
+function containedSelectionOffsets(
+  element,
+  selection,
+  documentObject = document,
+) {
+  if (!element || !selection?.rangeCount) return null;
+  const range = selection.getRangeAt(0);
+  if (
+    !element.contains(range.startContainer) ||
+    !element.contains(range.endContainer)
+  )
+    return null;
+  const before = documentObject.createRange();
+  before.selectNodeContents(element);
+  before.setEnd(range.startContainer, range.startOffset);
+  return [
+    before.toString().length,
+    before.toString().length + range.toString().length,
+  ];
+}
+function confirmStepDeletion(steps, index, confirmAction) {
+  if (steps.length <= 1 || index < 0 || index >= steps.length) return false;
+  return confirmAction(`Delete Step ${index + 1}: ${steps[index].title}?`);
+}
+function splitListRuns(runs, offset) {
+  let position = 0,
+    before = [],
+    after = [];
+  for (const run of runs) {
+    const split = Math.max(0, Math.min(run.text.length, offset - position));
+    if (split) before.push({ ...run, text: run.text.slice(0, split) });
+    if (split < run.text.length)
+      after.push({ ...run, text: run.text.slice(split) });
+    position += run.text.length;
+  }
+  return [normaliseRuns(before), normaliseRuns(after)];
+}
+function removeEmptyListItem(block, index) {
+  const item = block?.items?.[index];
+  if (!item || index < 1 || item.runs?.some((run) => run.text)) return null;
+  block.items.splice(index, 1);
+  const previous = block.items[index - 1];
+  return {
+    itemId: previous.id,
+    offset: (previous.runs || []).reduce(
+      (length, run) => length + run.text.length,
+      0,
+    ),
+  };
+}
+function insertTableRowBeforeTotals(block, makeId) {
+  let index =
+    block.rows.reduce((last, row, i) => (row.isTotal ? last : i), -1) + 1;
+  block.rows.splice(index, 0, {
+    id: makeId('row'),
+    isTotal: false,
+    cells: block.columns.map(() => ({ id: makeId('cell'), runs: [] })),
+  });
+  return index;
+}
+function insertTableRowAfter(block, rowIndex, makeId) {
+  const index =
+    Number.isInteger(rowIndex) && rowIndex >= 0 && rowIndex < block.rows.length
+      ? rowIndex + 1
+      : block.rows.length;
+  block.rows.splice(index, 0, {
+    id: makeId('row'),
+    isTotal: false,
+    cells: block.columns.map(() => ({ id: makeId('cell'), runs: [] })),
+  });
+  return index;
+}
+function insertTableColumnAfter(block, columnIndex, makeId) {
+  const index =
+    Number.isInteger(columnIndex) &&
+    columnIndex >= 0 &&
+    columnIndex < block.columns.length
+      ? columnIndex + 1
+      : block.columns.length;
+  block.columns.splice(index, 0, {
+    id: makeId('column'),
+    headingRuns: [{ text: `Column ${index + 1}` }],
+    width: 100 / (block.columns.length + 1),
+    format: 'text',
+    totalEnabled: false,
+  });
+  block.rows.forEach((row) =>
+    row.cells.splice(index, 0, { id: makeId('cell'), runs: [] }),
+  );
+  return index;
+}
+class GenerationGate {
+  generation = 0;
+  next() {
+    return ++this.generation;
+  }
+  isCurrent(value) {
+    return value === this.generation;
+  }
+  cancel() {
+    this.generation++;
+  }
+}
+function restoreTextSelection(
+  element,
+  offsets,
+  environment = globalThis,
+) {
+  if (!element || !offsets) return false;
+  element.focus({ preventScroll: true });
+  const walker = environment.document.createTreeWalker(
+    element,
+    environment.NodeFilter.SHOW_TEXT,
+  );
+  let position = 0,
+    start,
+    end,
+    node;
+  while ((node = walker.nextNode())) {
+    if (!start && offsets[0] <= position + node.length)
+      start = [node, offsets[0] - position];
+    if (offsets[1] <= position + node.length) {
+      end = [node, offsets[1] - position];
+      break;
+    }
+    position += node.length;
+  }
+  if (!start) return false;
+  const range = environment.document.createRange();
+  range.setStart(...start);
+  range.setEnd(...(end || start));
+  const selection = environment.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return true;
+}
 
 class RepaginationScheduler {
-  constructor(renderer,{delay=500,capture=()=>null,restore=()=>{}}={}){this.renderer=renderer;this.delay=delay;this.capture=capture;this.restore=restore;this.gate=new GenerationGate;this.timer=null;}
-  request({immediate=false}={}){this.cancel();const generation=this.gate.next(),view=this.capture();if(immediate)return this.run(generation,view);return new Promise(resolve=>{this.queuedResolve=resolve;this.timer=setTimeout(()=>{this.timer=null;this.queuedResolve=null;this.run(generation,view).then(resolve)},this.delay)});}
-  cancel(){if(this.timer){clearTimeout(this.timer);this.timer=null;this.queuedResolve?.(false);this.queuedResolve=null}this.gate.cancel()}
-  async run(generation,view){const isCurrent=()=>this.gate.isCurrent(generation);const completed=await this.renderer({isCurrent});if(!completed||!isCurrent())return false;await this.restore(view);return isCurrent();}
+  constructor(
+    renderer,
+    { delay = 500, capture = () => null, restore = () => {} } = {},
+  ) {
+    this.renderer = renderer;
+    this.delay = delay;
+    this.capture = capture;
+    this.restore = restore;
+    this.gate = new GenerationGate();
+    this.timer = null;
+  }
+  request({ immediate = false } = {}) {
+    this.cancel();
+    const generation = this.gate.next(),
+      view = this.capture();
+    if (immediate) return this.run(generation, view);
+    return new Promise((resolve) => {
+      this.queuedResolve = resolve;
+      this.timer = setTimeout(() => {
+        this.timer = null;
+        this.queuedResolve = null;
+        this.run(generation, view).then(resolve);
+      }, this.delay);
+    });
+  }
+  cancel() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+      this.queuedResolve?.(false);
+      this.queuedResolve = null;
+    }
+    this.gate.cancel();
+  }
+  async run(generation, view) {
+    const isCurrent = () => this.gate.isCurrent(generation);
+    const completed = await this.renderer({ isCurrent });
+    if (!completed || !isCurrent()) return false;
+    await this.restore(view);
+    return isCurrent();
+  }
 }
 
 class PrintLifecycle {
-  constructor({flush,cancelPagination,render,prepare,clearPresentation,print,restore,onAfterPrint,onError=()=>{},setFallback=(callback)=>setTimeout(callback,1000),clearFallback=clearTimeout}) {
-    Object.assign(this,{flush,cancelPagination,render,prepare,clearPresentation,print,restore,onAfterPrint,onError,setFallback,clearFallback});
-    this.busy=false;
+  constructor({
+    flush,
+    cancelPagination,
+    render,
+    prepare,
+    clearPresentation,
+    print,
+    restore,
+    onAfterPrint,
+    onError = () => {},
+    setFallback = (callback) => setTimeout(callback, 1000),
+    clearFallback = clearTimeout,
+  }) {
+    Object.assign(this, {
+      flush,
+      cancelPagination,
+      render,
+      prepare,
+      clearPresentation,
+      print,
+      restore,
+      onAfterPrint,
+      onError,
+      setFallback,
+      clearFallback,
+    });
+    this.busy = false;
   }
 
-  async run(){
-    if(this.busy)return false;
-    this.busy=true;
-    const context=this.prepare();
+  async run() {
+    if (this.busy) return false;
+    this.busy = true;
+    const context = this.prepare();
     let fallback;
-    let removeAfterPrint=()=>{};
-    const cleanup=()=>{
-      if(!this.busy)return;
-      this.busy=false;
-      if(fallback!==undefined)this.clearFallback(fallback);
+    let removeAfterPrint = () => {};
+    const cleanup = () => {
+      if (!this.busy) return;
+      this.busy = false;
+      if (fallback !== undefined) this.clearFallback(fallback);
       removeAfterPrint();
       this.restore(context);
     };
-    try{
+    try {
       this.flush();
       this.cancelPagination();
-      if(!await this.render())throw new Error('The document could not be prepared for printing.');
+      if (!(await this.render()))
+        throw new Error('The document could not be prepared for printing.');
       // The first pass calculates the new page map. The second pass lays out the
       // contents page with that map, so the printed TOC matches the final pages.
-      if(!await this.render())throw new Error('The document contents could not be reconciled for printing.');
+      if (!(await this.render()))
+        throw new Error(
+          'The document contents could not be reconciled for printing.',
+        );
       this.clearPresentation();
-      removeAfterPrint=this.onAfterPrint(cleanup);
+      removeAfterPrint = this.onAfterPrint(cleanup);
       this.print();
-      if(this.busy)fallback=this.setFallback(cleanup);
+      if (this.busy) fallback = this.setFallback(cleanup);
       return true;
-    }catch(error){
+    } catch (error) {
       cleanup();
       this.onError(error);
       return false;
@@ -2385,88 +3650,141 @@ class PrintLifecycle {
   }
 }
 
-const TABLE_COMMANDS = new Set(['addRow','removeRow','moveRowUp','moveRowDown','addColumn','removeColumn','moveColumnLeft','moveColumnRight']);
-
-const canApplyBlockStyle = (blockType, action) => {
-  if (/^heading[1-4]$/.test(action)) return ['paragraph', 'heading'].includes(blockType);
-  if (action === 'body') return ['paragraph', 'heading'].includes(blockType);
-  return ['bulletList', 'numberList'].includes(action) && ['paragraph', 'heading', 'bulletList', 'numberList'].includes(blockType);
-};
-
-const blockStyleChoices = blockType => ['bulletList','numberList'].includes(blockType)
-  ? [['bulletList','Bulleted list'],['numberList','Numbered list']]
-  : [['body','Body text'],['heading1','Heading 1'],['heading2','Heading 2'],['heading3','Heading 3'],['heading4','Heading 4'],['bulletList','Bulleted list'],['numberList','Numbered list']];
-
-const BLOCK_COMMANDS = new Map([
-  ['addParagraph','paragraph'],
-  ['addHeading','heading'],
-  ['addBulletList','bulletList'],
-  ['addNumberList','numberList'],
-  ['addTable','table']
+const TABLE_COMMANDS = new Set([
+  'addRow',
+  'removeRow',
+  'moveRowUp',
+  'moveRowDown',
+  'addColumn',
+  'removeColumn',
+  'moveColumnLeft',
+  'moveColumnRight',
 ]);
 
-function routeInsertionCommand(action){
-  if(TABLE_COMMANDS.has(action))return {kind:'table',action};
-  const blockType=BLOCK_COMMANDS.get(action);
-  if(typeof blockType==='string')return {kind:'block',blockType};
+const canApplyBlockStyle = (blockType, action) => {
+  if (/^heading[1-4]$/.test(action))
+    return ['paragraph', 'heading'].includes(blockType);
+  if (action === 'body') return ['paragraph', 'heading'].includes(blockType);
+  return (
+    ['bulletList', 'numberList'].includes(action) &&
+    ['paragraph', 'heading', 'bulletList', 'numberList'].includes(blockType)
+  );
+};
+
+const blockStyleChoices = (blockType) =>
+  ['bulletList', 'numberList'].includes(blockType)
+    ? [
+        ['bulletList', 'Bulleted list'],
+        ['numberList', 'Numbered list'],
+      ]
+    : [
+        ['body', 'Body text'],
+        ['heading1', 'Heading 1'],
+        ['heading2', 'Heading 2'],
+        ['heading3', 'Heading 3'],
+        ['heading4', 'Heading 4'],
+        ['bulletList', 'Bulleted list'],
+        ['numberList', 'Numbered list'],
+      ];
+
+const BLOCK_COMMANDS = new Map([
+  ['addParagraph', 'paragraph'],
+  ['addHeading', 'heading'],
+  ['addBulletList', 'bulletList'],
+  ['addNumberList', 'numberList'],
+  ['addTable', 'table'],
+]);
+
+function routeInsertionCommand(action) {
+  if (TABLE_COMMANDS.has(action)) return { kind: 'table', action };
+  const blockType = BLOCK_COMMANDS.get(action);
+  if (typeof blockType === 'string') return { kind: 'block', blockType };
   return null;
 }
 
-function renderList(block,renderRuns,escapeAttribute=String){
-  const tag=block.type==='numberList'?'ol':block.type==='bulletList'?'ul':null;
-  if(!tag)return '';
-  const counters=[0,0,0];
-  const items=block.items.map(item=>{
-    const level=Math.min(3,Math.max(1,Number(item.level)||1));
-    counters[level-1]++;
-    counters.fill(0,level);
-    const value=tag==='ol'?` value="${counters[level-1]}"`:'';
-    return `<li class="list-item" contenteditable="true" data-container="item" data-item-id="${escapeAttribute(item.id)}" data-level="${level}" aria-level="${level}"${value}>${renderRuns(item.runs)}</li>`;
-  }).join('');
+function renderList(block, renderRuns, escapeAttribute = String) {
+  const tag =
+    block.type === 'numberList'
+      ? 'ol'
+      : block.type === 'bulletList'
+        ? 'ul'
+        : null;
+  if (!tag) return '';
+  const counters = [0, 0, 0];
+  const items = block.items
+    .map((item) => {
+      const level = Math.min(3, Math.max(1, Number(item.level) || 1));
+      counters[level - 1]++;
+      counters.fill(0, level);
+      const value = tag === 'ol' ? ` value="${counters[level - 1]}"` : '';
+      return `<li class="list-item" contenteditable="true" data-container="item" data-item-id="${escapeAttribute(item.id)}" data-level="${level}" aria-level="${level}"${value}>${renderRuns(item.runs)}</li>`;
+    })
+    .join('');
   return `<${tag} class="list-items" data-list-type="${block.type}">${items}</${tag}><button class="list-trailing-hit-area" type="button" aria-label="Add another list item" data-list-append></button>`;
 }
 
-const textFromRuns=runs=>(runs||[]).map(run=>run.text||'').join('');
+const textFromRuns = (runs) =>
+  (runs || []).map((run) => run.text || '').join('');
 
-function blockTypeLabel(type){
-  return ({paragraph:'paragraph',heading:'heading',bulletList:'bulleted list',numberList:'numbered list',table:'table',image:'image'})[type]||'block';
+function blockTypeLabel(type) {
+  return (
+    {
+      paragraph: 'paragraph',
+      heading: 'heading',
+      bulletList: 'bulleted list',
+      numberList: 'numbered list',
+      table: 'table',
+      image: 'image',
+    }[type] || 'block'
+  );
 }
 
-function blockHasContent(block){
-  if(['table','image'].includes(block.type))return true;
-  if(block.type.endsWith('List'))return (block.items||[]).some(item=>textFromRuns(item.runs).trim());
+function blockHasContent(block) {
+  if (['table', 'image'].includes(block.type)) return true;
+  if (block.type.endsWith('List'))
+    return (block.items || []).some((item) => textFromRuns(item.runs).trim());
   return Boolean(textFromRuns(block.runs).trim());
 }
 
-function removeBlockFromGroup(group,id,makeId){
-  const index=group.blocks.findIndex(block=>block.id===id);
-  if(index<0)return null;
-  const [deleted]=group.blocks.splice(index,1);
-  let replacement=null;
-  if(!group.blocks.length){
-    replacement={id:makeId('block'),type:'paragraph',runs:[]};
+function removeBlockFromGroup(group, id, makeId) {
+  const index = group.blocks.findIndex((block) => block.id === id);
+  if (index < 0) return null;
+  const [deleted] = group.blocks.splice(index, 1);
+  let replacement = null;
+  if (!group.blocks.length) {
+    replacement = { id: makeId('block'), type: 'paragraph', runs: [] };
     group.blocks.push(replacement);
   }
-  return {deleted,target:group.blocks[index-1]||group.blocks[index]||replacement};
+  return {
+    deleted,
+    target: group.blocks[index - 1] || group.blocks[index] || replacement,
+  };
 }
 
 function insertionIndex(group, context) {
   if (!group || group.id !== context?.groupId) return -1;
   if (!context.referenceBlockId) return group.blocks.length;
-  const referenceIndex = group.blocks.findIndex(block => block.id === context.referenceBlockId);
+  const referenceIndex = group.blocks.findIndex(
+    (block) => block.id === context.referenceBlockId,
+  );
   if (referenceIndex < 0) return group.blocks.length;
   return referenceIndex + (context.position === 'before' ? 0 : 1);
 }
 
 function insertionContextFromPoint(groupId, blockElements, clientY) {
   const blocks = blockElements
-    .map(element => ({ id: element.dataset.blockId, rect: element.getBoundingClientRect() }))
-    .filter(item => item.id && item.rect.height > 0)
+    .map((element) => ({
+      id: element.dataset.blockId,
+      rect: element.getBoundingClientRect(),
+    }))
+    .filter((item) => item.id && item.rect.height > 0)
     .sort((a, b) => a.rect.top - b.rect.top);
-  const preceding = blocks.filter(item => item.rect.top <= clientY).at(-1);
-  if (preceding) return { groupId, referenceBlockId: preceding.id, position: 'after' };
-  const following = blocks.find(item => item.rect.top > clientY);
-  if (following) return { groupId, referenceBlockId: following.id, position: 'before' };
+  const preceding = blocks.filter((item) => item.rect.top <= clientY).at(-1);
+  if (preceding)
+    return { groupId, referenceBlockId: preceding.id, position: 'after' };
+  const following = blocks.find((item) => item.rect.top > clientY);
+  if (following)
+    return { groupId, referenceBlockId: following.id, position: 'before' };
   return { groupId, referenceBlockId: null, position: 'after' };
 }
 
@@ -2474,13 +3792,13 @@ function canOpenBlankSpaceInsertion(activeGroupId, clickedGroupId) {
   return Boolean(activeGroupId && activeGroupId === clickedGroupId);
 }
 
-function bindCallouts(root=document){
-  root.querySelectorAll('dialog').forEach(dialog=>{
-    dialog.addEventListener('click',event=>{
-      if(event.target===dialog)dialog.close('cancel');
+function bindCallouts(root = document) {
+  root.querySelectorAll('dialog').forEach((dialog) => {
+    dialog.addEventListener('click', (event) => {
+      if (event.target === dialog) dialog.close('cancel');
     });
-    dialog.querySelectorAll('[data-dialog-cancel]').forEach(button=>{
-      button.addEventListener('click',event=>{
+    dialog.querySelectorAll('[data-dialog-cancel]').forEach((button) => {
+      button.addEventListener('click', (event) => {
         event.preventDefault();
         dialog.close('cancel');
       });
@@ -2489,30 +3807,63 @@ function bindCallouts(root=document){
 }
 
 
-function followEditorLink(href,{navigateInternal,openExternal,openMailto,report=()=>{}}){
-  const safe=safeHref(href);
-  if(!safe){report('This link is not safe to open');return false}
-  if(safe.startsWith('#')){const opened=navigateInternal(safe.slice(1));if(!opened)report('The linked document destination no longer exists');return opened}
-  if(/^https?:/i.test(safe)){openExternal(safe);return true}
-  if(/^mailto:/i.test(safe)){openMailto(safe);return true}
+function followEditorLink(
+  href,
+  { navigateInternal, openExternal, openMailto, report = () => {} },
+) {
+  const safe = safeHref(href);
+  if (!safe) {
+    report('This link is not safe to open');
+    return false;
+  }
+  if (safe.startsWith('#')) {
+    const opened = navigateInternal(safe.slice(1));
+    if (!opened) report('The linked document destination no longer exists');
+    return opened;
+  }
+  if (/^https?:/i.test(safe)) {
+    openExternal(safe);
+    return true;
+  }
+  if (/^mailto:/i.test(safe)) {
+    openMailto(safe);
+    return true;
+  }
   return false;
 }
 
-function handleEditableLinkClick(event,openLink){
-  const link=event.target?.closest?.('.editable-runs a');
-  if(!link||event.button!==0)return false;
-  event.preventDefault();openLink(link.getAttribute('href'));return true;
+function handleEditableLinkClick(event, openLink) {
+  const link = event.target?.closest?.('.editable-runs a');
+  if (!link || event.button !== 0) return false;
+  event.preventDefault();
+  openLink(link.getAttribute('href'));
+  return true;
 }
 
 class NavigationHistory {
-  constructor() { this.entries = []; }
-  push(view) { if (view) this.entries.push(structuredClone(view)); }
-  undo() { return this.entries.length ? this.entries.pop() : null; }
-  clear() { this.entries.length = 0; }
+  constructor() {
+    this.entries = [];
+  }
+  push(view) {
+    if (view) this.entries.push(structuredClone(view));
+  }
+  undo() {
+    return this.entries.length ? this.entries.pop() : null;
+  }
+  clear() {
+    this.entries.length = 0;
+  }
 }
 
 
-const escapeHtml = value => String(value).replace(/[&<>"']/g, character => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[character]));
+const escapeHtml = (value) =>
+  String(value).replace(
+    /[&<>"']/g,
+    (character) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[
+        character
+      ],
+  );
 
 const gridSelector = '[data-grid-row][data-grid-column]';
 
@@ -2522,39 +3873,233 @@ function gridDestination(targets, current, key, shiftKey = false) {
   const index = targets.indexOf(current);
 
   if (key === 'Tab') {
-    return targets[(index + (shiftKey ? -1 : 1) + targets.length) % targets.length];
+    return targets[
+      (index + (shiftKey ? -1 : 1) + targets.length) % targets.length
+    ];
   }
 
-  const rowChange = key === 'ArrowUp' || (key === 'Enter' && shiftKey) ? -1
-    : key === 'ArrowDown' || key === 'Enter' ? 1 : 0;
+  const rowChange =
+    key === 'ArrowUp' || (key === 'Enter' && shiftKey)
+      ? -1
+      : key === 'ArrowDown' || key === 'Enter'
+        ? 1
+        : 0;
   const columnChange = key === 'ArrowLeft' ? -1 : key === 'ArrowRight' ? 1 : 0;
-  return targets.find(target => (
-    Number(target.dataset.gridRow) === row + rowChange
-    && Number(target.dataset.gridColumn) === column + columnChange
-  )) || current;
+  return (
+    targets.find(
+      (target) =>
+        Number(target.dataset.gridRow) === row + rowChange &&
+        Number(target.dataset.gridColumn) === column + columnChange,
+    ) || current
+  );
 }
 
 class ExcelEditor {
-  constructor({ root, toolbar, getDocument, updateDocument, report }) { this.root=root;this.toolbar=toolbar;this.getDocument=getDocument;this.updateDocument=updateDocument;this.report=report;this.history=new History(getDocument().excel);this.focus={};this.bindToolbar(); }
-  get excel() { return this.getDocument().excel; }
-  get company() { return this.excel.companies.find(item=>item.id===this.excel.selectedCompanyId); }
-  replace(excel, record=true) { if(record)this.history.commit(excel);else this.history.replace(excel);this.updateDocument(excel);this.render(); }
-  mutate(change) { const excel=structuredClone(this.excel);change(excel);this.replace(excel); }
-  synchronize() { const next=syncSteps(this.excel,this.getDocument().steps);if(JSON.stringify(next)!==JSON.stringify(this.excel))this.replace(next);else this.render(); }
-  undo() { const next=syncSteps(this.history.undo(),this.getDocument().steps);this.history.replace(next);this.updateDocument(next);this.render(); }
-  redo() { const next=syncSteps(this.history.redo(),this.getDocument().steps);this.history.replace(next);this.updateDocument(next);this.render(); }
-  restore(excel) { this.history=new History(excel);this.render(); }
-  bindToolbar() { this.toolbar.addEventListener('click',event=>{const action=event.target.dataset.excelAction;if(!action)return;this[action]?.();}); }
-  addCompany() { const name=prompt('Company name:','New company');if(!name?.trim())return;this.mutate(excel=>{const company=createCompany(name.trim());excel.companies.push(company);excel.selectedCompanyId=company.id;}); }
-  deleteCompany() { const company=this.company;if(!company)return;const typed=prompt(`Type “${company.name}” to permanently delete this company. This can be undone.`);if(typed!==company.name){if(typed!==null)this.report('Company name did not match; nothing was deleted.');return;}this.mutate(excel=>{excel.companies=excel.companies.filter(item=>item.id!==company.id);excel.selectedCompanyId=excel.companies[0]?.id||null;}); }
-  addShareholder() { if(!this.company||this.company.shareholders.length>=100)return this.report('The 100-shareholder limit has been reached.');this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId),at=this.focus.holderId?company.shareholders.findIndex(item=>item.id===this.focus.holderId)+1:company.shareholders.length;const holder={id:`holder-${crypto.randomUUID()}`,name:'',type:'Individual'};company.shareholders.splice(at,0,holder);this.focus={holderId:holder.id};}); }
-  removeShareholder() { const company=this.company,holder=company?.shareholders.find(item=>item.id===this.focus.holderId);if(!holder)return this.report('Focus a shareholder row first.');const blocking=findBlocking(company,null,holder.id,this.getDocument().steps);if(blocking)return this.blocked(blocking);this.mutate(excel=>{const current=excel.companies.find(item=>item.id===company.id);current.shareholders=current.shareholders.filter(item=>item.id!==holder.id);}); }
-  addGroup() { if(!this.company)return; if(classesOf(this.company).length>=100)return this.report('The 100-share-class limit has been reached.');this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId);company.groups.push({id:`group-${crypto.randomUUID()}`,name:'New group',classes:[{id:`class-${crypto.randomUUID()}`,label:''}]});}); }
-  removeGroup() { const company=this.company,group=company?.groups.find(item=>item.id===this.focus.groupId);if(!group)return this.report('Focus a share-group header first.');const blocking=findBlocking(company,group.classes.map(item=>item.id),null,this.getDocument().steps);if(blocking)return this.blocked(blocking);this.mutate(excel=>excel.companies.find(item=>item.id===company.id).groups=company.groups.filter(item=>item.id!==group.id)); }
-  addClass() { if(!this.company)return;if(classesOf(this.company).length>=100)return this.report('The 100-share-class limit has been reached.');this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId),group=company.groups.find(item=>item.id===this.focus.groupId)||company.groups.at(-1);if(!group)return this.report('Add a share group first.');const at=this.focus.classId?group.classes.findIndex(item=>item.id===this.focus.classId)+1:group.classes.length;group.classes.splice(at,0,{id:`class-${crypto.randomUUID()}`,label:''});}); }
-  removeClass() { const company=this.company,shareClass=classesOf(company||{groups:[]}).find(item=>item.id===this.focus.classId);if(!shareClass)return this.report('Focus a share-class header first.');const blocking=findBlocking(company,[shareClass.id],null,this.getDocument().steps);if(blocking)return this.blocked(blocking);this.mutate(excel=>{for(const group of excel.companies.find(item=>item.id===company.id).groups)group.classes=group.classes.filter(item=>item.id!==shareClass.id);}); }
-  blocked(item) { this.report(`${this.company.name} — ${item.location}: ${item.holder.name}, ${item.shareClass.label||'unnamed share class'} contains data and blocks deletion.`); }
-  table(title, values, editable, stepId='') {
+  constructor({ root, toolbar, getDocument, updateDocument, report }) {
+    this.root = root;
+    this.toolbar = toolbar;
+    this.getDocument = getDocument;
+    this.updateDocument = updateDocument;
+    this.report = report;
+    this.history = new History(getDocument().excel);
+    this.focus = {};
+    this.bindToolbar();
+  }
+  get excel() {
+    return this.getDocument().excel;
+  }
+  get company() {
+    return this.excel.companies.find(
+      (item) => item.id === this.excel.selectedCompanyId,
+    );
+  }
+  replace(excel, record = true) {
+    if (record) this.history.commit(excel);
+    else this.history.replace(excel);
+    this.updateDocument(excel);
+    this.render();
+  }
+  mutate(change) {
+    const excel = structuredClone(this.excel);
+    change(excel);
+    this.replace(excel);
+  }
+  synchronize() {
+    const next = syncSteps(this.excel, this.getDocument().steps);
+    if (JSON.stringify(next) !== JSON.stringify(this.excel)) this.replace(next);
+    else this.render();
+  }
+  undo() {
+    const next = syncSteps(this.history.undo(), this.getDocument().steps);
+    this.history.replace(next);
+    this.updateDocument(next);
+    this.render();
+  }
+  redo() {
+    const next = syncSteps(this.history.redo(), this.getDocument().steps);
+    this.history.replace(next);
+    this.updateDocument(next);
+    this.render();
+  }
+  restore(excel) {
+    this.history = new History(excel);
+    this.render();
+  }
+  bindToolbar() {
+    this.toolbar.addEventListener('click', (event) => {
+      const action = event.target.dataset.excelAction;
+      if (!action) return;
+      this[action]?.();
+    });
+  }
+  addCompany() {
+    const name = prompt('Company name:', 'New company');
+    if (!name?.trim()) return;
+    this.mutate((excel) => {
+      const company = createCompany(name.trim());
+      excel.companies.push(company);
+      excel.selectedCompanyId = company.id;
+    });
+  }
+  deleteCompany() {
+    const company = this.company;
+    if (!company) return;
+    const typed = prompt(
+      `Type “${company.name}” to permanently delete this company. This can be undone.`,
+    );
+    if (typed !== company.name) {
+      if (typed !== null)
+        this.report('Company name did not match; nothing was deleted.');
+      return;
+    }
+    this.mutate((excel) => {
+      excel.companies = excel.companies.filter(
+        (item) => item.id !== company.id,
+      );
+      excel.selectedCompanyId = excel.companies[0]?.id || null;
+    });
+  }
+  addShareholder() {
+    if (!this.company || this.company.shareholders.length >= 100)
+      return this.report('The 100-shareholder limit has been reached.');
+    this.mutate((excel) => {
+      const company = excel.companies.find(
+          (item) => item.id === excel.selectedCompanyId,
+        ),
+        at = this.focus.holderId
+          ? company.shareholders.findIndex(
+              (item) => item.id === this.focus.holderId,
+            ) + 1
+          : company.shareholders.length;
+      const holder = {
+        id: `holder-${crypto.randomUUID()}`,
+        name: '',
+        type: 'Individual',
+      };
+      company.shareholders.splice(at, 0, holder);
+      this.focus = { holderId: holder.id };
+    });
+  }
+  removeShareholder() {
+    const company = this.company,
+      holder = company?.shareholders.find(
+        (item) => item.id === this.focus.holderId,
+      );
+    if (!holder) return this.report('Focus a shareholder row first.');
+    const blocking = findBlocking(
+      company,
+      null,
+      holder.id,
+      this.getDocument().steps,
+    );
+    if (blocking) return this.blocked(blocking);
+    this.mutate((excel) => {
+      const current = excel.companies.find((item) => item.id === company.id);
+      current.shareholders = current.shareholders.filter(
+        (item) => item.id !== holder.id,
+      );
+    });
+  }
+  addGroup() {
+    if (!this.company) return;
+    if (classesOf(this.company).length >= 100)
+      return this.report('The 100-share-class limit has been reached.');
+    this.mutate((excel) => {
+      const company = excel.companies.find(
+        (item) => item.id === excel.selectedCompanyId,
+      );
+      company.groups.push({
+        id: `group-${crypto.randomUUID()}`,
+        name: 'New group',
+        classes: [{ id: `class-${crypto.randomUUID()}`, label: '' }],
+      });
+    });
+  }
+  removeGroup() {
+    const company = this.company,
+      group = company?.groups.find((item) => item.id === this.focus.groupId);
+    if (!group) return this.report('Focus a share-group header first.');
+    const blocking = findBlocking(
+      company,
+      group.classes.map((item) => item.id),
+      null,
+      this.getDocument().steps,
+    );
+    if (blocking) return this.blocked(blocking);
+    this.mutate(
+      (excel) =>
+        (excel.companies.find((item) => item.id === company.id).groups =
+          company.groups.filter((item) => item.id !== group.id)),
+    );
+  }
+  addClass() {
+    if (!this.company) return;
+    if (classesOf(this.company).length >= 100)
+      return this.report('The 100-share-class limit has been reached.');
+    this.mutate((excel) => {
+      const company = excel.companies.find(
+          (item) => item.id === excel.selectedCompanyId,
+        ),
+        group =
+          company.groups.find((item) => item.id === this.focus.groupId) ||
+          company.groups.at(-1);
+      if (!group) return this.report('Add a share group first.');
+      const at = this.focus.classId
+        ? group.classes.findIndex((item) => item.id === this.focus.classId) + 1
+        : group.classes.length;
+      group.classes.splice(at, 0, {
+        id: `class-${crypto.randomUUID()}`,
+        label: '',
+      });
+    });
+  }
+  removeClass() {
+    const company = this.company,
+      shareClass = classesOf(company || { groups: [] }).find(
+        (item) => item.id === this.focus.classId,
+      );
+    if (!shareClass) return this.report('Focus a share-class header first.');
+    const blocking = findBlocking(
+      company,
+      [shareClass.id],
+      null,
+      this.getDocument().steps,
+    );
+    if (blocking) return this.blocked(blocking);
+    this.mutate((excel) => {
+      for (const group of excel.companies.find((item) => item.id === company.id)
+        .groups)
+        group.classes = group.classes.filter(
+          (item) => item.id !== shareClass.id,
+        );
+    });
+  }
+  blocked(item) {
+    this.report(
+      `${this.company.name} — ${item.location}: ${item.holder.name}, ${item.shareClass.label || 'unnamed share class'} contains data and blocks deletion.`,
+    );
+  }
+  table(title, values, editable, stepId = '') {
     const company = this.company;
     const classes = classesOf(company);
     const summary = totals(company, values);
@@ -2564,45 +4109,100 @@ class ExcelEditor {
     for (const group of company.groups) {
       groupHeaders += `<th class="group-head" data-group-id="${escapeHtml(group.id)}" colspan="${Math.max(1, group.classes.length)}"><input data-group-name value="${escapeHtml(group.name)}" aria-label="Share group"></th>`;
       for (const item of group.classes) {
-        const column = classes.findIndex(shareClass => shareClass.id === item.id) + 1;
+        const column =
+          classes.findIndex((shareClass) => shareClass.id === item.id) + 1;
         classHeaders += `<th data-group-id="${escapeHtml(group.id)}" data-class-id="${escapeHtml(item.id)}"><input data-class-label data-grid-row="0" data-grid-column="${column}" value="${escapeHtml(item.label)}" aria-label="Share class"></th>`;
       }
     }
 
-    const rows = company.shareholders.map((holder, row) => {
-      const shareholder = `<th><input data-holder-name data-holder-id="${escapeHtml(holder.id)}" data-grid-row="${row + 1}" data-grid-column="0" value="${escapeHtml(holder.name)}" aria-label="Shareholder"></th>`;
-      const type = `<td><select data-holder-type data-holder-id="${escapeHtml(holder.id)}" tabindex="-1">${TYPES.map(item => `<option${item === holder.type ? ' selected' : ''}>${item}</option>`).join('')}</select></td>`;
-      const rowValues = classes.map((item, column) => {
-        const value = valueAt(values, holder.id, item.id);
-        const negative = value < 0 && (editable === 'opening' || !editable);
-        return `<td class="number ${negative ? 'negative' : ''}" tabindex="${editable ? '0' : '-1'}" ${editable ? 'contenteditable="true"' : ''} data-grid-row="${row + 1}" data-grid-column="${column + 1}" data-holder-id="${escapeHtml(holder.id)}" data-class-id="${escapeHtml(item.id)}" data-step-id="${escapeHtml(stepId)}" data-editable="${editable ? 'true' : 'false'}">${formatShares(value)}</td>`;
-      }).join('');
-      return `<tr>${shareholder}${type}${rowValues}<td class="number total">${formatShares(summary.rows[holder.id])}</td></tr>`;
-    }).join('');
+    const rows = company.shareholders
+      .map((holder, row) => {
+        const shareholder = `<th><input data-holder-name data-holder-id="${escapeHtml(holder.id)}" data-grid-row="${row + 1}" data-grid-column="0" value="${escapeHtml(holder.name)}" aria-label="Shareholder"></th>`;
+        const type = `<td><select data-holder-type data-holder-id="${escapeHtml(holder.id)}" tabindex="-1">${TYPES.map((item) => `<option${item === holder.type ? ' selected' : ''}>${item}</option>`).join('')}</select></td>`;
+        const rowValues = classes
+          .map((item, column) => {
+            const value = valueAt(values, holder.id, item.id);
+            const negative = value < 0 && (editable === 'opening' || !editable);
+            return `<td class="number ${negative ? 'negative' : ''}" tabindex="${editable ? '0' : '-1'}" ${editable ? 'contenteditable="true"' : ''} data-grid-row="${row + 1}" data-grid-column="${column + 1}" data-holder-id="${escapeHtml(holder.id)}" data-class-id="${escapeHtml(item.id)}" data-step-id="${escapeHtml(stepId)}" data-editable="${editable ? 'true' : 'false'}">${formatShares(value)}</td>`;
+          })
+          .join('');
+        return `<tr>${shareholder}${type}${rowValues}<td class="number total">${formatShares(summary.rows[holder.id])}</td></tr>`;
+      })
+      .join('');
 
-    const columnTotals = classes.map(item => `<td class="number">${formatShares(summary.columns[item.id])}</td>`).join('');
+    const columnTotals = classes
+      .map(
+        (item) =>
+          `<td class="number">${formatShares(summary.columns[item.id])}</td>`,
+      )
+      .join('');
     return `<section class="share-table"><h3>${escapeHtml(title)}</h3><div class="table-scroll"><table><thead><tr><th rowspan="2">Shareholder</th><th rowspan="2">Type</th>${groupHeaders}<th rowspan="2">Total</th></tr><tr>${classHeaders}</tr></thead><tbody>${rows}<tr class="total-row"><th colspan="2">Total</th>${columnTotals}<td class="number">${formatShares(summary.grand)}</td></tr></tbody></table></div></section>`;
   }
-  render() { const excel=this.excel,company=this.company;this.root.innerHTML=`<div class="company-tabs" role="tablist">${excel.companies.map(item=>`<button role="tab" aria-selected="${item.id===excel.selectedCompanyId}" data-company-id="${escapeHtml(item.id)}">${escapeHtml(item.name)}</button>`).join('')}</div>${company?this.table('Opening Position',company.opening,'opening')+this.getDocument().steps.map((step,index)=>`<section class="step-share-section"><button class="collapse-step" data-collapse="${escapeHtml(step.id)}" aria-expanded="${!company.collapsed[step.id]}">${company.collapsed[step.id]?'▸':'▾'} Step ${index+1}: ${escapeHtml(step.title)}</button><div ${company.collapsed[step.id]?'hidden':''}>${this.table(`Step ${index+1} Movement`,company.movements[step.id],true,step.id)}${this.table(`Step ${index+1} Resulting Position`,resultingValues(company,this.getDocument().steps,index),false,step.id)}</div></section>`).join(''):'<p>Add a company to begin.</p>'}`;this.bindGrid(); }
+  render() {
+    const excel = this.excel,
+      company = this.company;
+    this.root.innerHTML = `<div class="company-tabs" role="tablist">${excel.companies.map((item) => `<button role="tab" aria-selected="${item.id === excel.selectedCompanyId}" data-company-id="${escapeHtml(item.id)}">${escapeHtml(item.name)}</button>`).join('')}</div>${
+      company
+        ? this.table('Opening Position', company.opening, 'opening') +
+          this.getDocument()
+            .steps.map(
+              (step, index) =>
+                `<section class="step-share-section"><button class="collapse-step" data-collapse="${escapeHtml(step.id)}" aria-expanded="${!company.collapsed[step.id]}">${company.collapsed[step.id] ? '▸' : '▾'} Step ${index + 1}: ${escapeHtml(step.title)}</button><div ${company.collapsed[step.id] ? 'hidden' : ''}>${this.table(`Step ${index + 1} Movement`, company.movements[step.id], true, step.id)}${this.table(`Step ${index + 1} Resulting Position`, resultingValues(company, this.getDocument().steps, index), false, step.id)}</div></section>`,
+            )
+            .join('')
+        : '<p>Add a company to begin.</p>'
+    }`;
+    this.bindGrid();
+  }
   bindGrid() {
-    this.root.querySelectorAll('[data-company-id]').forEach(button => button.onclick = () => this.mutate(excel => excel.selectedCompanyId = button.dataset.companyId));
-    this.root.querySelectorAll('[data-collapse]').forEach(button => button.onclick = () => this.mutate(excel => {
-      const company = excel.companies.find(item => item.id === excel.selectedCompanyId);
-      company.collapsed[button.dataset.collapse] = !company.collapsed[button.dataset.collapse];
-    }));
-    this.root.querySelectorAll('[data-holder-id]').forEach(element => element.onfocus = () => {
-      this.focus.holderId = element.dataset.holderId;
-    });
-    this.root.querySelectorAll('[data-group-id]').forEach(element => element.onfocus = () => {
-      this.focus.groupId = element.dataset.groupId;
-      this.focus.classId = element.dataset.classId;
-    });
-    this.root.querySelectorAll(gridSelector).forEach(target => target.onkeydown = event => this.keydown(event, target));
-    this.root.querySelectorAll('td[data-editable=true]').forEach(cell => {
+    this.root
+      .querySelectorAll('[data-company-id]')
+      .forEach(
+        (button) =>
+          (button.onclick = () =>
+            this.mutate(
+              (excel) => (excel.selectedCompanyId = button.dataset.companyId),
+            )),
+      );
+    this.root.querySelectorAll('[data-collapse]').forEach(
+      (button) =>
+        (button.onclick = () =>
+          this.mutate((excel) => {
+            const company = excel.companies.find(
+              (item) => item.id === excel.selectedCompanyId,
+            );
+            company.collapsed[button.dataset.collapse] =
+              !company.collapsed[button.dataset.collapse];
+          })),
+    );
+    this.root.querySelectorAll('[data-holder-id]').forEach(
+      (element) =>
+        (element.onfocus = () => {
+          this.focus.holderId = element.dataset.holderId;
+        }),
+    );
+    this.root.querySelectorAll('[data-group-id]').forEach(
+      (element) =>
+        (element.onfocus = () => {
+          this.focus.groupId = element.dataset.groupId;
+          this.focus.classId = element.dataset.classId;
+        }),
+    );
+    this.root
+      .querySelectorAll(gridSelector)
+      .forEach(
+        (target) => (target.onkeydown = (event) => this.keydown(event, target)),
+      );
+    this.root.querySelectorAll('td[data-editable=true]').forEach((cell) => {
       cell.onfocus = () => {
-        const header = [...cell.closest('table').querySelectorAll('[data-class-id]')]
-          .find(item => item.dataset.classId === cell.dataset.classId);
-        this.focus = {holderId:cell.dataset.holderId, classId:cell.dataset.classId, groupId:header?.dataset.groupId};
+        const header = [
+          ...cell.closest('table').querySelectorAll('[data-class-id]'),
+        ].find((item) => item.dataset.classId === cell.dataset.classId);
+        this.focus = {
+          holderId: cell.dataset.holderId,
+          classId: cell.dataset.classId,
+          groupId: header?.dataset.groupId,
+        };
         if (cell.textContent.trim() === '0') cell.textContent = '';
       };
       cell.onblur = () => {
@@ -2610,43 +4210,98 @@ class ExcelEditor {
         this.commitCell(cell);
       };
     });
-    const companyOf = excel => excel.companies.find(item => item.id === excel.selectedCompanyId);
-    this.root.querySelectorAll('[data-holder-name]').forEach(input => input.onchange = () => this.mutate(excel => {
-      const holder = companyOf(excel).shareholders.find(item => item.id === input.dataset.holderId);
-      if (holder) holder.name = input.value;
-    }));
-    this.root.querySelectorAll('[data-holder-type]').forEach(select => select.onchange = () => this.mutate(excel => {
-      const holder = companyOf(excel).shareholders.find(item => item.id === select.dataset.holderId);
-      if (holder) holder.type = select.value;
-    }));
-    this.root.querySelectorAll('[data-group-name]').forEach(input => input.onchange = () => this.mutate(excel => {
-      const group = companyOf(excel).groups.find(item => item.id === input.closest('[data-group-id]').dataset.groupId);
-      if (group) group.name = input.value;
-    }));
-    this.root.querySelectorAll('[data-class-label]').forEach(input => input.onchange = () => this.mutate(excel => {
-      const header = input.closest('[data-class-id]');
-      const shareClass = classesOf(companyOf(excel)).find(item => item.id === header.dataset.classId);
-      if (shareClass) shareClass.label = input.value;
-    }));
+    const companyOf = (excel) =>
+      excel.companies.find((item) => item.id === excel.selectedCompanyId);
+    this.root.querySelectorAll('[data-holder-name]').forEach(
+      (input) =>
+        (input.onchange = () =>
+          this.mutate((excel) => {
+            const holder = companyOf(excel).shareholders.find(
+              (item) => item.id === input.dataset.holderId,
+            );
+            if (holder) holder.name = input.value;
+          })),
+    );
+    this.root.querySelectorAll('[data-holder-type]').forEach(
+      (select) =>
+        (select.onchange = () =>
+          this.mutate((excel) => {
+            const holder = companyOf(excel).shareholders.find(
+              (item) => item.id === select.dataset.holderId,
+            );
+            if (holder) holder.type = select.value;
+          })),
+    );
+    this.root.querySelectorAll('[data-group-name]').forEach(
+      (input) =>
+        (input.onchange = () =>
+          this.mutate((excel) => {
+            const group = companyOf(excel).groups.find(
+              (item) =>
+                item.id === input.closest('[data-group-id]').dataset.groupId,
+            );
+            if (group) group.name = input.value;
+          })),
+    );
+    this.root.querySelectorAll('[data-class-label]').forEach(
+      (input) =>
+        (input.onchange = () =>
+          this.mutate((excel) => {
+            const header = input.closest('[data-class-id]');
+            const shareClass = classesOf(companyOf(excel)).find(
+              (item) => item.id === header.dataset.classId,
+            );
+            if (shareClass) shareClass.label = input.value;
+          })),
+    );
   }
-  commitCell(cell) { if(cell.contentEditable!=='true')return;const value=parseShares(cell.textContent);if(value===null){this.report('Only whole integers are permitted.');this.render();return;}this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId),values=cell.dataset.stepId?company.movements[cell.dataset.stepId]:company.opening;values[cellKey(cell.dataset.holderId,cell.dataset.classId)]=value;}); }
+  commitCell(cell) {
+    if (cell.contentEditable !== 'true') return;
+    const value = parseShares(cell.textContent);
+    if (value === null) {
+      this.report('Only whole integers are permitted.');
+      this.render();
+      return;
+    }
+    this.mutate((excel) => {
+      const company = excel.companies.find(
+          (item) => item.id === excel.selectedCompanyId,
+        ),
+        values = cell.dataset.stepId
+          ? company.movements[cell.dataset.stepId]
+          : company.opening;
+      values[cellKey(cell.dataset.holderId, cell.dataset.classId)] = value;
+    });
+  }
   keydown(event, target) {
     if (event.key === 'Escape' && target.matches('td[data-editable=true]')) {
       event.preventDefault();
       this.render();
       return;
     }
-    const navigationKeys = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Enter', 'Tab'];
+    const navigationKeys = [
+      'ArrowUp',
+      'ArrowDown',
+      'ArrowLeft',
+      'ArrowRight',
+      'Enter',
+      'Tab',
+    ];
     if (!navigationKeys.includes(event.key)) return;
 
     const table = target.closest('table');
-    const targets = [...table.querySelectorAll(gridSelector)].filter(item => (
-      !item.matches('td[data-editable=false]')
-    ));
-    const destination = gridDestination(targets, target, event.key, event.shiftKey);
+    const targets = [...table.querySelectorAll(gridSelector)].filter(
+      (item) => !item.matches('td[data-editable=false]'),
+    );
+    const destination = gridDestination(
+      targets,
+      target,
+      event.key,
+      event.shiftKey,
+    );
     const destinationPosition = {
-      row:destination.dataset.gridRow,
-      column:destination.dataset.gridColumn
+      row: destination.dataset.gridRow,
+      column: destination.dataset.gridColumn,
     };
     const tables = [...this.root.querySelectorAll('.share-table table')];
     const tableIndex = tables.indexOf(table);
@@ -2658,149 +4313,2047 @@ class ExcelEditor {
     } else if (target.matches('[data-holder-name], [data-class-label]')) {
       target.onchange();
     }
-    const currentTable = this.root.querySelectorAll('.share-table table')[tableIndex] || table;
-    currentTable.querySelector(`${gridSelector}[data-grid-row="${destinationPosition.row}"][data-grid-column="${destinationPosition.column}"]`)?.focus();
+    const currentTable =
+      this.root.querySelectorAll('.share-table table')[tableIndex] || table;
+    currentTable
+      .querySelector(
+        `${gridSelector}[data-grid-row="${destinationPosition.row}"][data-grid-column="${destinationPosition.column}"]`,
+      )
+      ?.focus();
   }
 }
 
 
-let initial=seedDocument,loadedRevision=0;try{const draft=readDraft();initial=snapshotFromLocation()||draft?.document||readRecovery()?.document||seedDocument;loadedRevision=draft?.revision||0}catch(error){setTimeout(()=>alert(error.message),0)}const history = new History(initial); let state = history.checkout(); let currentPage = 1;let dirty=false,autosaveTimer=null;
-const editorSelection = { activeGroupId:null, activeGroupType:null, activeStepId:null, activeBlockId:null, container:null, row:null, column:null, rowId:null, columnId:null, cellId:null, blockType:null, offsets:null, restoreFocus:false };
-let activeEditor='steps', excelController=null;
-const pending = new Map(), pendingStepTitles = new Map(); const $ = s => document.querySelector(s); const esc = x => String(x).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
-const runText = runs => (runs||[]).map(r=>r.text).join('');
-const runsHTML = runs => (runs||[]).map(r=>{let text=esc(r.text).replace(/\n/g,'<br>');if(r.link)text=`<a href="${esc(r.link.href)}">${text}</a>`;return r.highlight?`<mark>${text}</mark>`:text}).join('');
-const editableRuns = (runs, attrs='') => `<span class="editable-runs" contenteditable="true" spellcheck="true" ${attrs}>${runsHTML(runs)}</span>`;
-const allGroups = () => [...state.sections,...state.steps,...state.appendices];
-const findBlock = id => { for(const group of allGroups()){const block=group.blocks.find(x=>x.id===id);if(block)return {group,block};} return {}; };
-const selectedEditableGroup = () => (editorSelection.activeGroupType==='appendix'?state.appendices:state.steps).find(x=>x.id===editorSelection.activeGroupId);
-const appendixLabel = index => `Appendix ${String.fromCharCode(65+index)}`;
-
-function header(){const x=document.createElement('header');x.className='page-header';x.innerHTML=`<span class="header-brand">UBTA</span><span class="header-details">${esc(state.meta.clientName)} · ${esc(state.meta.projectTitle)} · ${esc(state.meta.version)}</span>`;return x}
-function sheet(kind){const x=document.createElement('section');x.className=`sheet-source ${kind}`;x.append(header());return x}
-function footer(x,n,total){const f=document.createElement('footer');f.className='page-footer';f.textContent=`Page ${n} of ${total}`;x.append(f)}
-function blockElement(block){const x=document.createElement('div');x.className='editable-block';x.dataset.blockId=block.id;x.dataset.type=block.type;x.dataset.level=block.level||'';x.draggable=false;x.tabIndex=-1;
-  if(['heading','paragraph'].includes(block.type))x.innerHTML=editableRuns(block.runs,'data-container="block"');
-  else if(block.type.endsWith('List')){x.classList.add('list-block');x.dataset.listType=block.type;x.innerHTML=renderList(block,runsHTML,esc)}
-  else if(block.type==='table'){x.classList.add('table-block');recalculateTableTotals(block);const cellHTML=(cell,row,ri,ci)=>{const format=tableColumnFormat(block.columns[ci]),numeric=format!=='text',value=runText(cell.runs),parsed=numeric?parseTableNumber(value):null,display=parsed===null?value:formatTableNumber(parsed,format),attrs=`data-container="cell" data-row="${ri}" data-column="${ci}" data-row-id="${esc(row.id)}" data-column-id="${esc(block.columns[ci].id)}" data-cell-id="${esc(cell.id)}"`;return `<td class="format-${format}">${row.isTotal&&numeric?`<output ${attrs}>${esc(display)}</output>`:editableRuns(numeric?[{text:display}]:cell.runs,attrs)}</td>`};x.innerHTML=`<table><caption>${editableRuns(block.captionRuns,'data-container="caption"')}</caption><colgroup>${block.columns.map(c=>`<col style="width:${c.width}%">`).join('')}</colgroup><thead><tr>${block.columns.map((c,i)=>`<th class="format-${tableColumnFormat(c)}">${editableRuns(c.headingRuns,`data-container="heading" data-column="${i}"`)}</th>`).join('')}</tr></thead><tbody>${block.rows.map((r,ri)=>`<tr class="${r.isTotal?'total-row':''}" data-row="${ri}">${r.cells.map((c,ci)=>cellHTML(c,r,ri,ci)).join('')}</tr>`).join('')}</tbody></table>`}
-  else {x.classList.add('image-block');x.innerHTML=block.src?`<figure><img src="${esc(block.src)}" alt="${esc(block.alt||'')}" style="width:${block.width}%"><figcaption>${editableRuns(block.captionRuns,'data-container="image-caption"')}</figcaption></figure>`:'<p class="image-error">Image unavailable.</p>'}
-  x.insertAdjacentHTML('afterbegin',`<div class="block-controls" contenteditable="false"><button type="button" data-block-move="before" aria-label="Move block before">↑</button><button type="button" data-block-move="after" aria-label="Move block after">↓</button><button type="button" class="delete-block" data-block-delete aria-label="Delete ${blockTypeLabel(block.type)}">Delete</button></div>`);return x
+let initial = seedDocument,
+  loadedRevision = 0;
+try {
+  const draft = readDraft();
+  initial =
+    snapshotFromLocation() ||
+    draft?.document ||
+    readRecovery()?.document ||
+    seedDocument;
+  loadedRevision = draft?.revision || 0;
+} catch (error) {
+  setTimeout(() => alert(error.message), 0);
 }
-function groupSheet(group,title,kind){const x=sheet(kind);x.id=stableAnchor(group);x.tabIndex=-1;if(['step','appendix'].includes(kind)){x.dataset.editableGroupId=group.id;x.dataset.groupType=kind;if(group.id===editorSelection.activeGroupId)x.classList.add('is-selected');x.innerHTML+=`<div class="step-heading"><div class="step-label">${esc(kind==='step'?(title.match(/^Step \d+/)?.[0]||''):title.split('. ')[0])}</div><input class="step-title" data-group-title="${group.id}" value="${esc(group.title)}" aria-label="${kind==='step'?'Step':'Appendix'} title"><div class="step-title-print" aria-hidden="true">${esc(group.title)}</div></div>`}else x.innerHTML+=`<h1 class="section-title">${esc(title)}</h1>`;const body=document.createElement('div');body.className='document-body';group.blocks.forEach(b=>body.append(blockElement(b)));x.append(body);return x}
-function cover(){const x=sheet('cover');x.innerHTML+=`<div class="cover-kicker">${esc(state.meta.documentType)} · ${esc(state.meta.status)}</div><h1>${esc(state.meta.clientName)}</h1><h2>${esc(state.meta.projectTitle)}</h2><p>${esc(state.meta.subtitle)}</p><p>${esc(state.meta.date)} · ${esc(state.meta.adviser)} · ${esc(state.meta.version)}</p>`;return x}
-function contentsEntries(){return [...state.sections.map(group=>({group,type:'section',label:group.title})),...state.steps.map((group,index)=>({group,type:'step',label:`Step ${index+1}. ${group.title}`})),...state.appendices.map((group,index)=>({group,type:'appendix',label:`${appendixLabel(index)}. ${group.title}`}))]}
-function contents(map={}){const x=sheet('contents'),entries=contentsEntries();x.innerHTML+='<h1 class="doc-title">Contents</h1><ol class="toc">'+entries.map(({group,type,label})=>`<li class="toc-${type} ${hasReview(group)?'toc-review':''}"><a href="#${stableAnchor(group)}">${esc(label)}</a><span class="dots"></span><span class="toc-page">${map[stableAnchor(group)]||'—'}</span></li>`).join('')+'</ol>';return x}
-function captureSelection(){const offsets=containedSelectionOffsets(activeEditable(),getSelection(),document);if(offsets)editorSelection.offsets=offsets}
-function captureView(){captureSelection();return {currentPage,scrollX:window.scrollX,scrollY:window.scrollY,selection:structuredClone(editorSelection)}}
-async function restoreView(view){setCurrentPage(view.currentPage,{scroll:false,focus:false});Object.assign(editorSelection,view.selection);if(editorSelection.restoreFocus)restoreTextSelection(activeEditable(),editorSelection.offsets);window.scrollTo(view.scrollX,view.scrollY)}
-async function paginate({isCurrent}){const source=document.createElement('main'),staging=document.createElement('div');staging.className='pagedjs_pages';source.append(cover(),contents(window.__pageMap||{}));state.sections.forEach(g=>source.append(groupSheet(g,g.title,'section')));state.steps.forEach((g,i)=>source.append(groupSheet(g,`Step ${i+1}. ${g.title}`,'step')));state.appendices.forEach((g,i)=>source.append(groupSheet(g,`${appendixLabel(i)}. ${g.title}`,'appendix')));await new Paged.Previewer().preview(source,[],staging);if(!isCurrent())return false;const pages=[...staging.children],map={};pages.forEach((p,i)=>{footer(p.querySelector('.sheet-source'),i+1,pages.length);p.dataset.pageNumber=String(i+1);p.querySelectorAll('[id^=anchor-]').forEach(a=>map[a.id]??=i+1);if(p.dataset.anchorId)map[p.dataset.anchorId]??=i+1});if(!isCurrent())return false;window.__pageMap=map;disconnectPageObserver();$('#preview').replaceChildren(...pages);bindEditing();observePages();updateControls();setCurrentPage(currentPage,{scroll:false,focus:false});$('#total').textContent=pages.length;rebuildPageJump(pages);return true}
-const repagination=new RepaginationScheduler(paginate,{capture:captureView,restore:restoreView});
-const navigationHistory=new NavigationHistory();
-const render=({immediate=true}={})=>repagination.request({immediate});
+const history = new History(initial);
+let state = history.checkout();
+let currentPage = 1;
+let dirty = false,
+  autosaveTimer = null;
+const editorSelection = {
+  activeGroupId: null,
+  activeGroupType: null,
+  activeStepId: null,
+  activeBlockId: null,
+  container: null,
+  row: null,
+  column: null,
+  rowId: null,
+  columnId: null,
+  cellId: null,
+  blockType: null,
+  offsets: null,
+  restoreFocus: false,
+};
+let activeEditor = 'steps',
+  excelController = null;
+const pending = new Map(),
+  pendingStepTitles = new Map();
+const $ = (s) => document.querySelector(s);
+const esc = (x) =>
+  String(x).replace(
+    /[&<>"']/g,
+    (c) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[
+        c
+      ],
+  );
+const runText = (runs) => (runs || []).map((r) => r.text).join('');
+const runsHTML = (runs) =>
+  (runs || [])
+    .map((r) => {
+      let text = esc(r.text).replace(/\n/g, '<br>');
+      if (r.link) text = `<a href="${esc(r.link.href)}">${text}</a>`;
+      return r.highlight ? `<mark>${text}</mark>` : text;
+    })
+    .join('');
+const editableRuns = (runs, attrs = '') =>
+  `<span class="editable-runs" contenteditable="true" spellcheck="true" ${attrs}>${runsHTML(runs)}</span>`;
+const allGroups = () => [
+  ...state.sections,
+  ...state.steps,
+  ...state.appendices,
+];
+const findBlock = (id) => {
+  for (const group of allGroups()) {
+    const block = group.blocks.find((x) => x.id === id);
+    if (block) return { group, block };
+  }
+  return {};
+};
+const selectedEditableGroup = () =>
+  (editorSelection.activeGroupType === 'appendix'
+    ? state.appendices
+    : state.steps
+  ).find((x) => x.id === editorSelection.activeGroupId);
+const appendixLabel = (index) => `Appendix ${String.fromCharCode(65 + index)}`;
 
-function activeEditable(){const id=editorSelection.activeBlockId;if(!id)return editorSelection.activeGroupId?document.querySelector(`[data-group-title="${editorSelection.activeGroupId}"]`):null;const block=document.querySelector(`[data-block-id="${id}"]`);if(!block)return null;const c=editorSelection.container;if(c==='block')return block.querySelector('[data-container=block]');if(c==='item')return block.querySelector(`li[data-container="item"][data-item-id="${editorSelection.itemId}"]`);if(c==='caption')return block.querySelector('[data-container=caption]');if(c==='image-caption')return block.querySelector('[data-container=image-caption]');if(c==='heading')return block.querySelector(`[data-container=heading][data-column="${editorSelection.column}"]`);if(c==='cell')return block.querySelector(`[data-container=cell][data-cell-id="${CSS.escape(editorSelection.cellId||'')}"]`)||block.querySelector(`[data-container=cell][data-row="${editorSelection.row}"][data-column="${editorSelection.column}"]`);return block}
-function setActive(target){const group=target.closest('[data-editable-group-id]');if(group){editorSelection.activeGroupId=group.dataset.editableGroupId;editorSelection.activeGroupType=group.dataset.groupType;editorSelection.activeStepId=group.dataset.groupType==='step'?group.dataset.editableGroupId:null}const block=target.closest('[data-block-id]'),item=target.closest('li[data-container="item"]');editorSelection.activeBlockId=block?.dataset.blockId||null;editorSelection.blockType=block?.dataset.type||null;editorSelection.container=item?.dataset.container||target.dataset.container||(['heading','paragraph'].includes(editorSelection.blockType)?'block':null);editorSelection.itemId=item?.dataset.itemId||null;editorSelection.row=target.dataset.row??null;editorSelection.column=target.dataset.column??null;editorSelection.rowId=target.dataset.rowId??null;editorSelection.columnId=target.dataset.columnId??null;editorSelection.cellId=target.dataset.cellId??null;editorSelection.restoreFocus=true;document.querySelectorAll('[data-editable-group-id]').forEach(x=>x.classList.toggle('is-selected',x.dataset.editableGroupId===editorSelection.activeGroupId));updateControls()}
-function syncElement(el, record=true){if(!el?.isConnected)return false;const blockEl=el.closest('[data-block-id]'), found=findBlock(blockEl?.dataset.blockId);if(!found.block)return false;const before=structuredClone(state);const b=found.block,c=el.dataset.container;if(c==='item'){const i=b.items.find(x=>x.id===el.dataset.itemId);if(i)i.runs=runsFromElement(el)}else if(c==='caption')b.captionRuns=runsFromElement(el);else if(c==='image-caption')b.captionRuns=runsFromElement(el);else if(c==='heading')b.columns[+el.dataset.column].headingRuns=runsFromElement(el);else if(c==='cell'){captureSelection();const row=b.rows.find(r=>r.id===el.dataset.rowId)||b.rows[+el.dataset.row],columnIndex=b.columns.findIndex(column=>column.id===el.dataset.columnId),cell=row?.cells.find(cell=>cell.id===el.dataset.cellId)||row?.cells[columnIndex<0?+el.dataset.column:columnIndex];if(cell)cell.runs=runsFromElement(el);editorSelection.cellId=cell?.id||editorSelection.cellId;}else {const peers=[...document.querySelectorAll(`[data-block-id="${b.id}"] [data-container="block"]`)];b.runs=peers.length>1?peers.flatMap(runsFromElement):runsFromElement(el)}state=normaliseDocument(state);if(record)history.commit(state);else history.replace(state);const changed=JSON.stringify(before)!==JSON.stringify(state);if(changed)markDirty();return changed}
-function schedule(el){const key=targetKey(el),old=pending.get(key);if(old)clearTimeout(old.timer);pending.set(key,{el,timer:setTimeout(()=>{const p=pending.get(key);if(!p||p.el!==el||!el.isConnected)return;syncElement(el);pending.delete(key);updateControls();render({immediate:false})},450)})}
-const targetKey=el=>[el.closest('[data-block-id]')?.dataset.blockId,el.dataset.container,el.dataset.itemId,el.dataset.row,el.dataset.column].join(':');
-function flushTarget(el,record=true){const key=targetKey(el),p=pending.get(key);if(!p)return;clearTimeout(p.timer);pending.delete(key);if(p.el.isConnected)syncElement(p.el,record)}
-function syncStepTitle(el,{renderAfter=true}={}){const pendingTitle=pendingStepTitles.get(el.dataset.groupTitle);if(pendingTitle)clearTimeout(pendingTitle.timer);pendingStepTitles.delete(el.dataset.groupTitle);if(!el.isConnected)return false;const group=allGroups().find(x=>x.id===el.dataset.groupTitle),title=el.value.trim()||'Untitled';if(!group||group.title===title)return false;group.title=title;history.commit(state);markDirty();updateControls();if(renderAfter)render({immediate:false});return true}
-function flushAll(record=true){[...pending.values()].forEach(p=>{clearTimeout(p.timer);if(p.el.isConnected)syncElement(p.el,record)});pending.clear();[...pendingStepTitles.values()].forEach(p=>syncStepTitle(p.el,{renderAfter:false}))}
-const hasPendingInputs=()=>pending.size>0||pendingStepTitles.size>0;
-function markDirty(){dirty=true;const indicator=$('#save-state');if(indicator){indicator.textContent='Unsaved changes';indicator.className='save-state dirty'}clearTimeout(autosaveTimer);autosaveTimer=setTimeout(()=>persistDraft(),1500)}
-function commit(mutator,{focus=true}={}){flushAll();const before=structuredClone(state);mutator();state=normaliseDocument(state);history.replace(before);history.commit(state);state=history.checkout();markDirty();editorSelection.restoreFocus=focus;return render({restore:focus})}
-function applyDocumentOperation(result,{focus=true}={}){if(!result?.changed)return false;const before=state;history.replace(before);history.commit(result.document);state=history.checkout();markDirty();if(result.selectedGroupId){editorSelection.activeGroupId=result.selectedGroupId;editorSelection.activeGroupType=state.steps.some(x=>x.id===result.selectedGroupId)?'step':'appendix';editorSelection.activeStepId=editorSelection.activeGroupType==='step'?result.selectedGroupId:null}if(result.selectedBlockId)editorSelection.activeBlockId=result.selectedBlockId;if('rowIndex'in result)editorSelection.row=result.rowIndex;if('columnIndex'in result)editorSelection.column=result.columnIndex;refreshSelectedTableCell(result);editorSelection.restoreFocus=focus;render({restore:focus});return true}
-function refreshSelectedTableCell(result){if(!('rowIndex'in result)&&!('columnIndex'in result))return;const {block}=findBlock(editorSelection.activeBlockId);if(block?.type!=='table')return;const row=block.rows[Number(editorSelection.row)],column=block.columns[Number(editorSelection.column)];editorSelection.rowId=row?.id||null;editorSelection.columnId=column?.id||null;editorSelection.cellId=row?.cells?.[Number(editorSelection.column)]?.id||null}
-function selectOperationResult(result,type){const group=state.steps.find(x=>x.id===result.selectedGroupId)||state.appendices.find(x=>x.id===result.selectedGroupId);if(!group)return;selectGroup(group,state.steps.includes(group)?'step':'appendix',{blockId:result.selectedBlockId});Object.assign(editorSelection,{activeBlockId:result.selectedBlockId||null,blockType:type||result.selectedBlockType||null,container:type==='table'?'cell':type?.endsWith('List')?'item':type==='image'?'image-caption':'block',row:type==='table'?0:null,column:type==='table'?0:null,rowId:type==='table'?group.blocks.find(b=>b.id===result.selectedBlockId)?.rows?.[0]?.id:null,columnId:type==='table'?group.blocks.find(b=>b.id===result.selectedBlockId)?.columns?.[0]?.id:null,cellId:type==='table'?group.blocks.find(b=>b.id===result.selectedBlockId)?.rows?.[0]?.cells?.[0]?.id:null,offsets:[0,0],restoreFocus:true})}
-
-function bindEditing(){document.querySelectorAll('[data-editable-group-id]').forEach(x=>{x.addEventListener('pointerdown',e=>{if(e.target.closest('.editable-block,.step-heading,button,input,select,textarea,[contenteditable="true"]'))setActive(e.target)});x.addEventListener('click',blankStepClick)});document.querySelectorAll('[contenteditable=true]').forEach(el=>{el.addEventListener('focusin',()=>setActive(el));el.addEventListener('input',()=>{repagination.cancel();schedule(el)});el.addEventListener('blur',()=>{flushTarget(el);editorSelection.restoreFocus=false});el.addEventListener('paste',e=>insertPlainText(e,document))});
- document.querySelectorAll('[data-group-title]').forEach(el=>{const sync=()=>syncStepTitle(el);el.addEventListener('focusin',()=>setActive(el));el.addEventListener('input',()=>{repagination.cancel();const old=pendingStepTitles.get(el.dataset.groupTitle);if(old)clearTimeout(old.timer);pendingStepTitles.set(el.dataset.groupTitle,{el,timer:setTimeout(sync,450)})});el.addEventListener('blur',()=>{sync();editorSelection.restoreFocus=false});el.addEventListener('keydown',e=>{if(e.key==='Enter'){e.preventDefault();el.blur()}else if(e.key==='Tab')editorSelection.restoreFocus=false})});
- document.querySelectorAll('.list-block > :is(ol,ul) > li[data-container="item"]').forEach(el=>{el.addEventListener('keydown',listKeydown);el.addEventListener('blur',event=>listBlur(event,el))});document.querySelectorAll('[data-list-append]').forEach(el=>el.addEventListener('click',appendListItem));document.querySelectorAll('[data-type="heading"] > [data-container="block"]').forEach(el=>el.addEventListener('keydown',headingEnter));document.querySelectorAll('[data-container=cell]').forEach(el=>el.addEventListener('keydown',tableTab));document.querySelectorAll('[data-block-move]').forEach(b=>b.onclick=()=>moveBlock(b.closest('[data-block-id]').dataset.blockId,b.dataset.blockMove));document.querySelectorAll('[data-block-delete]').forEach(b=>b.onclick=()=>deleteBlock(b.closest('[data-block-id]').dataset.blockId));document.querySelectorAll('.toc a').forEach(a=>a.onclick=e=>{e.preventDefault();navigateToAnchor(a.getAttribute('href').slice(1))})}
-function headingEnter(e){if(e.key!=='Enter'||e.shiftKey)return;e.preventDefault();const el=e.currentTarget;flushTarget(el);const {group,block}=findBlock(el.closest('[data-block-id]').dataset.blockId);if(!group||block?.type!=='heading')return;const id=newId('block'),index=group.blocks.indexOf(block);const result=insertBlockOperation(state,group.id,{id,type:'paragraph',runs:[]},index+1);if(applyDocumentOperation(result))Object.assign(editorSelection,{activeBlockId:id,blockType:'paragraph',container:'block',itemId:null,row:null,column:null,offsets:[0,0]})}
-function listKeydown(e){if(e.key==='Enter')return listEnter(e);const el=e.currentTarget,{block}=findBlock(el.closest('[data-block-id]').dataset.blockId),index=block?.items?.findIndex(item=>item.id===el.dataset.itemId),offsets=getOffsets(el),atBoundary=e.key==='ArrowUp'?offsets?.[0]===0:offsets?.[1]===runText(block?.items?.[index]?.runs||[]).length;if((e.key==='ArrowUp'||e.key==='ArrowDown')&&!e.shiftKey&&!e.ctrlKey&&!e.metaKey&&!e.altKey&&offsets?.[0]===offsets?.[1]&&atBoundary){const target=index+(e.key==='ArrowUp'?-1:1);if(target<0||target>=block.items.length)return;e.preventDefault();const offset=e.key==='ArrowUp'?runText(block.items[target].runs).length:0;editorSelection.itemId=block.items[target].id;editorSelection.offsets=[offset,offset];restoreTextSelection(el.parentElement.children[target],editorSelection.offsets);return}if(e.key!=='Backspace')return;flushTarget(el);if(!Number.isInteger(index)||index<1||runText(block.items[index].runs))return;e.preventDefault();commit(()=>{const target=removeEmptyListItem(block,index);editorSelection.itemId=target.itemId;editorSelection.offsets=[target.offset,target.offset]})}
-function listBlur(event,el){const blockEl=el.closest('[data-block-id]'),next=event.relatedTarget;if(next?.closest?.(`[data-block-id="${blockEl?.dataset.blockId}"] [data-item-id="${el.dataset.itemId}"]`))return;queueMicrotask(()=>{if(!el.isConnected)return;const {block}=findBlock(blockEl.dataset.blockId),index=block?.items?.findIndex(item=>item.id===el.dataset.itemId);if(block?.items.length>1&&index>=0&&!runText(block.items[index].runs)){commit(()=>{block.items.splice(index,1);const target=block.items[Math.max(0,index-1)];editorSelection.itemId=target.id;editorSelection.offsets=[runText(target.runs).length,runText(target.runs).length]},{focus:false})}})}
-function appendListItem(event){event.preventDefault();event.stopPropagation();flushAll();const blockId=event.currentTarget.closest('[data-block-id]').dataset.blockId,{block}=findBlock(blockId);if(!block?.items)return;const id=newId('item');Object.assign(editorSelection,{activeBlockId:blockId,blockType:block.type,container:'item',itemId:id,offsets:[0,0],restoreFocus:true});commit(()=>block.items.push({id,level:block.items.at(-1)?.level||1,runs:[]}))}
-function listEnter(e){if(e.key!=='Enter')return;e.preventDefault();const el=e.currentTarget;flushTarget(el);const {block}=findBlock(el.closest('[data-block-id]').dataset.blockId),index=block.items.findIndex(i=>i.id===el.dataset.itemId);const offsets=getOffsets(el)||[0,0],text=runText(block.items[index].runs);if(!text.trim()){commit(()=>{block.items.splice(index,1);if(!block.items.length){block.type='paragraph';block.runs=[];delete block.items}});return}const id=newId('item');commit(()=>{const item=block.items[index],[before,after]=splitListRuns(item.runs,offsets[0]);item.runs=before;block.items.splice(index+1,0,{id,level:item.level,runs:after});editorSelection.itemId=id;editorSelection.offsets=[0,0]})}
-function tableTab(e){if(e.key!=='Tab')return;const cells=[...document.querySelectorAll(`[data-block-id="${editorSelection.activeBlockId}"] [data-container=cell]`)],i=cells.indexOf(e.currentTarget);if(e.shiftKey||i<cells.length-1)return;e.preventDefault();flushTarget(e.currentTarget);const {block}=findBlock(editorSelection.activeBlockId);tableMutation('addRow')}
-const getOffsets=el=>containedSelectionOffsets(el,getSelection(),document);
-function resolveRuns(){const {block}=findBlock(editorSelection.activeBlockId);if(!block)return null;if(editorSelection.container==='block')return block.runs;if(editorSelection.container==='item')return block.items.find(x=>x.id===editorSelection.itemId)?.runs;if(editorSelection.container==='caption'||editorSelection.container==='image-caption')return block.captionRuns;if(editorSelection.container==='heading')return block.columns[editorSelection.column]?.headingRuns;if(editorSelection.container==='cell')return block.rows[editorSelection.row]?.cells[editorSelection.column]?.runs;return null}
-function replaceResolved(runs){const {block}=findBlock(editorSelection.activeBlockId);if(editorSelection.container==='block')block.runs=runs;else if(editorSelection.container==='item')block.items.find(x=>x.id===editorSelection.itemId).runs=runs;else if(['caption','image-caption'].includes(editorSelection.container))block.captionRuns=runs;else if(editorSelection.container==='heading')block.columns[editorSelection.column].headingRuns=runs;else if(editorSelection.container==='cell')block.rows[editorSelection.row].cells[editorSelection.column].runs=runs}
-function transformSelection(kind,value,{useCaptured=false}={}){flushAll();if(!useCaptured){const offsets=getOffsets(activeEditable());if(offsets)editorSelection.offsets=offsets}const runs=resolveRuns();if(!runs||!editorSelection.offsets)return false;if(kind==='highlight'&&editorSelection.offsets[0]===editorSelection.offsets[1])editorSelection.offsets=[0,runText(runs).length];commit(()=>replaceResolved(transformRuns(runs,editorSelection.offsets,kind,value)));return true}
-function defaultInsertionContext(){const group=selectedEditableGroup();return group?{groupId:group.id,referenceBlockId:editorSelection.activeBlockId,position:'after'}:null}
-function insertBlock(type,context=defaultInsertionContext(),headingLevel=2){if(typeof type!=='string'||!['paragraph','heading','bulletList','numberList','table'].includes(type))return false;const group=[...state.steps,...state.appendices].find(x=>x.id===context?.groupId);if(!group)return false;const index=insertionIndex(group,context);if(index<0)return false;const id=newId('block');let block={id,type,runs:[]};if(type==='heading')block.level=Math.min(4,Math.max(1,Number(headingLevel)||2));if(type.endsWith('List'))block={id,type,items:[{id:newId('item'),level:1,runs:[]}]};if(type==='table')block={id,type,captionRuns:[{text:'Table caption'}],columns:[{id:newId('column'),headingRuns:[{text:'Column 1'}],width:50},{id:newId('column'),headingRuns:[{text:'Column 2'}],width:50}],rows:[{id:newId('row'),cells:[{id:newId('cell'),runs:[]},{id:newId('cell'),runs:[]}]}]};const result=insertBlockOperation(state,group.id,block,index);selectOperationResult(result,type);editorSelection.restoreFocus=true;if(!applyDocumentOperation(result))return false;return true}
-function moveBlock(id,direction){flushAll();const result=moveBlockOperation(state,id,direction);if(!applyDocumentOperation(result))return false;editorSelection.activeBlockId=id;announce(`Block moved to position ${result.index+1}`);return true}
-function deleteBlock(id){flushAll();const found=findBlock(id);if(!found.block)return false;const label=blockTypeLabel(found.block.type),result=deleteBlockOperation(state,id);if(!applyDocumentOperation(result))return false;selectOperationResult(result,result.selectedBlockType);announce(`${label[0].toUpperCase()+label.slice(1)} deleted`);return true}
-function selectGroup(group,type,{blockId=null}={}){Object.assign(editorSelection,{activeGroupId:group?.id||null,activeGroupType:group?type:null,activeStepId:type==='step'?group?.id||null:null,activeBlockId:blockId,blockType:blockId?'paragraph':null,container:blockId?'block':null,offsets:[0,0]})}
-function manageStep(action){flushAll();const id=editorSelection.activeStepId,index=state.steps.findIndex(x=>x.id===id);if(index<0)return;if(action==='deleteStep'){if(stepHasMovements(state.excel,id)&&!confirm('Deleting this step will delete its nonzero Excel share movements from every company. Continue?'))return;if(!confirmStepDeletion(state.steps,index,confirm))return;const result=deleteStepOperation(state,id);if(applyDocumentOperation(result)){const target=state.steps.find(x=>x.id===result.selectedGroupId);if(target)selectGroup(target,'step');announce('Step deleted')}return}const result=moveStepOperation(state,id,action==='moveStepUp'?-1:1);if(applyDocumentOperation(result))announce(`Step moved to position ${result.index+1}`)}
-function addStep(where='after'){flushAll();const result=addStepOperation(state,{referenceId:editorSelection.activeStepId,position:where,idFactory:newId});if(!applyDocumentOperation(result))return false;selectOperationResult(result,'paragraph');return true}
-function addAppendix(){flushAll();const result=addAppendixOperation(state,{idFactory:newId});if(!applyDocumentOperation(result))return false;selectOperationResult(result,'paragraph');announce(`${appendixLabel(result.index)} added`);return true}
-function manageAppendix(action){flushAll();const id=editorSelection.activeGroupId,index=state.appendices.findIndex(x=>x.id===id);if(index<0)return;const appendix=state.appendices[index];if(action==='deleteAppendix'){if(!confirm(`Delete ${appendixLabel(index)}: ${appendix.title}? This can be undone.`))return;const result=deleteAppendixOperation(state,id);if(!applyDocumentOperation(result))return;const target=state.appendices.find(x=>x.id===result.selectedGroupId)||state.steps.at(-1);if(target)selectGroup(target,state.appendices.includes(target)?'appendix':'step');announce('Appendix deleted');return}const result=moveAppendixOperation(state,id,action==='moveAppendixUp'?-1:1);if(applyDocumentOperation(result))announce(`Appendix moved to ${appendixLabel(result.index)}`)}
-function tableMutation(action){flushAll();const {block}=findBlock(editorSelection.activeBlockId);if(block?.type!=='table')return false;const rowIndex=editorSelection.row==null?NaN:Number(editorSelection.row),columnIndex=editorSelection.column==null?NaN:Number(editorSelection.column),row=block.rows[rowIndex],column=block.columns[columnIndex];let result;if(action==='moveRowUp'||action==='moveRowDown')result=moveTableRowOperation(state,block.id,row?.id,action==='moveRowUp'?-1:1);else if(action==='moveColumnLeft'||action==='moveColumnRight')result=moveTableColumnOperation(state,block.id,column?.id,action==='moveColumnLeft'?-1:1);else if(action==='addRow')result=insertTableRowOperation(state,block.id,row?.id,{idFactory:newId});else if(action==='addColumn')result=insertTableColumnOperation(state,block.id,column?.id,{idFactory:newId});else if(action==='removeRow')result=deleteTableRowOperation(state,block.id,row?.id);else if(action==='removeColumn')result=deleteTableColumnOperation(state,block.id,column?.id);else return false;if(!applyDocumentOperation(result))return false;if('rowIndex'in result)editorSelection.row=result.rowIndex;if('columnIndex'in result)editorSelection.column=result.columnIndex;editorSelection.offsets=[0,0];if(action.startsWith('moveRow'))announce(`Row moved to position ${result.rowIndex+1}`);if(action.startsWith('moveColumn'))announce(`Column moved to position ${result.columnIndex+1}`);return true}
-function linkPicker(){captureSelection();const dialog=$('#link-picker'),list=$('#link-destination'),destinations=[...state.steps.map((group,index)=>({group,label:`Step ${index+1}. ${group.title}`})),...state.appendices.map((group,index)=>({group,label:`${appendixLabel(index)}. ${group.title}`}))];list.innerHTML=destinations.map(({group,label})=>`<option value="#${stableAnchor(group)}">${esc(label)}</option>`).join('');dialog.showModal()}
-let insertionContext=null,imageInsertionContext=null;
-function blankStepClick(event){
-  if(event.button!==0||event.defaultPrevented)return;
-  const stepElement=event.currentTarget;
-  const active=document.activeElement,editing=active?.matches?.('[contenteditable=true],[data-group-title]');
-  if(editing&&!event.target.closest('[contenteditable=true],[data-group-title],button,input,select,textarea,a')){flushAll();active.blur();getSelection()?.removeAllRanges();Object.assign(editorSelection,{activeBlockId:null,blockType:null,container:null,itemId:null,row:null,column:null,rowId:null,columnId:null,cellId:null,offsets:null,restoreFocus:false});return}
-  if(event.target.closest('.editable-block,.step-heading,.page-header,.page-footer,a,button,input,select,textarea,[contenteditable="true"],.block-controls,.toolbar'))return;
-  const body=event.target.closest('.document-body')||stepElement.querySelector('.document-body');
-  if(!body||!stepElement.contains(event.target))return;
-  const group=[...state.steps,...state.appendices].find(item=>item.id===stepElement.dataset.editableGroupId);
-  if(!group)return;
-  const canInsert=canOpenBlankSpaceInsertion(editorSelection.activeGroupId,group.id);
-  selectGroup(group,stepElement.dataset.groupType);
-  document.querySelectorAll('[data-editable-group-id]').forEach(element=>element.classList.toggle('is-selected',element.dataset.editableGroupId===group.id));
-  if(!canInsert)return;
-  insertionContext=insertionContextFromPoint(group.id,[...stepElement.querySelectorAll('[data-block-id]')],event.clientY);
-  const chooser=$('#insertion-chooser');
-  if(!chooser.open)chooser.showModal();
-  queueMicrotask(()=>chooser.querySelector('[data-insert-choice="paragraph"]').focus());
+function header() {
+  const x = document.createElement('header');
+  x.className = 'page-header';
+  x.innerHTML = `<span class="header-brand">UBTA</span><span class="header-details">${esc(state.meta.clientName)} · ${esc(state.meta.projectTitle)} · ${esc(state.meta.version)}</span>`;
+  return x;
 }
-function addImage(context=defaultInsertionContext()){if(![...state.steps,...state.appendices].some(group=>group.id===context?.groupId))return;imageInsertionContext=context;const form=$('#image-form'),error=$('#image-form-error');form.reset();error.hidden=true;error.textContent='';$('#image-dialog').showModal();form.elements.src.focus()}
-function historyChangeTarget(next){if(!next)return null;const currentGroups=allGroups(),nextGroups=[...next.sections,...next.steps,...next.appendices];for(const nextGroup of nextGroups){const currentGroup=currentGroups.find(group=>group.id===nextGroup.id);if(!currentGroup)return {groupId:nextGroup.id};if(currentGroup.title!==nextGroup.title)return {groupId:currentGroup.id};const ids=new Set([...currentGroup.blocks.map(block=>block.id),...nextGroup.blocks.map(block=>block.id)]);for(const id of ids){const before=currentGroup.blocks.find(block=>block.id===id),after=nextGroup.blocks.find(block=>block.id===id);if(JSON.stringify(before)!==JSON.stringify(after))return {groupId:currentGroup.id,blockId:before?.id||null}}}const removed=currentGroups.find(group=>!nextGroups.some(item=>item.id===group.id));return removed?{groupId:removed.id}:null}
-function revealHistoryChange(next){const target=historyChangeTarget(next);if(!target)return;const node=(target.blockId&&document.querySelector(`[data-block-id="${CSS.escape(target.blockId)}"]`))||document.querySelector(`[data-editable-group-id="${CSS.escape(target.groupId)}"]`)||document.querySelector(`.pagedjs_page[data-group-id="${CSS.escape(target.groupId)}"]`);const page=node?.closest('.pagedjs_page')||(node?.matches('.pagedjs_page')?node:null);if(!page)return;const pages=[...document.querySelectorAll('.pagedjs_page')];setCurrentPage(pages.indexOf(page)+1,{scroll:false,focus:false});page.scrollIntoView({behavior:'auto',block:'center'})}
-function command(action){flushAll();if((action==='undo'||action==='redo')&&activeEditor==='excel'){excelController[action]();markDirty();return}if(action==='undo'){const previousView=navigationHistory.undo();if(previousView){restoreView(previousView);announce('Returned to the previous location');return}}if(action==='undo'||action==='redo'){navigationHistory.clear();pending.forEach(x=>clearTimeout(x.timer));pending.clear();const next=action==='undo'?history.peekUndo():history.peekRedo();revealHistoryChange(next);const currentExcel=state.excel,stepsState=action==='undo'?history.undo():history.redo();state=normaliseDocument({...stepsState,excel:currentExcel});history.replace(state);markDirty();if(![...state.steps,...state.appendices].some(x=>x.id===editorSelection.activeGroupId)){const group=state.steps[0]||state.appendices[0];selectGroup(group,state.steps.includes(group)?'step':'appendix')}return render()}if(action==='addStepBefore'||action==='addStepAfter')return addStep(action.endsWith('After')?'after':'before');if(['moveStepUp','moveStepDown','deleteStep'].includes(action))return manageStep(action);if(action==='addAppendix')return addAppendix();if(['moveAppendixUp','moveAppendixDown','deleteAppendix'].includes(action))return manageAppendix(action);const insertion=routeInsertionCommand(action);if(insertion?.kind==='table')return tableMutation(insertion.action);if(insertion?.kind==='block'&&typeof insertion.blockType==='string')return insertBlock(insertion.blockType);if(action==='addImage')return addImage();if(action==='highlight'||action==='unlink')return transformSelection(action==='unlink'?'unlink':'highlight');if(action==='link')return linkPicker();if(editorSelection.blockType==='image')return;const {block}=findBlock(editorSelection.activeBlockId);if(!block||!['heading','paragraph','bulletList','numberList'].includes(block.type))return;if(canApplyBlockStyle(block.type,action)){const result=convertBlockStyleOperation(state,block.id,action,{idFactory:newId});if(applyDocumentOperation(result))editorSelection.blockType=result.selectedBlockType}}
-function announce(message){$('#editor-status').textContent='';requestAnimationFrame(()=>$('#editor-status').textContent=message)}
-function updateControls(){const i=state.steps.findIndex(x=>x.id===editorSelection.activeStepId),step=i>=0,appendixIndex=editorSelection.activeGroupType==='appendix'?state.appendices.findIndex(x=>x.id===editorSelection.activeGroupId):-1,editable=!!selectedEditableGroup();document.querySelectorAll('[data-command=moveStepUp]').forEach(x=>x.disabled=!step||i===0);document.querySelectorAll('[data-command=moveStepDown]').forEach(x=>x.disabled=!step||i===state.steps.length-1);document.querySelectorAll('[data-command=deleteStep]').forEach(x=>x.disabled=!step||state.steps.length===1);document.querySelectorAll('[data-requires-step]').forEach(x=>x.disabled=!step);document.querySelectorAll('[data-requires-group]').forEach(x=>x.disabled=!editable);document.querySelectorAll('[data-command=moveAppendixUp]').forEach(x=>x.disabled=appendixIndex<=0);document.querySelectorAll('[data-command=moveAppendixDown]').forEach(x=>x.disabled=appendixIndex<0||appendixIndex===state.appendices.length-1);document.querySelectorAll('[data-command=deleteAppendix]').forEach(x=>x.disabled=appendixIndex<0);const runs=resolveRuns(),text=!!runs;document.querySelectorAll('[data-text-command]').forEach(x=>x.disabled=!text);const {block}=findBlock(editorSelection.activeBlockId),style=$('#style'),choices=blockStyleChoices(block?.type);if(style.dataset.choices!==JSON.stringify(choices)){style.replaceChildren(...choices.map(([value,label])=>{const option=document.createElement('option');option.value=value;option.textContent=label;return option}));style.dataset.choices=JSON.stringify(choices)}document.querySelectorAll('[data-table-command]').forEach(x=>x.hidden=block?.type!=='table');document.querySelectorAll('[data-table-group]').forEach(x=>x.hidden=block?.type!=='table');style.disabled=!text;if(block?.type==='heading')style.value=`heading${block.level}`;else if(block?.type==='paragraph')style.value='body';else if(['bulletList','numberList'].includes(block?.type))style.value=block.type;const row=editorSelection.row==null?NaN:Number(editorSelection.row),column=editorSelection.column==null?NaN:Number(editorSelection.column),selectedRow=block?.rows?.[row];document.querySelectorAll('[data-command=moveRowUp]').forEach(x=>x.disabled=!selectedRow||row===0||block.rows[row-1]?.isTotal!==selectedRow.isTotal);document.querySelectorAll('[data-command=moveRowDown]').forEach(x=>x.disabled=!selectedRow||row===block.rows.length-1||block.rows[row+1]?.isTotal!==selectedRow.isTotal);document.querySelectorAll('[data-command=moveColumnLeft]').forEach(x=>x.disabled=!block?.columns?.[column]||column===0);document.querySelectorAll('[data-command=moveColumnRight]').forEach(x=>x.disabled=!block?.columns?.[column]||column===block.columns.length-1);const format=$('#column-format'),selectedColumn=block?.columns?.[column];format.disabled=!selectedColumn;if(selectedColumn)format.value=tableColumnFormat(selectedColumn);const total=$('#column-total-enabled');total.disabled=!selectedColumn||tableColumnFormat(selectedColumn)==='text';total.checked=!!selectedColumn?.totalEnabled}
-document.querySelectorAll('[data-command]').forEach(b=>{b.addEventListener('pointerdown',e=>{if(b.dataset.textCommand!==undefined){e.preventDefault();captureSelection()}});b.addEventListener('click',()=>command(b.dataset.command))});$('#style').onchange=e=>command(e.target.value);$('#column-format').onchange=e=>{const {block}=findBlock(editorSelection.activeBlockId),column=block?.columns?.[editorSelection.column==null?NaN:Number(editorSelection.column)];if(!column)return;const result=setTableColumnFormatOperation(state,block.id,column.id,e.target.value);if(applyDocumentOperation(result))announce(`Column format changed to ${e.target.selectedOptions[0].textContent}`)};$('#column-total-enabled').onchange=e=>{captureSelection();const {block}=findBlock(editorSelection.activeBlockId),column=block?.columns?.find(c=>c.id===editorSelection.columnId)||block?.columns?.[Number(editorSelection.column)];if(!column)return;applyDocumentOperation(setTableColumnTotalOperation(state,block.id,column.id,e.target.checked));};const linkDialog=$('#link-picker');let applyingLink=false;$('#link-form').onsubmit=e=>{e.preventDefault();const external=$('#external-link').value,href=validatedLink(external,$('#link-destination').value);if(href){applyingLink=true;linkDialog.close();transformSelection('link',href,{useCaptured:true});applyingLink=false;editorSelection.offsets=null}else announce('Enter a valid HTTPS, HTTP, mailto, or internal destination.')};linkDialog.addEventListener('close',()=>{if(!applyingLink)editorSelection.offsets=null;$('#link-form').reset()});
-const insertionChooser=$('#insertion-chooser'),templateLoader=new EncryptedTemplateLoader();
-function showInsertionPanel(name,focus=true){insertionChooser.querySelectorAll('[data-insertion-panel]').forEach(panel=>panel.hidden=panel.dataset.insertionPanel!==name);if(focus)queueMicrotask(()=>insertionChooser.querySelector(`[data-insertion-panel="${name}"] button, [data-insertion-panel="${name}"] input`)?.focus())}
-function finishInsertion(callback){const context=insertionContext;insertionContext=null;insertionChooser.close();callback(context)}
-insertionChooser.querySelectorAll('[data-open-insertion-panel]').forEach(button=>button.onclick=()=>{showInsertionPanel(button.dataset.openInsertionPanel);if(button.dataset.openInsertionPanel==='defaults')openDefaults()});
-insertionChooser.querySelectorAll('[data-insertion-back]').forEach(button=>button.onclick=()=>showInsertionPanel('main'));
-insertionChooser.querySelectorAll('[data-insert-choice]').forEach(button=>button.onclick=()=>finishInsertion(context=>button.dataset.insertChoice==='image'?addImage(context):insertBlock(button.dataset.insertChoice,context)));
-insertionChooser.querySelectorAll('[data-insert-heading]').forEach(button=>button.onclick=()=>finishInsertion(context=>insertBlock('heading',context,button.dataset.insertHeading)));
-function renderTemplates(templates){const choices=$('#default-template-choices');choices.replaceChildren(...templates.map(template=>{const button=document.createElement('button');button.type='button';button.textContent=template.header;button.onclick=()=>finishInsertion(context=>insertTemplate(template,context));return button}));$('#default-unlock').hidden=true;choices.querySelector('button')?.focus()}
-async function openDefaults(){const error=$('#default-error');error.hidden=true;if(templateLoader.cached){renderTemplates(await templateLoader.unlock());return}$('#default-unlock').hidden=false;$('#default-password').focus()}
-$('#unlock-defaults').onclick=async()=>{const input=$('#default-password'),button=$('#unlock-defaults'),error=$('#default-error'),password=input.value;input.value='';button.disabled=true;error.hidden=true;try{renderTemplates(await templateLoader.unlock(defaultTemplateEnvelope,password))}catch(failure){error.textContent=failure.message;error.hidden=false;input.focus()}finally{button.disabled=false}};
-$('#default-password').addEventListener('keydown',event=>{if(event.key!=='Enter')return;event.preventDefault();event.stopPropagation();$('#unlock-defaults').click()});
-function insertTemplate(template,context){const group=[...state.steps,...state.appendices].find(item=>item.id===context?.groupId),at=insertionIndex(group,context);if(!group||at<0){announce('That insertion location is no longer available.');return false}const blocks=templateBlocks(template,newId);let result;for(const [offset,block] of blocks.entries()){result=insertBlockOperation(result?.document||state,group.id,block,at+offset);if(!result.changed)return false}applyDocumentOperation(result);Object.assign(editorSelection,{activeBlockId:blocks[0].id,blockType:'heading',container:'block',itemId:null,row:null,column:null,offsets:[0,template.header.length]});announce(`${template.header} inserted`);return true}
-insertionChooser.addEventListener('close',()=>{insertionContext=null;$('#default-password').value='';showInsertionPanel('main',false)});
+function sheet(kind) {
+  const x = document.createElement('section');
+  x.className = `sheet-source ${kind}`;
+  x.append(header());
+  return x;
+}
+function footer(x, n, total) {
+  const f = document.createElement('footer');
+  f.className = 'page-footer';
+  f.textContent = `Page ${n} of ${total}`;
+  x.append(f);
+}
+function blockElement(block) {
+  const x = document.createElement('div');
+  x.className = 'editable-block';
+  x.dataset.blockId = block.id;
+  x.dataset.type = block.type;
+  x.dataset.level = block.level || '';
+  x.draggable = false;
+  x.tabIndex = -1;
+  if (['heading', 'paragraph'].includes(block.type))
+    x.innerHTML = editableRuns(block.runs, 'data-container="block"');
+  else if (block.type.endsWith('List')) {
+    x.classList.add('list-block');
+    x.dataset.listType = block.type;
+    x.innerHTML = renderList(block, runsHTML, esc);
+  } else if (block.type === 'table') {
+    x.classList.add('table-block');
+    recalculateTableTotals(block);
+    const cellHTML = (cell, row, ri, ci) => {
+      const format = tableColumnFormat(block.columns[ci]),
+        numeric = format !== 'text',
+        value = runText(cell.runs),
+        parsed = numeric ? parseTableNumber(value) : null,
+        display = parsed === null ? value : formatTableNumber(parsed, format),
+        attrs = `data-container="cell" data-row="${ri}" data-column="${ci}" data-row-id="${esc(row.id)}" data-column-id="${esc(block.columns[ci].id)}" data-cell-id="${esc(cell.id)}"`;
+      return `<td class="format-${format}">${row.isTotal && numeric ? `<output ${attrs}>${esc(display)}</output>` : editableRuns(numeric ? [{ text: display }] : cell.runs, attrs)}</td>`;
+    };
+    x.innerHTML = `<table><caption>${editableRuns(block.captionRuns, 'data-container="caption"')}</caption><colgroup>${block.columns.map((c) => `<col style="width:${c.width}%">`).join('')}</colgroup><thead><tr>${block.columns.map((c, i) => `<th class="format-${tableColumnFormat(c)}">${editableRuns(c.headingRuns, `data-container="heading" data-column="${i}"`)}</th>`).join('')}</tr></thead><tbody>${block.rows.map((r, ri) => `<tr class="${r.isTotal ? 'total-row' : ''}" data-row="${ri}">${r.cells.map((c, ci) => cellHTML(c, r, ri, ci)).join('')}</tr>`).join('')}</tbody></table>`;
+  } else {
+    x.classList.add('image-block');
+    x.innerHTML = block.src
+      ? `<figure><img src="${esc(block.src)}" alt="${esc(block.alt || '')}" style="width:${block.width}%"><figcaption>${editableRuns(block.captionRuns, 'data-container="image-caption"')}</figcaption></figure>`
+      : '<p class="image-error">Image unavailable.</p>';
+  }
+  x.insertAdjacentHTML(
+    'afterbegin',
+    `<div class="block-controls" contenteditable="false"><button type="button" data-block-move="before" aria-label="Move block before">↑</button><button type="button" data-block-move="after" aria-label="Move block after">↓</button><button type="button" class="delete-block" data-block-delete aria-label="Delete ${blockTypeLabel(block.type)}">Delete</button></div>`,
+  );
+  return x;
+}
+function groupSheet(group, title, kind) {
+  const x = sheet(kind);
+  x.id = stableAnchor(group);
+  x.tabIndex = -1;
+  if (['step', 'appendix'].includes(kind)) {
+    x.dataset.editableGroupId = group.id;
+    x.dataset.groupType = kind;
+    if (group.id === editorSelection.activeGroupId)
+      x.classList.add('is-selected');
+    x.innerHTML += `<div class="step-heading"><div class="step-label">${esc(kind === 'step' ? title.match(/^Step \d+/)?.[0] || '' : title.split('. ')[0])}</div><input class="step-title" data-group-title="${group.id}" value="${esc(group.title)}" aria-label="${kind === 'step' ? 'Step' : 'Appendix'} title"><div class="step-title-print" aria-hidden="true">${esc(group.title)}</div></div>`;
+  } else x.innerHTML += `<h1 class="section-title">${esc(title)}</h1>`;
+  const body = document.createElement('div');
+  body.className = 'document-body';
+  group.blocks.forEach((b) => body.append(blockElement(b)));
+  x.append(body);
+  return x;
+}
+function cover() {
+  const x = sheet('cover');
+  x.innerHTML += `<div class="cover-kicker">${esc(state.meta.documentType)} · ${esc(state.meta.status)}</div><h1>${esc(state.meta.clientName)}</h1><h2>${esc(state.meta.projectTitle)}</h2><p>${esc(state.meta.subtitle)}</p><p>${esc(state.meta.date)} · ${esc(state.meta.adviser)} · ${esc(state.meta.version)}</p>`;
+  return x;
+}
+function contentsEntries() {
+  return [
+    ...state.sections.map((group) => ({
+      group,
+      type: 'section',
+      label: group.title,
+    })),
+    ...state.steps.map((group, index) => ({
+      group,
+      type: 'step',
+      label: `Step ${index + 1}. ${group.title}`,
+    })),
+    ...state.appendices.map((group, index) => ({
+      group,
+      type: 'appendix',
+      label: `${appendixLabel(index)}. ${group.title}`,
+    })),
+  ];
+}
+function contents(map = {}) {
+  const x = sheet('contents'),
+    entries = contentsEntries();
+  x.innerHTML +=
+    '<h1 class="doc-title">Contents</h1><ol class="toc">' +
+    entries
+      .map(
+        ({ group, type, label }) =>
+          `<li class="toc-${type} ${hasReview(group) ? 'toc-review' : ''}"><a href="#${stableAnchor(group)}">${esc(label)}</a><span class="dots"></span><span class="toc-page">${map[stableAnchor(group)] || '—'}</span></li>`,
+      )
+      .join('') +
+    '</ol>';
+  return x;
+}
+function captureSelection() {
+  const offsets = containedSelectionOffsets(
+    activeEditable(),
+    getSelection(),
+    document,
+  );
+  if (offsets) editorSelection.offsets = offsets;
+}
+function captureView() {
+  captureSelection();
+  return {
+    currentPage,
+    scrollX: window.scrollX,
+    scrollY: window.scrollY,
+    selection: structuredClone(editorSelection),
+  };
+}
+async function restoreView(view) {
+  setCurrentPage(view.currentPage, { scroll: false, focus: false });
+  Object.assign(editorSelection, view.selection);
+  if (editorSelection.restoreFocus)
+    restoreTextSelection(activeEditable(), editorSelection.offsets);
+  window.scrollTo(view.scrollX, view.scrollY);
+}
+async function paginate({ isCurrent }) {
+  const source = document.createElement('main'),
+    staging = document.createElement('div');
+  staging.className = 'pagedjs_pages';
+  source.append(cover(), contents(window.__pageMap || {}));
+  state.sections.forEach((g) =>
+    source.append(groupSheet(g, g.title, 'section')),
+  );
+  state.steps.forEach((g, i) =>
+    source.append(groupSheet(g, `Step ${i + 1}. ${g.title}`, 'step')),
+  );
+  state.appendices.forEach((g, i) =>
+    source.append(groupSheet(g, `${appendixLabel(i)}. ${g.title}`, 'appendix')),
+  );
+  await new Paged.Previewer().preview(source, [], staging);
+  if (!isCurrent()) return false;
+  const pages = [...staging.children],
+    map = {};
+  pages.forEach((p, i) => {
+    footer(p.querySelector('.sheet-source'), i + 1, pages.length);
+    p.dataset.pageNumber = String(i + 1);
+    p.querySelectorAll('[id^=anchor-]').forEach((a) => (map[a.id] ??= i + 1));
+    if (p.dataset.anchorId) map[p.dataset.anchorId] ??= i + 1;
+  });
+  if (!isCurrent()) return false;
+  window.__pageMap = map;
+  disconnectPageObserver();
+  $('#preview').replaceChildren(...pages);
+  bindEditing();
+  observePages();
+  updateControls();
+  setCurrentPage(currentPage, { scroll: false, focus: false });
+  $('#total').textContent = pages.length;
+  rebuildPageJump(pages);
+  return true;
+}
+const repagination = new RepaginationScheduler(paginate, {
+  capture: captureView,
+  restore: restoreView,
+});
+const navigationHistory = new NavigationHistory();
+const render = ({ immediate = true } = {}) =>
+  repagination.request({ immediate });
+
+function activeEditable() {
+  const id = editorSelection.activeBlockId;
+  if (!id)
+    return editorSelection.activeGroupId
+      ? document.querySelector(
+          `[data-group-title="${editorSelection.activeGroupId}"]`,
+        )
+      : null;
+  const block = document.querySelector(`[data-block-id="${id}"]`);
+  if (!block) return null;
+  const c = editorSelection.container;
+  if (c === 'block') return block.querySelector('[data-container=block]');
+  if (c === 'item')
+    return block.querySelector(
+      `li[data-container="item"][data-item-id="${editorSelection.itemId}"]`,
+    );
+  if (c === 'caption') return block.querySelector('[data-container=caption]');
+  if (c === 'image-caption')
+    return block.querySelector('[data-container=image-caption]');
+  if (c === 'heading')
+    return block.querySelector(
+      `[data-container=heading][data-column="${editorSelection.column}"]`,
+    );
+  if (c === 'cell')
+    return (
+      block.querySelector(
+        `[data-container=cell][data-cell-id="${CSS.escape(editorSelection.cellId || '')}"]`,
+      ) ||
+      block.querySelector(
+        `[data-container=cell][data-row="${editorSelection.row}"][data-column="${editorSelection.column}"]`,
+      )
+    );
+  return block;
+}
+function setActive(target) {
+  const group = target.closest('[data-editable-group-id]');
+  if (group) {
+    editorSelection.activeGroupId = group.dataset.editableGroupId;
+    editorSelection.activeGroupType = group.dataset.groupType;
+    editorSelection.activeStepId =
+      group.dataset.groupType === 'step' ? group.dataset.editableGroupId : null;
+  }
+  const block = target.closest('[data-block-id]'),
+    item = target.closest('li[data-container="item"]');
+  editorSelection.activeBlockId = block?.dataset.blockId || null;
+  editorSelection.blockType = block?.dataset.type || null;
+  editorSelection.container =
+    item?.dataset.container ||
+    target.dataset.container ||
+    (['heading', 'paragraph'].includes(editorSelection.blockType)
+      ? 'block'
+      : null);
+  editorSelection.itemId = item?.dataset.itemId || null;
+  editorSelection.row = target.dataset.row ?? null;
+  editorSelection.column = target.dataset.column ?? null;
+  editorSelection.rowId = target.dataset.rowId ?? null;
+  editorSelection.columnId = target.dataset.columnId ?? null;
+  editorSelection.cellId = target.dataset.cellId ?? null;
+  editorSelection.restoreFocus = true;
+  document
+    .querySelectorAll('[data-editable-group-id]')
+    .forEach((x) =>
+      x.classList.toggle(
+        'is-selected',
+        x.dataset.editableGroupId === editorSelection.activeGroupId,
+      ),
+    );
+  updateControls();
+}
+function syncElement(el, record = true) {
+  if (!el?.isConnected) return false;
+  const blockEl = el.closest('[data-block-id]'),
+    found = findBlock(blockEl?.dataset.blockId);
+  if (!found.block) return false;
+  const before = structuredClone(state);
+  const b = found.block,
+    c = el.dataset.container;
+  if (c === 'item') {
+    const i = b.items.find((x) => x.id === el.dataset.itemId);
+    if (i) i.runs = runsFromElement(el);
+  } else if (c === 'caption') b.captionRuns = runsFromElement(el);
+  else if (c === 'image-caption') b.captionRuns = runsFromElement(el);
+  else if (c === 'heading')
+    b.columns[+el.dataset.column].headingRuns = runsFromElement(el);
+  else if (c === 'cell') {
+    captureSelection();
+    const row =
+        b.rows.find((r) => r.id === el.dataset.rowId) ||
+        b.rows[+el.dataset.row],
+      columnIndex = b.columns.findIndex(
+        (column) => column.id === el.dataset.columnId,
+      ),
+      cell =
+        row?.cells.find((cell) => cell.id === el.dataset.cellId) ||
+        row?.cells[columnIndex < 0 ? +el.dataset.column : columnIndex];
+    if (cell) cell.runs = runsFromElement(el);
+    editorSelection.cellId = cell?.id || editorSelection.cellId;
+  } else {
+    const peers = [
+      ...document.querySelectorAll(
+        `[data-block-id="${b.id}"] [data-container="block"]`,
+      ),
+    ];
+    b.runs =
+      peers.length > 1 ? peers.flatMap(runsFromElement) : runsFromElement(el);
+  }
+  state = normaliseDocument(state);
+  if (record) history.commit(state);
+  else history.replace(state);
+  const changed = JSON.stringify(before) !== JSON.stringify(state);
+  if (changed) markDirty();
+  return changed;
+}
+function schedule(el) {
+  const key = targetKey(el),
+    old = pending.get(key);
+  if (old) clearTimeout(old.timer);
+  pending.set(key, {
+    el,
+    timer: setTimeout(() => {
+      const p = pending.get(key);
+      if (!p || p.el !== el || !el.isConnected) return;
+      syncElement(el);
+      pending.delete(key);
+      updateControls();
+      render({ immediate: false });
+    }, 450),
+  });
+}
+const targetKey = (el) =>
+  [
+    el.closest('[data-block-id]')?.dataset.blockId,
+    el.dataset.container,
+    el.dataset.itemId,
+    el.dataset.row,
+    el.dataset.column,
+  ].join(':');
+function flushTarget(el, record = true) {
+  const key = targetKey(el),
+    p = pending.get(key);
+  if (!p) return;
+  clearTimeout(p.timer);
+  pending.delete(key);
+  if (p.el.isConnected) syncElement(p.el, record);
+}
+function syncStepTitle(el, { renderAfter = true } = {}) {
+  const pendingTitle = pendingStepTitles.get(el.dataset.groupTitle);
+  if (pendingTitle) clearTimeout(pendingTitle.timer);
+  pendingStepTitles.delete(el.dataset.groupTitle);
+  if (!el.isConnected) return false;
+  const group = allGroups().find((x) => x.id === el.dataset.groupTitle),
+    title = el.value.trim() || 'Untitled';
+  if (!group || group.title === title) return false;
+  group.title = title;
+  history.commit(state);
+  markDirty();
+  updateControls();
+  if (renderAfter) render({ immediate: false });
+  return true;
+}
+function flushAll(record = true) {
+  [...pending.values()].forEach((p) => {
+    clearTimeout(p.timer);
+    if (p.el.isConnected) syncElement(p.el, record);
+  });
+  pending.clear();
+  [...pendingStepTitles.values()].forEach((p) =>
+    syncStepTitle(p.el, { renderAfter: false }),
+  );
+}
+const hasPendingInputs = () => pending.size > 0 || pendingStepTitles.size > 0;
+function markDirty() {
+  dirty = true;
+  const indicator = $('#save-state');
+  if (indicator) {
+    indicator.textContent = 'Unsaved changes';
+    indicator.className = 'save-state dirty';
+  }
+  clearTimeout(autosaveTimer);
+  autosaveTimer = setTimeout(() => persistDraft(), 1500);
+}
+function commit(mutator, { focus = true } = {}) {
+  flushAll();
+  const before = structuredClone(state);
+  mutator();
+  state = normaliseDocument(state);
+  history.replace(before);
+  history.commit(state);
+  state = history.checkout();
+  markDirty();
+  editorSelection.restoreFocus = focus;
+  return render({ restore: focus });
+}
+function applyDocumentOperation(result, { focus = true } = {}) {
+  if (!result?.changed) return false;
+  const before = state;
+  history.replace(before);
+  history.commit(result.document);
+  state = history.checkout();
+  markDirty();
+  if (result.selectedGroupId) {
+    editorSelection.activeGroupId = result.selectedGroupId;
+    editorSelection.activeGroupType = state.steps.some(
+      (x) => x.id === result.selectedGroupId,
+    )
+      ? 'step'
+      : 'appendix';
+    editorSelection.activeStepId =
+      editorSelection.activeGroupType === 'step'
+        ? result.selectedGroupId
+        : null;
+  }
+  if (result.selectedBlockId)
+    editorSelection.activeBlockId = result.selectedBlockId;
+  if ('rowIndex' in result) editorSelection.row = result.rowIndex;
+  if ('columnIndex' in result) editorSelection.column = result.columnIndex;
+  refreshSelectedTableCell(result);
+  editorSelection.restoreFocus = focus;
+  render({ restore: focus });
+  return true;
+}
+function refreshSelectedTableCell(result) {
+  if (!('rowIndex' in result) && !('columnIndex' in result)) return;
+  const { block } = findBlock(editorSelection.activeBlockId);
+  if (block?.type !== 'table') return;
+  const row = block.rows[Number(editorSelection.row)],
+    column = block.columns[Number(editorSelection.column)];
+  editorSelection.rowId = row?.id || null;
+  editorSelection.columnId = column?.id || null;
+  editorSelection.cellId =
+    row?.cells?.[Number(editorSelection.column)]?.id || null;
+}
+function selectOperationResult(result, type) {
+  const group =
+    state.steps.find((x) => x.id === result.selectedGroupId) ||
+    state.appendices.find((x) => x.id === result.selectedGroupId);
+  if (!group) return;
+  selectGroup(group, state.steps.includes(group) ? 'step' : 'appendix', {
+    blockId: result.selectedBlockId,
+  });
+  Object.assign(editorSelection, {
+    activeBlockId: result.selectedBlockId || null,
+    blockType: type || result.selectedBlockType || null,
+    container:
+      type === 'table'
+        ? 'cell'
+        : type?.endsWith('List')
+          ? 'item'
+          : type === 'image'
+            ? 'image-caption'
+            : 'block',
+    row: type === 'table' ? 0 : null,
+    column: type === 'table' ? 0 : null,
+    rowId:
+      type === 'table'
+        ? group.blocks.find((b) => b.id === result.selectedBlockId)?.rows?.[0]
+            ?.id
+        : null,
+    columnId:
+      type === 'table'
+        ? group.blocks.find((b) => b.id === result.selectedBlockId)
+            ?.columns?.[0]?.id
+        : null,
+    cellId:
+      type === 'table'
+        ? group.blocks.find((b) => b.id === result.selectedBlockId)?.rows?.[0]
+            ?.cells?.[0]?.id
+        : null,
+    offsets: [0, 0],
+    restoreFocus: true,
+  });
+}
+
+function bindEditing() {
+  document.querySelectorAll('[data-editable-group-id]').forEach((x) => {
+    x.addEventListener('pointerdown', (e) => {
+      if (
+        e.target.closest(
+          '.editable-block,.step-heading,button,input,select,textarea,[contenteditable="true"]',
+        )
+      )
+        setActive(e.target);
+    });
+    x.addEventListener('click', blankStepClick);
+  });
+  document.querySelectorAll('[contenteditable=true]').forEach((el) => {
+    el.addEventListener('focusin', () => setActive(el));
+    el.addEventListener('input', () => {
+      repagination.cancel();
+      schedule(el);
+    });
+    el.addEventListener('blur', () => {
+      flushTarget(el);
+      editorSelection.restoreFocus = false;
+    });
+    el.addEventListener('paste', (e) => insertPlainText(e, document));
+  });
+  document.querySelectorAll('[data-group-title]').forEach((el) => {
+    const sync = () => syncStepTitle(el);
+    el.addEventListener('focusin', () => setActive(el));
+    el.addEventListener('input', () => {
+      repagination.cancel();
+      const old = pendingStepTitles.get(el.dataset.groupTitle);
+      if (old) clearTimeout(old.timer);
+      pendingStepTitles.set(el.dataset.groupTitle, {
+        el,
+        timer: setTimeout(sync, 450),
+      });
+    });
+    el.addEventListener('blur', () => {
+      sync();
+      editorSelection.restoreFocus = false;
+    });
+    el.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        el.blur();
+      } else if (e.key === 'Tab') editorSelection.restoreFocus = false;
+    });
+  });
+  document
+    .querySelectorAll('.list-block > :is(ol,ul) > li[data-container="item"]')
+    .forEach((el) => {
+      el.addEventListener('keydown', listKeydown);
+      el.addEventListener('blur', (event) => listBlur(event, el));
+    });
+  document
+    .querySelectorAll('[data-list-append]')
+    .forEach((el) => el.addEventListener('click', appendListItem));
+  document
+    .querySelectorAll('[data-type="heading"] > [data-container="block"]')
+    .forEach((el) => el.addEventListener('keydown', headingEnter));
+  document
+    .querySelectorAll('[data-container=cell]')
+    .forEach((el) => el.addEventListener('keydown', tableTab));
+  document
+    .querySelectorAll('[data-block-move]')
+    .forEach(
+      (b) =>
+        (b.onclick = () =>
+          moveBlock(
+            b.closest('[data-block-id]').dataset.blockId,
+            b.dataset.blockMove,
+          )),
+    );
+  document
+    .querySelectorAll('[data-block-delete]')
+    .forEach(
+      (b) =>
+        (b.onclick = () =>
+          deleteBlock(b.closest('[data-block-id]').dataset.blockId)),
+    );
+  document.querySelectorAll('.toc a').forEach(
+    (a) =>
+      (a.onclick = (e) => {
+        e.preventDefault();
+        navigateToAnchor(a.getAttribute('href').slice(1));
+      }),
+  );
+}
+function headingEnter(e) {
+  if (e.key !== 'Enter' || e.shiftKey) return;
+  e.preventDefault();
+  const el = e.currentTarget;
+  flushTarget(el);
+  const { group, block } = findBlock(
+    el.closest('[data-block-id]').dataset.blockId,
+  );
+  if (!group || block?.type !== 'heading') return;
+  const id = newId('block'),
+    index = group.blocks.indexOf(block);
+  const result = insertBlockOperation(
+    state,
+    group.id,
+    { id, type: 'paragraph', runs: [] },
+    index + 1,
+  );
+  if (applyDocumentOperation(result))
+    Object.assign(editorSelection, {
+      activeBlockId: id,
+      blockType: 'paragraph',
+      container: 'block',
+      itemId: null,
+      row: null,
+      column: null,
+      offsets: [0, 0],
+    });
+}
+function listKeydown(e) {
+  if (e.key === 'Enter') return listEnter(e);
+  const el = e.currentTarget,
+    { block } = findBlock(el.closest('[data-block-id]').dataset.blockId),
+    index = block?.items?.findIndex((item) => item.id === el.dataset.itemId),
+    offsets = getOffsets(el),
+    atBoundary =
+      e.key === 'ArrowUp'
+        ? offsets?.[0] === 0
+        : offsets?.[1] === runText(block?.items?.[index]?.runs || []).length;
+  if (
+    (e.key === 'ArrowUp' || e.key === 'ArrowDown') &&
+    !e.shiftKey &&
+    !e.ctrlKey &&
+    !e.metaKey &&
+    !e.altKey &&
+    offsets?.[0] === offsets?.[1] &&
+    atBoundary
+  ) {
+    const target = index + (e.key === 'ArrowUp' ? -1 : 1);
+    if (target < 0 || target >= block.items.length) return;
+    e.preventDefault();
+    const offset =
+      e.key === 'ArrowUp' ? runText(block.items[target].runs).length : 0;
+    editorSelection.itemId = block.items[target].id;
+    editorSelection.offsets = [offset, offset];
+    restoreTextSelection(
+      el.parentElement.children[target],
+      editorSelection.offsets,
+    );
+    return;
+  }
+  if (e.key !== 'Backspace') return;
+  flushTarget(el);
+  if (!Number.isInteger(index) || index < 1 || runText(block.items[index].runs))
+    return;
+  e.preventDefault();
+  commit(() => {
+    const target = removeEmptyListItem(block, index);
+    editorSelection.itemId = target.itemId;
+    editorSelection.offsets = [target.offset, target.offset];
+  });
+}
+function listBlur(event, el) {
+  const blockEl = el.closest('[data-block-id]'),
+    next = event.relatedTarget;
+  if (
+    next?.closest?.(
+      `[data-block-id="${blockEl?.dataset.blockId}"] [data-item-id="${el.dataset.itemId}"]`,
+    )
+  )
+    return;
+  queueMicrotask(() => {
+    if (!el.isConnected) return;
+    const { block } = findBlock(blockEl.dataset.blockId),
+      index = block?.items?.findIndex((item) => item.id === el.dataset.itemId);
+    if (
+      block?.items.length > 1 &&
+      index >= 0 &&
+      !runText(block.items[index].runs)
+    ) {
+      commit(
+        () => {
+          block.items.splice(index, 1);
+          const target = block.items[Math.max(0, index - 1)];
+          editorSelection.itemId = target.id;
+          editorSelection.offsets = [
+            runText(target.runs).length,
+            runText(target.runs).length,
+          ];
+        },
+        { focus: false },
+      );
+    }
+  });
+}
+function appendListItem(event) {
+  event.preventDefault();
+  event.stopPropagation();
+  flushAll();
+  const blockId =
+      event.currentTarget.closest('[data-block-id]').dataset.blockId,
+    { block } = findBlock(blockId);
+  if (!block?.items) return;
+  const id = newId('item');
+  Object.assign(editorSelection, {
+    activeBlockId: blockId,
+    blockType: block.type,
+    container: 'item',
+    itemId: id,
+    offsets: [0, 0],
+    restoreFocus: true,
+  });
+  commit(() =>
+    block.items.push({ id, level: block.items.at(-1)?.level || 1, runs: [] }),
+  );
+}
+function listEnter(e) {
+  if (e.key !== 'Enter') return;
+  e.preventDefault();
+  const el = e.currentTarget;
+  flushTarget(el);
+  const { block } = findBlock(el.closest('[data-block-id]').dataset.blockId),
+    index = block.items.findIndex((i) => i.id === el.dataset.itemId);
+  const offsets = getOffsets(el) || [0, 0],
+    text = runText(block.items[index].runs);
+  if (!text.trim()) {
+    commit(() => {
+      block.items.splice(index, 1);
+      if (!block.items.length) {
+        block.type = 'paragraph';
+        block.runs = [];
+        delete block.items;
+      }
+    });
+    return;
+  }
+  const id = newId('item');
+  commit(() => {
+    const item = block.items[index],
+      [before, after] = splitListRuns(item.runs, offsets[0]);
+    item.runs = before;
+    block.items.splice(index + 1, 0, { id, level: item.level, runs: after });
+    editorSelection.itemId = id;
+    editorSelection.offsets = [0, 0];
+  });
+}
+function tableTab(e) {
+  if (e.key !== 'Tab') return;
+  const cells = [
+      ...document.querySelectorAll(
+        `[data-block-id="${editorSelection.activeBlockId}"] [data-container=cell]`,
+      ),
+    ],
+    i = cells.indexOf(e.currentTarget);
+  if (e.shiftKey || i < cells.length - 1) return;
+  e.preventDefault();
+  flushTarget(e.currentTarget);
+  const { block } = findBlock(editorSelection.activeBlockId);
+  tableMutation('addRow');
+}
+const getOffsets = (el) =>
+  containedSelectionOffsets(el, getSelection(), document);
+function resolveRuns() {
+  const { block } = findBlock(editorSelection.activeBlockId);
+  if (!block) return null;
+  if (editorSelection.container === 'block') return block.runs;
+  if (editorSelection.container === 'item')
+    return block.items.find((x) => x.id === editorSelection.itemId)?.runs;
+  if (
+    editorSelection.container === 'caption' ||
+    editorSelection.container === 'image-caption'
+  )
+    return block.captionRuns;
+  if (editorSelection.container === 'heading')
+    return block.columns[editorSelection.column]?.headingRuns;
+  if (editorSelection.container === 'cell')
+    return block.rows[editorSelection.row]?.cells[editorSelection.column]?.runs;
+  return null;
+}
+function replaceResolved(runs) {
+  const { block } = findBlock(editorSelection.activeBlockId);
+  if (editorSelection.container === 'block') block.runs = runs;
+  else if (editorSelection.container === 'item')
+    block.items.find((x) => x.id === editorSelection.itemId).runs = runs;
+  else if (['caption', 'image-caption'].includes(editorSelection.container))
+    block.captionRuns = runs;
+  else if (editorSelection.container === 'heading')
+    block.columns[editorSelection.column].headingRuns = runs;
+  else if (editorSelection.container === 'cell')
+    block.rows[editorSelection.row].cells[editorSelection.column].runs = runs;
+}
+function transformSelection(kind, value, { useCaptured = false } = {}) {
+  flushAll();
+  if (!useCaptured) {
+    const offsets = getOffsets(activeEditable());
+    if (offsets) editorSelection.offsets = offsets;
+  }
+  const runs = resolveRuns();
+  if (!runs || !editorSelection.offsets) return false;
+  if (
+    kind === 'highlight' &&
+    editorSelection.offsets[0] === editorSelection.offsets[1]
+  )
+    editorSelection.offsets = [0, runText(runs).length];
+  commit(() =>
+    replaceResolved(transformRuns(runs, editorSelection.offsets, kind, value)),
+  );
+  return true;
+}
+function defaultInsertionContext() {
+  const group = selectedEditableGroup();
+  return group
+    ? {
+        groupId: group.id,
+        referenceBlockId: editorSelection.activeBlockId,
+        position: 'after',
+      }
+    : null;
+}
+function insertBlock(
+  type,
+  context = defaultInsertionContext(),
+  headingLevel = 2,
+) {
+  if (
+    typeof type !== 'string' ||
+    !['paragraph', 'heading', 'bulletList', 'numberList', 'table'].includes(
+      type,
+    )
+  )
+    return false;
+  const group = [...state.steps, ...state.appendices].find(
+    (x) => x.id === context?.groupId,
+  );
+  if (!group) return false;
+  const index = insertionIndex(group, context);
+  if (index < 0) return false;
+  const id = newId('block');
+  let block = { id, type, runs: [] };
+  if (type === 'heading')
+    block.level = Math.min(4, Math.max(1, Number(headingLevel) || 2));
+  if (type.endsWith('List'))
+    block = { id, type, items: [{ id: newId('item'), level: 1, runs: [] }] };
+  if (type === 'table')
+    block = {
+      id,
+      type,
+      captionRuns: [{ text: 'Table caption' }],
+      columns: [
+        { id: newId('column'), headingRuns: [{ text: 'Column 1' }], width: 50 },
+        { id: newId('column'), headingRuns: [{ text: 'Column 2' }], width: 50 },
+      ],
+      rows: [
+        {
+          id: newId('row'),
+          cells: [
+            { id: newId('cell'), runs: [] },
+            { id: newId('cell'), runs: [] },
+          ],
+        },
+      ],
+    };
+  const result = insertBlockOperation(state, group.id, block, index);
+  selectOperationResult(result, type);
+  editorSelection.restoreFocus = true;
+  if (!applyDocumentOperation(result)) return false;
+  return true;
+}
+function moveBlock(id, direction) {
+  flushAll();
+  const result = moveBlockOperation(state, id, direction);
+  if (!applyDocumentOperation(result)) return false;
+  editorSelection.activeBlockId = id;
+  announce(`Block moved to position ${result.index + 1}`);
+  return true;
+}
+function deleteBlock(id) {
+  flushAll();
+  const found = findBlock(id);
+  if (!found.block) return false;
+  const label = blockTypeLabel(found.block.type),
+    result = deleteBlockOperation(state, id);
+  if (!applyDocumentOperation(result)) return false;
+  selectOperationResult(result, result.selectedBlockType);
+  announce(`${label[0].toUpperCase() + label.slice(1)} deleted`);
+  return true;
+}
+function selectGroup(group, type, { blockId = null } = {}) {
+  Object.assign(editorSelection, {
+    activeGroupId: group?.id || null,
+    activeGroupType: group ? type : null,
+    activeStepId: type === 'step' ? group?.id || null : null,
+    activeBlockId: blockId,
+    blockType: blockId ? 'paragraph' : null,
+    container: blockId ? 'block' : null,
+    offsets: [0, 0],
+  });
+}
+function manageStep(action) {
+  flushAll();
+  const id = editorSelection.activeStepId,
+    index = state.steps.findIndex((x) => x.id === id);
+  if (index < 0) return;
+  if (action === 'deleteStep') {
+    if (
+      stepHasMovements(state.excel, id) &&
+      !confirm(
+        'Deleting this step will delete its nonzero Excel share movements from every company. Continue?',
+      )
+    )
+      return;
+    if (!confirmStepDeletion(state.steps, index, confirm)) return;
+    const result = deleteStepOperation(state, id);
+    if (applyDocumentOperation(result)) {
+      const target = state.steps.find((x) => x.id === result.selectedGroupId);
+      if (target) selectGroup(target, 'step');
+      announce('Step deleted');
+    }
+    return;
+  }
+  const result = moveStepOperation(state, id, action === 'moveStepUp' ? -1 : 1);
+  if (applyDocumentOperation(result))
+    announce(`Step moved to position ${result.index + 1}`);
+}
+function addStep(where = 'after') {
+  flushAll();
+  const result = addStepOperation(state, {
+    referenceId: editorSelection.activeStepId,
+    position: where,
+    idFactory: newId,
+  });
+  if (!applyDocumentOperation(result)) return false;
+  selectOperationResult(result, 'paragraph');
+  return true;
+}
+function addAppendix() {
+  flushAll();
+  const result = addAppendixOperation(state, { idFactory: newId });
+  if (!applyDocumentOperation(result)) return false;
+  selectOperationResult(result, 'paragraph');
+  announce(`${appendixLabel(result.index)} added`);
+  return true;
+}
+function manageAppendix(action) {
+  flushAll();
+  const id = editorSelection.activeGroupId,
+    index = state.appendices.findIndex((x) => x.id === id);
+  if (index < 0) return;
+  const appendix = state.appendices[index];
+  if (action === 'deleteAppendix') {
+    if (
+      !confirm(
+        `Delete ${appendixLabel(index)}: ${appendix.title}? This can be undone.`,
+      )
+    )
+      return;
+    const result = deleteAppendixOperation(state, id);
+    if (!applyDocumentOperation(result)) return;
+    const target =
+      state.appendices.find((x) => x.id === result.selectedGroupId) ||
+      state.steps.at(-1);
+    if (target)
+      selectGroup(
+        target,
+        state.appendices.includes(target) ? 'appendix' : 'step',
+      );
+    announce('Appendix deleted');
+    return;
+  }
+  const result = moveAppendixOperation(
+    state,
+    id,
+    action === 'moveAppendixUp' ? -1 : 1,
+  );
+  if (applyDocumentOperation(result))
+    announce(`Appendix moved to ${appendixLabel(result.index)}`);
+}
+function tableMutation(action) {
+  flushAll();
+  const { block } = findBlock(editorSelection.activeBlockId);
+  if (block?.type !== 'table') return false;
+  const rowIndex =
+      editorSelection.row == null ? NaN : Number(editorSelection.row),
+    columnIndex =
+      editorSelection.column == null ? NaN : Number(editorSelection.column),
+    row = block.rows[rowIndex],
+    column = block.columns[columnIndex];
+  let result;
+  if (action === 'moveRowUp' || action === 'moveRowDown')
+    result = moveTableRowOperation(
+      state,
+      block.id,
+      row?.id,
+      action === 'moveRowUp' ? -1 : 1,
+    );
+  else if (action === 'moveColumnLeft' || action === 'moveColumnRight')
+    result = moveTableColumnOperation(
+      state,
+      block.id,
+      column?.id,
+      action === 'moveColumnLeft' ? -1 : 1,
+    );
+  else if (action === 'addRow')
+    result = insertTableRowOperation(state, block.id, row?.id, {
+      idFactory: newId,
+    });
+  else if (action === 'addColumn')
+    result = insertTableColumnOperation(state, block.id, column?.id, {
+      idFactory: newId,
+    });
+  else if (action === 'removeRow')
+    result = deleteTableRowOperation(state, block.id, row?.id);
+  else if (action === 'removeColumn')
+    result = deleteTableColumnOperation(state, block.id, column?.id);
+  else return false;
+  if (!applyDocumentOperation(result)) return false;
+  if ('rowIndex' in result) editorSelection.row = result.rowIndex;
+  if ('columnIndex' in result) editorSelection.column = result.columnIndex;
+  editorSelection.offsets = [0, 0];
+  if (action.startsWith('moveRow'))
+    announce(`Row moved to position ${result.rowIndex + 1}`);
+  if (action.startsWith('moveColumn'))
+    announce(`Column moved to position ${result.columnIndex + 1}`);
+  return true;
+}
+function linkPicker() {
+  captureSelection();
+  const dialog = $('#link-picker'),
+    list = $('#link-destination'),
+    destinations = [
+      ...state.steps.map((group, index) => ({
+        group,
+        label: `Step ${index + 1}. ${group.title}`,
+      })),
+      ...state.appendices.map((group, index) => ({
+        group,
+        label: `${appendixLabel(index)}. ${group.title}`,
+      })),
+    ];
+  list.innerHTML = destinations
+    .map(
+      ({ group, label }) =>
+        `<option value="#${stableAnchor(group)}">${esc(label)}</option>`,
+    )
+    .join('');
+  dialog.showModal();
+}
+let insertionContext = null,
+  imageInsertionContext = null;
+function blankStepClick(event) {
+  if (event.button !== 0 || event.defaultPrevented) return;
+  const stepElement = event.currentTarget;
+  const active = document.activeElement,
+    editing = active?.matches?.('[contenteditable=true],[data-group-title]');
+  if (
+    editing &&
+    !event.target.closest(
+      '[contenteditable=true],[data-group-title],button,input,select,textarea,a',
+    )
+  ) {
+    flushAll();
+    active.blur();
+    getSelection()?.removeAllRanges();
+    Object.assign(editorSelection, {
+      activeBlockId: null,
+      blockType: null,
+      container: null,
+      itemId: null,
+      row: null,
+      column: null,
+      rowId: null,
+      columnId: null,
+      cellId: null,
+      offsets: null,
+      restoreFocus: false,
+    });
+    return;
+  }
+  if (
+    event.target.closest(
+      '.editable-block,.step-heading,.page-header,.page-footer,a,button,input,select,textarea,[contenteditable="true"],.block-controls,.toolbar',
+    )
+  )
+    return;
+  const body =
+    event.target.closest('.document-body') ||
+    stepElement.querySelector('.document-body');
+  if (!body || !stepElement.contains(event.target)) return;
+  const group = [...state.steps, ...state.appendices].find(
+    (item) => item.id === stepElement.dataset.editableGroupId,
+  );
+  if (!group) return;
+  const canInsert = canOpenBlankSpaceInsertion(
+    editorSelection.activeGroupId,
+    group.id,
+  );
+  selectGroup(group, stepElement.dataset.groupType);
+  document
+    .querySelectorAll('[data-editable-group-id]')
+    .forEach((element) =>
+      element.classList.toggle(
+        'is-selected',
+        element.dataset.editableGroupId === group.id,
+      ),
+    );
+  if (!canInsert) return;
+  insertionContext = insertionContextFromPoint(
+    group.id,
+    [...stepElement.querySelectorAll('[data-block-id]')],
+    event.clientY,
+  );
+  const chooser = $('#insertion-chooser');
+  if (!chooser.open) chooser.showModal();
+  queueMicrotask(() =>
+    chooser.querySelector('[data-insert-choice="paragraph"]').focus(),
+  );
+}
+function addImage(context = defaultInsertionContext()) {
+  if (
+    ![...state.steps, ...state.appendices].some(
+      (group) => group.id === context?.groupId,
+    )
+  )
+    return;
+  imageInsertionContext = context;
+  const form = $('#image-form'),
+    error = $('#image-form-error');
+  form.reset();
+  error.hidden = true;
+  error.textContent = '';
+  $('#image-dialog').showModal();
+  form.elements.src.focus();
+}
+function historyChangeTarget(next) {
+  if (!next) return null;
+  const currentGroups = allGroups(),
+    nextGroups = [...next.sections, ...next.steps, ...next.appendices];
+  for (const nextGroup of nextGroups) {
+    const currentGroup = currentGroups.find(
+      (group) => group.id === nextGroup.id,
+    );
+    if (!currentGroup) return { groupId: nextGroup.id };
+    if (currentGroup.title !== nextGroup.title)
+      return { groupId: currentGroup.id };
+    const ids = new Set([
+      ...currentGroup.blocks.map((block) => block.id),
+      ...nextGroup.blocks.map((block) => block.id),
+    ]);
+    for (const id of ids) {
+      const before = currentGroup.blocks.find((block) => block.id === id),
+        after = nextGroup.blocks.find((block) => block.id === id);
+      if (JSON.stringify(before) !== JSON.stringify(after))
+        return { groupId: currentGroup.id, blockId: before?.id || null };
+    }
+  }
+  const removed = currentGroups.find(
+    (group) => !nextGroups.some((item) => item.id === group.id),
+  );
+  return removed ? { groupId: removed.id } : null;
+}
+function revealHistoryChange(next) {
+  const target = historyChangeTarget(next);
+  if (!target) return;
+  const node =
+    (target.blockId &&
+      document.querySelector(
+        `[data-block-id="${CSS.escape(target.blockId)}"]`,
+      )) ||
+    document.querySelector(
+      `[data-editable-group-id="${CSS.escape(target.groupId)}"]`,
+    ) ||
+    document.querySelector(
+      `.pagedjs_page[data-group-id="${CSS.escape(target.groupId)}"]`,
+    );
+  const page =
+    node?.closest('.pagedjs_page') ||
+    (node?.matches('.pagedjs_page') ? node : null);
+  if (!page) return;
+  const pages = [...document.querySelectorAll('.pagedjs_page')];
+  setCurrentPage(pages.indexOf(page) + 1, { scroll: false, focus: false });
+  page.scrollIntoView({ behavior: 'auto', block: 'center' });
+}
+function command(action) {
+  flushAll();
+  if ((action === 'undo' || action === 'redo') && activeEditor === 'excel') {
+    excelController[action]();
+    markDirty();
+    return;
+  }
+  if (action === 'undo') {
+    const previousView = navigationHistory.undo();
+    if (previousView) {
+      restoreView(previousView);
+      announce('Returned to the previous location');
+      return;
+    }
+  }
+  if (action === 'undo' || action === 'redo') {
+    navigationHistory.clear();
+    pending.forEach((x) => clearTimeout(x.timer));
+    pending.clear();
+    const next = action === 'undo' ? history.peekUndo() : history.peekRedo();
+    revealHistoryChange(next);
+    const currentExcel = state.excel,
+      stepsState = action === 'undo' ? history.undo() : history.redo();
+    state = normaliseDocument({ ...stepsState, excel: currentExcel });
+    history.replace(state);
+    markDirty();
+    if (
+      ![...state.steps, ...state.appendices].some(
+        (x) => x.id === editorSelection.activeGroupId,
+      )
+    ) {
+      const group = state.steps[0] || state.appendices[0];
+      selectGroup(group, state.steps.includes(group) ? 'step' : 'appendix');
+    }
+    return render();
+  }
+  if (action === 'addStepBefore' || action === 'addStepAfter')
+    return addStep(action.endsWith('After') ? 'after' : 'before');
+  if (['moveStepUp', 'moveStepDown', 'deleteStep'].includes(action))
+    return manageStep(action);
+  if (action === 'addAppendix') return addAppendix();
+  if (['moveAppendixUp', 'moveAppendixDown', 'deleteAppendix'].includes(action))
+    return manageAppendix(action);
+  const insertion = routeInsertionCommand(action);
+  if (insertion?.kind === 'table') return tableMutation(insertion.action);
+  if (insertion?.kind === 'block' && typeof insertion.blockType === 'string')
+    return insertBlock(insertion.blockType);
+  if (action === 'addImage') return addImage();
+  if (action === 'highlight' || action === 'unlink')
+    return transformSelection(action === 'unlink' ? 'unlink' : 'highlight');
+  if (action === 'link') return linkPicker();
+  if (editorSelection.blockType === 'image') return;
+  const { block } = findBlock(editorSelection.activeBlockId);
+  if (
+    !block ||
+    !['heading', 'paragraph', 'bulletList', 'numberList'].includes(block.type)
+  )
+    return;
+  if (canApplyBlockStyle(block.type, action)) {
+    const result = convertBlockStyleOperation(state, block.id, action, {
+      idFactory: newId,
+    });
+    if (applyDocumentOperation(result))
+      editorSelection.blockType = result.selectedBlockType;
+  }
+}
+function announce(message) {
+  $('#editor-status').textContent = '';
+  requestAnimationFrame(() => ($('#editor-status').textContent = message));
+}
+function updateControls() {
+  const i = state.steps.findIndex((x) => x.id === editorSelection.activeStepId),
+    step = i >= 0,
+    appendixIndex =
+      editorSelection.activeGroupType === 'appendix'
+        ? state.appendices.findIndex(
+            (x) => x.id === editorSelection.activeGroupId,
+          )
+        : -1,
+    editable = !!selectedEditableGroup();
+  document
+    .querySelectorAll('[data-command=moveStepUp]')
+    .forEach((x) => (x.disabled = !step || i === 0));
+  document
+    .querySelectorAll('[data-command=moveStepDown]')
+    .forEach((x) => (x.disabled = !step || i === state.steps.length - 1));
+  document
+    .querySelectorAll('[data-command=deleteStep]')
+    .forEach((x) => (x.disabled = !step || state.steps.length === 1));
+  document
+    .querySelectorAll('[data-requires-step]')
+    .forEach((x) => (x.disabled = !step));
+  document
+    .querySelectorAll('[data-requires-group]')
+    .forEach((x) => (x.disabled = !editable));
+  document
+    .querySelectorAll('[data-command=moveAppendixUp]')
+    .forEach((x) => (x.disabled = appendixIndex <= 0));
+  document
+    .querySelectorAll('[data-command=moveAppendixDown]')
+    .forEach(
+      (x) =>
+        (x.disabled =
+          appendixIndex < 0 || appendixIndex === state.appendices.length - 1),
+    );
+  document
+    .querySelectorAll('[data-command=deleteAppendix]')
+    .forEach((x) => (x.disabled = appendixIndex < 0));
+  const runs = resolveRuns(),
+    text = !!runs;
+  document
+    .querySelectorAll('[data-text-command]')
+    .forEach((x) => (x.disabled = !text));
+  const { block } = findBlock(editorSelection.activeBlockId),
+    style = $('#style'),
+    choices = blockStyleChoices(block?.type);
+  if (style.dataset.choices !== JSON.stringify(choices)) {
+    style.replaceChildren(
+      ...choices.map(([value, label]) => {
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = label;
+        return option;
+      }),
+    );
+    style.dataset.choices = JSON.stringify(choices);
+  }
+  document
+    .querySelectorAll('[data-table-command]')
+    .forEach((x) => (x.hidden = block?.type !== 'table'));
+  document
+    .querySelectorAll('[data-table-group]')
+    .forEach((x) => (x.hidden = block?.type !== 'table'));
+  style.disabled = !text;
+  if (block?.type === 'heading') style.value = `heading${block.level}`;
+  else if (block?.type === 'paragraph') style.value = 'body';
+  else if (['bulletList', 'numberList'].includes(block?.type))
+    style.value = block.type;
+  const row = editorSelection.row == null ? NaN : Number(editorSelection.row),
+    column =
+      editorSelection.column == null ? NaN : Number(editorSelection.column),
+    selectedRow = block?.rows?.[row];
+  document
+    .querySelectorAll('[data-command=moveRowUp]')
+    .forEach(
+      (x) =>
+        (x.disabled =
+          !selectedRow ||
+          row === 0 ||
+          block.rows[row - 1]?.isTotal !== selectedRow.isTotal),
+    );
+  document
+    .querySelectorAll('[data-command=moveRowDown]')
+    .forEach(
+      (x) =>
+        (x.disabled =
+          !selectedRow ||
+          row === block.rows.length - 1 ||
+          block.rows[row + 1]?.isTotal !== selectedRow.isTotal),
+    );
+  document
+    .querySelectorAll('[data-command=moveColumnLeft]')
+    .forEach((x) => (x.disabled = !block?.columns?.[column] || column === 0));
+  document
+    .querySelectorAll('[data-command=moveColumnRight]')
+    .forEach(
+      (x) =>
+        (x.disabled =
+          !block?.columns?.[column] || column === block.columns.length - 1),
+    );
+  const format = $('#column-format'),
+    selectedColumn = block?.columns?.[column];
+  format.disabled = !selectedColumn;
+  if (selectedColumn) format.value = tableColumnFormat(selectedColumn);
+  const total = $('#column-total-enabled');
+  total.disabled =
+    !selectedColumn || tableColumnFormat(selectedColumn) === 'text';
+  total.checked = !!selectedColumn?.totalEnabled;
+}
+document.querySelectorAll('[data-command]').forEach((b) => {
+  b.addEventListener('pointerdown', (e) => {
+    if (b.dataset.textCommand !== undefined) {
+      e.preventDefault();
+      captureSelection();
+    }
+  });
+  b.addEventListener('click', () => command(b.dataset.command));
+});
+$('#style').onchange = (e) => command(e.target.value);
+$('#column-format').onchange = (e) => {
+  const { block } = findBlock(editorSelection.activeBlockId),
+    column =
+      block?.columns?.[
+        editorSelection.column == null ? NaN : Number(editorSelection.column)
+      ];
+  if (!column) return;
+  const result = setTableColumnFormatOperation(
+    state,
+    block.id,
+    column.id,
+    e.target.value,
+  );
+  if (applyDocumentOperation(result))
+    announce(
+      `Column format changed to ${e.target.selectedOptions[0].textContent}`,
+    );
+};
+$('#column-total-enabled').onchange = (e) => {
+  captureSelection();
+  const { block } = findBlock(editorSelection.activeBlockId),
+    column =
+      block?.columns?.find((c) => c.id === editorSelection.columnId) ||
+      block?.columns?.[Number(editorSelection.column)];
+  if (!column) return;
+  applyDocumentOperation(
+    setTableColumnTotalOperation(state, block.id, column.id, e.target.checked),
+  );
+};
+const linkDialog = $('#link-picker');
+let applyingLink = false;
+$('#link-form').onsubmit = (e) => {
+  e.preventDefault();
+  const external = $('#external-link').value,
+    href = validatedLink(external, $('#link-destination').value);
+  if (href) {
+    applyingLink = true;
+    linkDialog.close();
+    transformSelection('link', href, { useCaptured: true });
+    applyingLink = false;
+    editorSelection.offsets = null;
+  } else
+    announce('Enter a valid HTTPS, HTTP, mailto, or internal destination.');
+};
+linkDialog.addEventListener('close', () => {
+  if (!applyingLink) editorSelection.offsets = null;
+  $('#link-form').reset();
+});
+const insertionChooser = $('#insertion-chooser'),
+  templateLoader = new EncryptedTemplateLoader();
+function showInsertionPanel(name, focus = true) {
+  insertionChooser
+    .querySelectorAll('[data-insertion-panel]')
+    .forEach((panel) => (panel.hidden = panel.dataset.insertionPanel !== name));
+  if (focus)
+    queueMicrotask(() =>
+      insertionChooser
+        .querySelector(
+          `[data-insertion-panel="${name}"] button, [data-insertion-panel="${name}"] input`,
+        )
+        ?.focus(),
+    );
+}
+function finishInsertion(callback) {
+  const context = insertionContext;
+  insertionContext = null;
+  insertionChooser.close();
+  callback(context);
+}
+insertionChooser.querySelectorAll('[data-open-insertion-panel]').forEach(
+  (button) =>
+    (button.onclick = () => {
+      showInsertionPanel(button.dataset.openInsertionPanel);
+      if (button.dataset.openInsertionPanel === 'defaults') openDefaults();
+    }),
+);
+insertionChooser
+  .querySelectorAll('[data-insertion-back]')
+  .forEach((button) => (button.onclick = () => showInsertionPanel('main')));
+insertionChooser
+  .querySelectorAll('[data-insert-choice]')
+  .forEach(
+    (button) =>
+      (button.onclick = () =>
+        finishInsertion((context) =>
+          button.dataset.insertChoice === 'image'
+            ? addImage(context)
+            : insertBlock(button.dataset.insertChoice, context),
+        )),
+  );
+insertionChooser
+  .querySelectorAll('[data-insert-heading]')
+  .forEach(
+    (button) =>
+      (button.onclick = () =>
+        finishInsertion((context) =>
+          insertBlock('heading', context, button.dataset.insertHeading),
+        )),
+  );
+function renderTemplates(templates) {
+  const choices = $('#default-template-choices');
+  choices.replaceChildren(
+    ...templates.map((template) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = template.header;
+      button.onclick = () =>
+        finishInsertion((context) => insertTemplate(template, context));
+      return button;
+    }),
+  );
+  $('#default-unlock').hidden = true;
+  choices.querySelector('button')?.focus();
+}
+async function openDefaults() {
+  const error = $('#default-error');
+  error.hidden = true;
+  if (templateLoader.cached) {
+    renderTemplates(await templateLoader.unlock());
+    return;
+  }
+  $('#default-unlock').hidden = false;
+  $('#default-password').focus();
+}
+$('#unlock-defaults').onclick = async () => {
+  const input = $('#default-password'),
+    button = $('#unlock-defaults'),
+    error = $('#default-error'),
+    password = input.value;
+  input.value = '';
+  button.disabled = true;
+  error.hidden = true;
+  try {
+    renderTemplates(
+      await templateLoader.unlock(defaultTemplateEnvelope, password),
+    );
+  } catch (failure) {
+    error.textContent = failure.message;
+    error.hidden = false;
+    input.focus();
+  } finally {
+    button.disabled = false;
+  }
+};
+$('#default-password').addEventListener('keydown', (event) => {
+  if (event.key !== 'Enter') return;
+  event.preventDefault();
+  event.stopPropagation();
+  $('#unlock-defaults').click();
+});
+function insertTemplate(template, context) {
+  const group = [...state.steps, ...state.appendices].find(
+      (item) => item.id === context?.groupId,
+    ),
+    at = insertionIndex(group, context);
+  if (!group || at < 0) {
+    announce('That insertion location is no longer available.');
+    return false;
+  }
+  const blocks = templateBlocks(template, newId);
+  let result;
+  for (const [offset, block] of blocks.entries()) {
+    result = insertBlockOperation(
+      result?.document || state,
+      group.id,
+      block,
+      at + offset,
+    );
+    if (!result.changed) return false;
+  }
+  applyDocumentOperation(result);
+  Object.assign(editorSelection, {
+    activeBlockId: blocks[0].id,
+    blockType: 'heading',
+    container: 'block',
+    itemId: null,
+    row: null,
+    column: null,
+    offsets: [0, template.header.length],
+  });
+  announce(`${template.header} inserted`);
+  return true;
+}
+insertionChooser.addEventListener('close', () => {
+  insertionContext = null;
+  $('#default-password').value = '';
+  showInsertionPanel('main', false);
+});
 bindCallouts();
-function persistDraft({quiet=false,updateUrl=false}={}){flushAll(false);clearTimeout(autosaveTimer);let result;try{result=saveDraft(state,loadedRevision)}catch(error){const indicator=$('#save-state');indicator.textContent='Save failed';indicator.className='save-state error';if(!quiet)alert(`Could not save this draft: ${error.message}`);return false}if(!result.ok){const indicator=$('#save-state');indicator.textContent='Newer draft in another tab';indicator.className='save-state error';if(!quiet)alert('This draft was changed in another tab. Reload before saving so that the newer draft and recovery copy are not overwritten.');return false}loadedRevision=result.revision;dirty=false;if(updateUrl)updateSnapshotUrl(result.record.document,window.location,window.history);const indicator=$('#save-state');indicator.textContent=`Saved locally ${new Date(result.record.savedAt).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'})}`;indicator.className='save-state';return true}
-function versionsDialog(){const dialog=$('#versions-dialog'),list=$('#versions-list'),versions=listVersions();list.innerHTML=versions.length?versions.map(v=>`<div class="version-row"><span><b>${esc(v.label)}</b><small>${new Date(v.savedAt).toLocaleString()}</small></span><button type="button" data-restore-version="${esc(v.id)}">Restore</button><button type="button" data-delete-version="${esc(v.id)}">Delete</button></div>`).join(''):'<p>No saved versions yet.</p>';list.querySelectorAll('[data-restore-version]').forEach(button=>button.onclick=async()=>{const version=listVersions().find(v=>v.id===button.dataset.restoreVersion);if(!version)return;if(!persistDraft())return;state=normaliseDocument(version.document);history.commit(state);excelController?.restore(state.excel);markDirty();dialog.close();await render({restore:false});announce('Saved version restored')});list.querySelectorAll('[data-delete-version]').forEach(button=>button.onclick=()=>{deleteVersion(button.dataset.deleteVersion);versionsDialog()});if(!dialog.open)dialog.showModal()}
-const propertiesDialog=$('#properties-dialog'),propertiesForm=$('#properties-form');$('#document-properties').onclick=()=>{for(const key of METADATA_KEYS)propertiesForm.elements[key].value=state.meta[key];propertiesDialog.showModal()};propertiesForm.onsubmit=async event=>{event.preventDefault();for(const key of METADATA_KEYS)propertiesForm.elements[key].value=propertiesForm.elements[key].value.trim();if(!propertiesForm.reportValidity())return;await commit(()=>{for(const key of METADATA_KEYS)state.meta[key]=propertiesForm.elements[key].value},{focus:false});propertiesDialog.close();announce('Document properties updated')};
-const imageDialog=$('#image-dialog'),imageForm=$('#image-form'),imageError=$('#image-form-error');imageDialog.addEventListener('close',()=>imageInsertionContext=null);imageForm.onsubmit=event=>{event.preventDefault();const caption=imageForm.elements.caption.value.trim(),widthValue=imageForm.elements.width.value,result=validateImageInput({source:imageForm.elements.src.value,altText:imageForm.elements.alt.value,width:widthValue});if(!result.ok||!imageForm.checkValidity()){const messages={'missing-source':'Enter an image URL and alternative text, and use a width between 20 and 100.','missing-alt-text':'Enter an image URL and alternative text, and use a width between 20 and 100.','malformed-source':'Enter a complete, well-formed image URL.','unsupported-protocol':'Unsupported protocol. Image URLs must use HTTPS.','unsupported-extension':'Unsupported image extension. Use a PNG, JPEG, GIF or WebP URL.'};imageError.textContent=messages[result.error]||'Enter an image URL and alternative text, and use a width between 20 and 100.';imageError.hidden=false;return}const context=imageInsertionContext,group=[...state.steps,...state.appendices].find(item=>item.id===context?.groupId),at=insertionIndex(group,context),id=newId('image'),{source,altText,width}=result.image;if(!group||at<0){imageError.textContent='That insertion location is no longer available.';imageError.hidden=false;return}const operation=insertBlockOperation(state,group.id,{id,type:'image',src:source,alt:altText,captionRuns:caption?[{text:caption}]:[],width},at);if(!applyDocumentOperation(operation))return;selectOperationResult(operation,'image');imageDialog.close();announce('Published image added')};
-$('#save-draft').onclick=()=>persistDraft({updateUrl:true});$('#save-version').onclick=()=>{if(!persistDraft())return;const label=prompt('Name this saved version:',`${state.meta.version||'Version'} — ${state.meta.status||'Draft'}`);if(label===null)return;const nextVersion=nextAvailableVersion(state.meta.version,listVersions());saveVersion(state,label);commit(()=>{state.meta.version=nextVersion},{focus:false});announce(`Named version saved; document advanced to ${nextVersion}`)};$('#show-versions').onclick=versionsDialog;$('#share-snapshot').onclick=async()=>{flushAll(false);const url=`${location.href.split('#')[0]}#snapshot=${encodeSnapshot(state)}`;try{await navigator.clipboard.writeText(url);announce('Snapshot link copied')}catch{prompt('Copy this validated snapshot link:',url)}};$('#open-selected-link').onpointerdown=event=>event.preventDefault();$('#open-selected-link').onclick=()=>openEditorLink($('#link-context').dataset.href);$('#preview').addEventListener('click',editableLinkClick);document.addEventListener('selectionchange',updateLinkContext);
-const printButton=$('#print-document');
-const printing=new PrintLifecycle({flush:()=>flushAll(false),cancelPagination:()=>repagination.cancel(),render:()=>render({immediate:true}),prepare:()=>{const view=captureView();document.documentElement.classList.add('preparing-print');printButton.disabled=true;announce('Preparing complete document for printing');return view},clearPresentation:()=>{getSelection()?.removeAllRanges();document.activeElement?.blur?.()},print:()=>window.print(),onAfterPrint:cleanup=>{window.addEventListener('afterprint',cleanup,{once:true});return()=>window.removeEventListener('afterprint',cleanup)},restore:view=>{document.documentElement.classList.remove('preparing-print');printButton.disabled=false;restoreView(view);announce('Print preparation finished')},onError:error=>announce(`Print preparation failed: ${error.message}`)});
-const exportDocument=()=>printing.run();printButton.onclick=exportDocument;$('#export-document').onclick=exportDocument;document.addEventListener('keydown',event=>{if(!(event.ctrlKey||event.metaKey)||event.altKey)return;const key=event.key.toLowerCase();let action=null;if(key==='z')action=event.shiftKey?'redo':'undo';else if(key==='y'&&!event.shiftKey)action='redo';else if(key==='s')action=event.shiftKey?'export':'save';if(!action)return;event.preventDefault();flushAll();if(action==='save')persistDraft({updateUrl:true});else if(action==='export')exportDocument();else command(action)});
-addEventListener('pagehide',()=>{if(dirty||hasPendingInputs())persistDraft({quiet:true})});document.addEventListener('visibilitychange',()=>{if(document.visibilityState==='hidden'&&(dirty||hasPendingInputs()))persistDraft({quiet:true})});addEventListener('storage',event=>{if(event.key==='ubta:draft'&&readDraft()?.revision!==loadedRevision){const indicator=$('#save-state');indicator.textContent='Newer draft in another tab';indicator.className='save-state error'}});
-let pageObserver=null,observedAreas=new Map();
-function pageLabel(page,index){const type=page.dataset.groupType,groupId=page.dataset.groupId,continued=Number(page.dataset.pageFragment)>0;if(type==='step'){const i=state.steps.findIndex(x=>x.id===groupId);return `Page ${index+1} — Step ${i+1}${continued?' (continued)':''}`}if(type==='appendix'){const i=state.appendices.findIndex(x=>x.id===groupId);return `Page ${index+1} — ${appendixLabel(i)}${continued?' (continued)':''}`}const sheet=page.querySelector('.sheet-source');return `Page ${index+1} — ${sheet?.classList.contains('cover')?'Cover':sheet?.classList.contains('contents')?'Contents':type==='section'?'Section':'Document'}`}
-function rebuildPageJump(pages=[...document.querySelectorAll('.pagedjs_page')]){const jump=$('#page-jump');jump.replaceChildren(...pages.map((page,index)=>{const option=document.createElement('option');option.value=String(index+1);option.textContent=pageLabel(page,index);return option}));jump.value=String(Math.min(currentPage,pages.length||1))}
-function setCurrentPage(page,{scroll=false,focus=false}={}){const pages=[...document.querySelectorAll('.pagedjs_page')];currentPage=Math.max(1,Math.min(pages.length||1,Number(page)||1));$('#current').textContent=currentPage;const jump=$('#page-jump');if(jump)jump.value=String(currentPage);$('#prev').disabled=currentPage<=1;$('#next').disabled=currentPage>=pages.length;if(scroll)pages[currentPage-1]?.scrollIntoView({behavior:'smooth',block:'center'});if(focus)setTimeout(()=>focusPageContext(pages[currentPage-1]),scroll?350:0)}
-function focusPageContext(page){if(!page)return;const type=page.dataset.groupType,id=page.dataset.groupId;if(type==='step'||type==='appendix'){const group=(type==='step'?state.steps:state.appendices).find(x=>x.id===id);selectGroup(group,type);const target=Number(page.dataset.pageFragment)===0?page.querySelector('[data-group-title]'):page.querySelector('[contenteditable=true], [data-group-title]');target?.focus({preventScroll:true});document.querySelectorAll('[data-editable-group-id]').forEach(x=>x.classList.toggle('is-selected',x.dataset.editableGroupId===id));announce(`${pageLabel(page,currentPage-1)}, ${group?.title||''}`)}else{Object.assign(editorSelection,{activeGroupId:null,activeGroupType:null,activeStepId:null,activeBlockId:null,container:null});page.focus({preventScroll:true});announce(pageLabel(page,currentPage-1))}updateControls()}
-function navigateToAnchor(anchor){const pages=[...document.querySelectorAll('.pagedjs_page')],index=pages.findIndex(page=>page.dataset.anchorId===anchor||page.querySelector(`#${CSS.escape(anchor)}`));if(index<0)return false;navigationHistory.push(captureView());setCurrentPage(index+1,{scroll:true,focus:true});return true}
-const openEditorLink=href=>followEditorLink(href,{navigateInternal:navigateToAnchor,openExternal:url=>{const opened=window.open(url,'_blank','noopener,noreferrer');if(opened)opened.opener=null},openMailto:url=>{window.location.href=url},report:announce});
-function editableLinkClick(event){handleEditableLinkClick(event,openEditorLink)}
-function selectedEditableLink(){const selection=getSelection(),node=selection?.anchorNode;return (node?.nodeType===Node.ELEMENT_NODE?node:node?.parentElement)?.closest?.('.editable-runs a')||null}
-function updateLinkContext(){const link=selectedEditableLink(),control=$('#link-context');control.hidden=!link;control.dataset.href=link?.getAttribute('href')||''}
-function disconnectPageObserver(){pageObserver?.disconnect();pageObserver=null;observedAreas.clear()}
-function observePages(){if(!('IntersectionObserver'in window))return;const pages=[...document.querySelectorAll('.pagedjs_page')];pageObserver=new IntersectionObserver(entries=>{for(const entry of entries)observedAreas.set(entry.target,entry.intersectionRect.width*entry.intersectionRect.height);let best=null;for(const page of pages){const area=observedAreas.get(page)||0,center=Math.abs(page.getBoundingClientRect().top+page.getBoundingClientRect().height/2-innerHeight/2);if(!best||area>best.area||(area===best.area&&center<best.center))best={page,area,center}}if(best?.area>0)setCurrentPage(pages.indexOf(best.page)+1)}, {threshold:[0,.1,.25,.5,.75,1]});pages.forEach(page=>pageObserver.observe(page))}
-function go(page){setCurrentPage(page,{scroll:true,focus:true})}$('#prev').onclick=()=>go(currentPage-1);$('#next').onclick=()=>go(currentPage+1);$('#page-jump').onchange=e=>go(Number(e.target.value));
-excelController=new ExcelEditor({root:$('#excel-editor'),toolbar:$('#excel-toolbar'),getDocument:()=>state,updateDocument:excel=>{state={...state,excel};history.replace(state);markDirty();},report:message=>{announce(message);alert(message);}});
-document.querySelectorAll('[data-editor]').forEach(button=>button.onclick=()=>{activeEditor=button.dataset.editor;document.querySelectorAll('[data-editor]').forEach(item=>item.toggleAttribute('aria-current',item===button));const excel=activeEditor==='excel';$('#preview').hidden=excel;$('#excel-editor').hidden=!excel;$('#excel-toolbar').hidden=!excel;if(excel)excelController.synchronize();});
-render({restore:false});
+function persistDraft({ quiet = false, updateUrl = false } = {}) {
+  flushAll(false);
+  clearTimeout(autosaveTimer);
+  let result;
+  try {
+    result = saveDraft(state, loadedRevision);
+  } catch (error) {
+    const indicator = $('#save-state');
+    indicator.textContent = 'Save failed';
+    indicator.className = 'save-state error';
+    if (!quiet) alert(`Could not save this draft: ${error.message}`);
+    return false;
+  }
+  if (!result.ok) {
+    const indicator = $('#save-state');
+    indicator.textContent = 'Newer draft in another tab';
+    indicator.className = 'save-state error';
+    if (!quiet)
+      alert(
+        'This draft was changed in another tab. Reload before saving so that the newer draft and recovery copy are not overwritten.',
+      );
+    return false;
+  }
+  loadedRevision = result.revision;
+  dirty = false;
+  if (updateUrl)
+    updateSnapshotUrl(result.record.document, window.location, window.history);
+  const indicator = $('#save-state');
+  indicator.textContent = `Saved locally ${new Date(result.record.savedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+  indicator.className = 'save-state';
+  return true;
+}
+function versionsDialog() {
+  const dialog = $('#versions-dialog'),
+    list = $('#versions-list'),
+    versions = listVersions();
+  list.innerHTML = versions.length
+    ? versions
+        .map(
+          (v) =>
+            `<div class="version-row"><span><b>${esc(v.label)}</b><small>${new Date(v.savedAt).toLocaleString()}</small></span><button type="button" data-restore-version="${esc(v.id)}">Restore</button><button type="button" data-delete-version="${esc(v.id)}">Delete</button></div>`,
+        )
+        .join('')
+    : '<p>No saved versions yet.</p>';
+  list.querySelectorAll('[data-restore-version]').forEach(
+    (button) =>
+      (button.onclick = async () => {
+        const version = listVersions().find(
+          (v) => v.id === button.dataset.restoreVersion,
+        );
+        if (!version) return;
+        if (!persistDraft()) return;
+        state = normaliseDocument(version.document);
+        history.commit(state);
+        excelController?.restore(state.excel);
+        markDirty();
+        dialog.close();
+        await render({ restore: false });
+        announce('Saved version restored');
+      }),
+  );
+  list.querySelectorAll('[data-delete-version]').forEach(
+    (button) =>
+      (button.onclick = () => {
+        deleteVersion(button.dataset.deleteVersion);
+        versionsDialog();
+      }),
+  );
+  if (!dialog.open) dialog.showModal();
+}
+const propertiesDialog = $('#properties-dialog'),
+  propertiesForm = $('#properties-form');
+$('#document-properties').onclick = () => {
+  for (const key of METADATA_KEYS)
+    propertiesForm.elements[key].value = state.meta[key];
+  propertiesDialog.showModal();
+};
+propertiesForm.onsubmit = async (event) => {
+  event.preventDefault();
+  for (const key of METADATA_KEYS)
+    propertiesForm.elements[key].value =
+      propertiesForm.elements[key].value.trim();
+  if (!propertiesForm.reportValidity()) return;
+  await commit(
+    () => {
+      for (const key of METADATA_KEYS)
+        state.meta[key] = propertiesForm.elements[key].value;
+    },
+    { focus: false },
+  );
+  propertiesDialog.close();
+  announce('Document properties updated');
+};
+const imageDialog = $('#image-dialog'),
+  imageForm = $('#image-form'),
+  imageError = $('#image-form-error');
+imageDialog.addEventListener('close', () => (imageInsertionContext = null));
+imageForm.onsubmit = (event) => {
+  event.preventDefault();
+  const caption = imageForm.elements.caption.value.trim(),
+    widthValue = imageForm.elements.width.value,
+    result = validateImageInput({
+      source: imageForm.elements.src.value,
+      altText: imageForm.elements.alt.value,
+      width: widthValue,
+    });
+  if (!result.ok || !imageForm.checkValidity()) {
+    const messages = {
+      'missing-source':
+        'Enter an image URL and alternative text, and use a width between 20 and 100.',
+      'missing-alt-text':
+        'Enter an image URL and alternative text, and use a width between 20 and 100.',
+      'malformed-source': 'Enter a complete, well-formed image URL.',
+      'unsupported-protocol':
+        'Unsupported protocol. Image URLs must use HTTPS.',
+      'unsupported-extension':
+        'Unsupported image extension. Use a PNG, JPEG, GIF or WebP URL.',
+    };
+    imageError.textContent =
+      messages[result.error] ||
+      'Enter an image URL and alternative text, and use a width between 20 and 100.';
+    imageError.hidden = false;
+    return;
+  }
+  const context = imageInsertionContext,
+    group = [...state.steps, ...state.appendices].find(
+      (item) => item.id === context?.groupId,
+    ),
+    at = insertionIndex(group, context),
+    id = newId('image'),
+    { source, altText, width } = result.image;
+  if (!group || at < 0) {
+    imageError.textContent = 'That insertion location is no longer available.';
+    imageError.hidden = false;
+    return;
+  }
+  const operation = insertBlockOperation(
+    state,
+    group.id,
+    {
+      id,
+      type: 'image',
+      src: source,
+      alt: altText,
+      captionRuns: caption ? [{ text: caption }] : [],
+      width,
+    },
+    at,
+  );
+  if (!applyDocumentOperation(operation)) return;
+  selectOperationResult(operation, 'image');
+  imageDialog.close();
+  announce('Published image added');
+};
+$('#save-draft').onclick = () => persistDraft({ updateUrl: true });
+$('#save-version').onclick = () => {
+  if (!persistDraft()) return;
+  const label = prompt(
+    'Name this saved version:',
+    `${state.meta.version || 'Version'} — ${state.meta.status || 'Draft'}`,
+  );
+  if (label === null) return;
+  const nextVersion = nextAvailableVersion(state.meta.version, listVersions());
+  saveVersion(state, label);
+  commit(
+    () => {
+      state.meta.version = nextVersion;
+    },
+    { focus: false },
+  );
+  announce(`Named version saved; document advanced to ${nextVersion}`);
+};
+$('#show-versions').onclick = versionsDialog;
+$('#share-snapshot').onclick = async () => {
+  flushAll(false);
+  const url = `${location.href.split('#')[0]}#snapshot=${encodeSnapshot(state)}`;
+  try {
+    await navigator.clipboard.writeText(url);
+    announce('Snapshot link copied');
+  } catch {
+    prompt('Copy this validated snapshot link:', url);
+  }
+};
+$('#open-selected-link').onpointerdown = (event) => event.preventDefault();
+$('#open-selected-link').onclick = () =>
+  openEditorLink($('#link-context').dataset.href);
+$('#preview').addEventListener('click', editableLinkClick);
+document.addEventListener('selectionchange', updateLinkContext);
+const printButton = $('#print-document');
+const printing = new PrintLifecycle({
+  flush: () => flushAll(false),
+  cancelPagination: () => repagination.cancel(),
+  render: () => render({ immediate: true }),
+  prepare: () => {
+    const view = captureView();
+    document.documentElement.classList.add('preparing-print');
+    printButton.disabled = true;
+    announce('Preparing complete document for printing');
+    return view;
+  },
+  clearPresentation: () => {
+    getSelection()?.removeAllRanges();
+    document.activeElement?.blur?.();
+  },
+  print: () => window.print(),
+  onAfterPrint: (cleanup) => {
+    window.addEventListener('afterprint', cleanup, { once: true });
+    return () => window.removeEventListener('afterprint', cleanup);
+  },
+  restore: (view) => {
+    document.documentElement.classList.remove('preparing-print');
+    printButton.disabled = false;
+    restoreView(view);
+    announce('Print preparation finished');
+  },
+  onError: (error) => announce(`Print preparation failed: ${error.message}`),
+});
+const exportDocument = () => printing.run();
+printButton.onclick = exportDocument;
+$('#export-document').onclick = exportDocument;
+document.addEventListener('keydown', (event) => {
+  if (!(event.ctrlKey || event.metaKey) || event.altKey) return;
+  const key = event.key.toLowerCase();
+  let action = null;
+  if (key === 'z') action = event.shiftKey ? 'redo' : 'undo';
+  else if (key === 'y' && !event.shiftKey) action = 'redo';
+  else if (key === 's') action = event.shiftKey ? 'export' : 'save';
+  if (!action) return;
+  event.preventDefault();
+  flushAll();
+  if (action === 'save') persistDraft({ updateUrl: true });
+  else if (action === 'export') exportDocument();
+  else command(action);
+});
+addEventListener('pagehide', () => {
+  if (dirty || hasPendingInputs()) persistDraft({ quiet: true });
+});
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'hidden' && (dirty || hasPendingInputs()))
+    persistDraft({ quiet: true });
+});
+addEventListener('storage', (event) => {
+  if (event.key === 'ubta:draft' && readDraft()?.revision !== loadedRevision) {
+    const indicator = $('#save-state');
+    indicator.textContent = 'Newer draft in another tab';
+    indicator.className = 'save-state error';
+  }
+});
+let pageObserver = null,
+  observedAreas = new Map();
+function pageLabel(page, index) {
+  const type = page.dataset.groupType,
+    groupId = page.dataset.groupId,
+    continued = Number(page.dataset.pageFragment) > 0;
+  if (type === 'step') {
+    const i = state.steps.findIndex((x) => x.id === groupId);
+    return `Page ${index + 1} — Step ${i + 1}${continued ? ' (continued)' : ''}`;
+  }
+  if (type === 'appendix') {
+    const i = state.appendices.findIndex((x) => x.id === groupId);
+    return `Page ${index + 1} — ${appendixLabel(i)}${continued ? ' (continued)' : ''}`;
+  }
+  const sheet = page.querySelector('.sheet-source');
+  return `Page ${index + 1} — ${sheet?.classList.contains('cover') ? 'Cover' : sheet?.classList.contains('contents') ? 'Contents' : type === 'section' ? 'Section' : 'Document'}`;
+}
+function rebuildPageJump(
+  pages = [...document.querySelectorAll('.pagedjs_page')],
+) {
+  const jump = $('#page-jump');
+  jump.replaceChildren(
+    ...pages.map((page, index) => {
+      const option = document.createElement('option');
+      option.value = String(index + 1);
+      option.textContent = pageLabel(page, index);
+      return option;
+    }),
+  );
+  jump.value = String(Math.min(currentPage, pages.length || 1));
+}
+function setCurrentPage(page, { scroll = false, focus = false } = {}) {
+  const pages = [...document.querySelectorAll('.pagedjs_page')];
+  currentPage = Math.max(1, Math.min(pages.length || 1, Number(page) || 1));
+  $('#current').textContent = currentPage;
+  const jump = $('#page-jump');
+  if (jump) jump.value = String(currentPage);
+  $('#prev').disabled = currentPage <= 1;
+  $('#next').disabled = currentPage >= pages.length;
+  if (scroll)
+    pages[currentPage - 1]?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+    });
+  if (focus)
+    setTimeout(
+      () => focusPageContext(pages[currentPage - 1]),
+      scroll ? 350 : 0,
+    );
+}
+function focusPageContext(page) {
+  if (!page) return;
+  const type = page.dataset.groupType,
+    id = page.dataset.groupId;
+  if (type === 'step' || type === 'appendix') {
+    const group = (type === 'step' ? state.steps : state.appendices).find(
+      (x) => x.id === id,
+    );
+    selectGroup(group, type);
+    const target =
+      Number(page.dataset.pageFragment) === 0
+        ? page.querySelector('[data-group-title]')
+        : page.querySelector('[contenteditable=true], [data-group-title]');
+    target?.focus({ preventScroll: true });
+    document
+      .querySelectorAll('[data-editable-group-id]')
+      .forEach((x) =>
+        x.classList.toggle('is-selected', x.dataset.editableGroupId === id),
+      );
+    announce(`${pageLabel(page, currentPage - 1)}, ${group?.title || ''}`);
+  } else {
+    Object.assign(editorSelection, {
+      activeGroupId: null,
+      activeGroupType: null,
+      activeStepId: null,
+      activeBlockId: null,
+      container: null,
+    });
+    page.focus({ preventScroll: true });
+    announce(pageLabel(page, currentPage - 1));
+  }
+  updateControls();
+}
+function navigateToAnchor(anchor) {
+  const pages = [...document.querySelectorAll('.pagedjs_page')],
+    index = pages.findIndex(
+      (page) =>
+        page.dataset.anchorId === anchor ||
+        page.querySelector(`#${CSS.escape(anchor)}`),
+    );
+  if (index < 0) return false;
+  navigationHistory.push(captureView());
+  setCurrentPage(index + 1, { scroll: true, focus: true });
+  return true;
+}
+const openEditorLink = (href) =>
+  followEditorLink(href, {
+    navigateInternal: navigateToAnchor,
+    openExternal: (url) => {
+      const opened = window.open(url, '_blank', 'noopener,noreferrer');
+      if (opened) opened.opener = null;
+    },
+    openMailto: (url) => {
+      window.location.href = url;
+    },
+    report: announce,
+  });
+function editableLinkClick(event) {
+  handleEditableLinkClick(event, openEditorLink);
+}
+function selectedEditableLink() {
+  const selection = getSelection(),
+    node = selection?.anchorNode;
+  return (
+    (node?.nodeType === Node.ELEMENT_NODE
+      ? node
+      : node?.parentElement
+    )?.closest?.('.editable-runs a') || null
+  );
+}
+function updateLinkContext() {
+  const link = selectedEditableLink(),
+    control = $('#link-context');
+  control.hidden = !link;
+  control.dataset.href = link?.getAttribute('href') || '';
+}
+function disconnectPageObserver() {
+  pageObserver?.disconnect();
+  pageObserver = null;
+  observedAreas.clear();
+}
+function observePages() {
+  if (!('IntersectionObserver' in window)) return;
+  const pages = [...document.querySelectorAll('.pagedjs_page')];
+  pageObserver = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries)
+        observedAreas.set(
+          entry.target,
+          entry.intersectionRect.width * entry.intersectionRect.height,
+        );
+      let best = null;
+      for (const page of pages) {
+        const area = observedAreas.get(page) || 0,
+          center = Math.abs(
+            page.getBoundingClientRect().top +
+              page.getBoundingClientRect().height / 2 -
+              innerHeight / 2,
+          );
+        if (
+          !best ||
+          area > best.area ||
+          (area === best.area && center < best.center)
+        )
+          best = { page, area, center };
+      }
+      if (best?.area > 0) setCurrentPage(pages.indexOf(best.page) + 1);
+    },
+    { threshold: [0, 0.1, 0.25, 0.5, 0.75, 1] },
+  );
+  pages.forEach((page) => pageObserver.observe(page));
+}
+function go(page) {
+  setCurrentPage(page, { scroll: true, focus: true });
+}
+$('#prev').onclick = () => go(currentPage - 1);
+$('#next').onclick = () => go(currentPage + 1);
+$('#page-jump').onchange = (e) => go(Number(e.target.value));
+excelController = new ExcelEditor({
+  root: $('#excel-editor'),
+  toolbar: $('#excel-toolbar'),
+  getDocument: () => state,
+  updateDocument: (excel) => {
+    state = { ...state, excel };
+    history.replace(state);
+    markDirty();
+  },
+  report: (message) => {
+    announce(message);
+    alert(message);
+  },
+});
+document.querySelectorAll('[data-editor]').forEach(
+  (button) =>
+    (button.onclick = () => {
+      activeEditor = button.dataset.editor;
+      document
+        .querySelectorAll('[data-editor]')
+        .forEach((item) =>
+          item.toggleAttribute('aria-current', item === button),
+        );
+      const excel = activeEditor === 'excel';
+      $('#preview').hidden = excel;
+      $('#excel-editor').hidden = !excel;
+      $('#excel-toolbar').hidden = !excel;
+      if (excel) excelController.synchronize();
+    }),
+);
+render({ restore: false });
 </script></body></html>

--- a/UBTA/package.json
+++ b/UBTA/package.json
@@ -1,1 +1,18 @@
-{"name":"ubta-steps-plan-editor","version":"0.1.0","private":true,"type":"module","scripts":{"build":"node scripts/build.mjs","test:schema":"node --test tests/scheme.test.js tests/image-model.test.js tests/table-model.test.js tests/document-operations.test.js tests/excel-model.test.js","test:editor":"node --test tests/default-templates.test.js tests/callouts.test.js tests/editor-interactions.test.js tests/excel-editor.test.js tests/repagination.test.js tests/printing.test.js","test:build":"node --test tests/build.test.js","test":"npm run test:schema && npm run test:editor && npm run test:build"}}
+{
+  "name": "ubta-steps-plan-editor",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node scripts/build.mjs",
+    "test:schema": "node --test tests/scheme.test.js tests/image-model.test.js tests/table-model.test.js tests/document-operations.test.js tests/excel-model.test.js",
+    "test:editor": "node --test tests/default-templates.test.js tests/callouts.test.js tests/editor-interactions.test.js tests/excel-editor.test.js tests/repagination.test.js tests/printing.test.js",
+    "test:build": "node --test tests/build.test.js",
+    "test": "npm run test:schema && npm run test:editor && npm run test:build",
+    "format": "prettier --write \"src/**/*.js\"",
+    "format:check": "prettier --check \"src/**/*.js\""
+  },
+  "devDependencies": {
+    "prettier": "^3.8.3"
+  }
+}

--- a/UBTA/scripts/build.mjs
+++ b/UBTA/scripts/build.mjs
@@ -1,7 +1,47 @@
-import fs from 'node:fs';import path from 'node:path';
-const root=path.resolve(import.meta.dirname,'..'),read=file=>fs.readFileSync(path.join(root,file),'utf8');
-const bundle=file=>read(file).replace(/^import .*;\n/gm,'').replace(/^export \{[^}]+\}(?: from ['"][^'"]+['"])?;\n?/gm,'').replace(/export /g,'');
-const modules=['src/editor/crypto.js','src/editor/default-template-data.js','src/editor/default-templates.js','src/state/table-model.js','src/state/image-model.js','src/state/excel-model.js','src/state/schema.js','src/state/document-operations.js','src/state/history.js','src/state/persistence.js','src/editor/dom-runs.js','src/editor/interactions.js','src/editor/repagination.js','src/editor/printing.js','src/editor/command-routing.js','src/editor/list-rendering.js','src/editor/block-deletion.js','src/editor/insertion-context.js','src/editor/callouts.js','src/editor/link-actions.js','src/editor/navigation-history.js','src/editor/excel-editor.js','src/main.js'];
-const css=['src/styles/app.css','src/styles/document.css'].map(read).join('\n'),vendor=read('src/vendor/paged.js'),body=read('src/index.html').match(/<body>([\s\S]*)<\/body>/)[1].replace(/<script[\s\S]*?<\/script>/g,'').trim();
-const html=`<!doctype html><html lang="en-GB"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>UBTA Steps Plan Editor</title><style>${css}</style></head><body>${body}<script>${vendor}\n${modules.map(bundle).join('\n')}<\/script></body></html>`;
-fs.mkdirSync(path.join(root,'dist'),{recursive:true});fs.writeFileSync(path.join(root,'dist/index.html'),html);console.log(`Built dist/index.html (${html.length} bytes)`);
+import fs from 'node:fs';
+import path from 'node:path';
+
+const root = path.resolve(import.meta.dirname, '..');
+const read = (file) => fs.readFileSync(path.join(root, file), 'utf8');
+const bundle = (file) =>
+  read(file)
+    .replace(/^import\s+[\s\S]*?\s+from\s+['"][^'"]+['"];?\n/gm, '')
+    .replace(/^export\s+\{[\s\S]*?\}(?:\s+from\s+['"][^'"]+['"])?;?\n?/gm, '')
+    .replace(/\bexport\s+/g, '');
+const modules = [
+  'src/editor/crypto.js',
+  'src/editor/default-template-data.js',
+  'src/editor/default-templates.js',
+  'src/state/table-model.js',
+  'src/state/image-model.js',
+  'src/state/excel-model.js',
+  'src/state/schema.js',
+  'src/state/document-operations.js',
+  'src/state/history.js',
+  'src/state/persistence.js',
+  'src/editor/dom-runs.js',
+  'src/editor/interactions.js',
+  'src/editor/repagination.js',
+  'src/editor/printing.js',
+  'src/editor/command-routing.js',
+  'src/editor/list-rendering.js',
+  'src/editor/block-deletion.js',
+  'src/editor/insertion-context.js',
+  'src/editor/callouts.js',
+  'src/editor/link-actions.js',
+  'src/editor/navigation-history.js',
+  'src/editor/excel-editor.js',
+  'src/main.js',
+];
+const css = ['src/styles/app.css', 'src/styles/document.css']
+    .map(read)
+    .join('\n'),
+  vendor = read('src/vendor/paged.js'),
+  body = read('src/index.html')
+    .match(/<body>([\s\S]*)<\/body>/)[1]
+    .replace(/<script[\s\S]*?<\/script>/g, '')
+    .trim();
+const html = `<!doctype html><html lang="en-GB"><head><meta charset="utf-8"><meta name="viewport" content="width=device-width"><title>UBTA Steps Plan Editor</title><style>${css}</style></head><body>${body}<script>${vendor}\n${modules.map(bundle).join('\n')}<\/script></body></html>`;
+fs.mkdirSync(path.join(root, 'dist'), { recursive: true });
+fs.writeFileSync(path.join(root, 'dist/index.html'), html);
+console.log(`Built dist/index.html (${html.length} bytes)`);

--- a/UBTA/src/editor/block-deletion.js
+++ b/UBTA/src/editor/block-deletion.js
@@ -1,23 +1,37 @@
-const textFromRuns=runs=>(runs||[]).map(run=>run.text||'').join('');
+const textFromRuns = (runs) =>
+  (runs || []).map((run) => run.text || '').join('');
 
-export function blockTypeLabel(type){
-  return ({paragraph:'paragraph',heading:'heading',bulletList:'bulleted list',numberList:'numbered list',table:'table',image:'image'})[type]||'block';
+export function blockTypeLabel(type) {
+  return (
+    {
+      paragraph: 'paragraph',
+      heading: 'heading',
+      bulletList: 'bulleted list',
+      numberList: 'numbered list',
+      table: 'table',
+      image: 'image',
+    }[type] || 'block'
+  );
 }
 
-export function blockHasContent(block){
-  if(['table','image'].includes(block.type))return true;
-  if(block.type.endsWith('List'))return (block.items||[]).some(item=>textFromRuns(item.runs).trim());
+export function blockHasContent(block) {
+  if (['table', 'image'].includes(block.type)) return true;
+  if (block.type.endsWith('List'))
+    return (block.items || []).some((item) => textFromRuns(item.runs).trim());
   return Boolean(textFromRuns(block.runs).trim());
 }
 
-export function removeBlockFromGroup(group,id,makeId){
-  const index=group.blocks.findIndex(block=>block.id===id);
-  if(index<0)return null;
-  const [deleted]=group.blocks.splice(index,1);
-  let replacement=null;
-  if(!group.blocks.length){
-    replacement={id:makeId('block'),type:'paragraph',runs:[]};
+export function removeBlockFromGroup(group, id, makeId) {
+  const index = group.blocks.findIndex((block) => block.id === id);
+  if (index < 0) return null;
+  const [deleted] = group.blocks.splice(index, 1);
+  let replacement = null;
+  if (!group.blocks.length) {
+    replacement = { id: makeId('block'), type: 'paragraph', runs: [] };
     group.blocks.push(replacement);
   }
-  return {deleted,target:group.blocks[index-1]||group.blocks[index]||replacement};
+  return {
+    deleted,
+    target: group.blocks[index - 1] || group.blocks[index] || replacement,
+  };
 }

--- a/UBTA/src/editor/callouts.js
+++ b/UBTA/src/editor/callouts.js
@@ -1,10 +1,10 @@
-export function bindCallouts(root=document){
-  root.querySelectorAll('dialog').forEach(dialog=>{
-    dialog.addEventListener('click',event=>{
-      if(event.target===dialog)dialog.close('cancel');
+export function bindCallouts(root = document) {
+  root.querySelectorAll('dialog').forEach((dialog) => {
+    dialog.addEventListener('click', (event) => {
+      if (event.target === dialog) dialog.close('cancel');
     });
-    dialog.querySelectorAll('[data-dialog-cancel]').forEach(button=>{
-      button.addEventListener('click',event=>{
+    dialog.querySelectorAll('[data-dialog-cancel]').forEach((button) => {
+      button.addEventListener('click', (event) => {
         event.preventDefault();
         dialog.close('cancel');
       });

--- a/UBTA/src/editor/command-routing.js
+++ b/UBTA/src/editor/command-routing.js
@@ -1,26 +1,51 @@
-export const TABLE_COMMANDS = new Set(['addRow','removeRow','moveRowUp','moveRowDown','addColumn','removeColumn','moveColumnLeft','moveColumnRight']);
-
-export const canApplyBlockStyle = (blockType, action) => {
-  if (/^heading[1-4]$/.test(action)) return ['paragraph', 'heading'].includes(blockType);
-  if (action === 'body') return ['paragraph', 'heading'].includes(blockType);
-  return ['bulletList', 'numberList'].includes(action) && ['paragraph', 'heading', 'bulletList', 'numberList'].includes(blockType);
-};
-
-export const blockStyleChoices = blockType => ['bulletList','numberList'].includes(blockType)
-  ? [['bulletList','Bulleted list'],['numberList','Numbered list']]
-  : [['body','Body text'],['heading1','Heading 1'],['heading2','Heading 2'],['heading3','Heading 3'],['heading4','Heading 4'],['bulletList','Bulleted list'],['numberList','Numbered list']];
-
-export const BLOCK_COMMANDS = new Map([
-  ['addParagraph','paragraph'],
-  ['addHeading','heading'],
-  ['addBulletList','bulletList'],
-  ['addNumberList','numberList'],
-  ['addTable','table']
+export const TABLE_COMMANDS = new Set([
+  'addRow',
+  'removeRow',
+  'moveRowUp',
+  'moveRowDown',
+  'addColumn',
+  'removeColumn',
+  'moveColumnLeft',
+  'moveColumnRight',
 ]);
 
-export function routeInsertionCommand(action){
-  if(TABLE_COMMANDS.has(action))return {kind:'table',action};
-  const blockType=BLOCK_COMMANDS.get(action);
-  if(typeof blockType==='string')return {kind:'block',blockType};
+export const canApplyBlockStyle = (blockType, action) => {
+  if (/^heading[1-4]$/.test(action))
+    return ['paragraph', 'heading'].includes(blockType);
+  if (action === 'body') return ['paragraph', 'heading'].includes(blockType);
+  return (
+    ['bulletList', 'numberList'].includes(action) &&
+    ['paragraph', 'heading', 'bulletList', 'numberList'].includes(blockType)
+  );
+};
+
+export const blockStyleChoices = (blockType) =>
+  ['bulletList', 'numberList'].includes(blockType)
+    ? [
+        ['bulletList', 'Bulleted list'],
+        ['numberList', 'Numbered list'],
+      ]
+    : [
+        ['body', 'Body text'],
+        ['heading1', 'Heading 1'],
+        ['heading2', 'Heading 2'],
+        ['heading3', 'Heading 3'],
+        ['heading4', 'Heading 4'],
+        ['bulletList', 'Bulleted list'],
+        ['numberList', 'Numbered list'],
+      ];
+
+export const BLOCK_COMMANDS = new Map([
+  ['addParagraph', 'paragraph'],
+  ['addHeading', 'heading'],
+  ['addBulletList', 'bulletList'],
+  ['addNumberList', 'numberList'],
+  ['addTable', 'table'],
+]);
+
+export function routeInsertionCommand(action) {
+  if (TABLE_COMMANDS.has(action)) return { kind: 'table', action };
+  const blockType = BLOCK_COMMANDS.get(action);
+  if (typeof blockType === 'string') return { kind: 'block', blockType };
   return null;
 }

--- a/UBTA/src/editor/crypto.js
+++ b/UBTA/src/editor/crypto.js
@@ -1,5 +1,66 @@
 export const DAMAGED_FILE_MESSAGE = 'Incorrect password or damaged file.';
-const invalid = () => Object.assign(new Error(DAMAGED_FILE_MESSAGE), { name:'EncryptedFileError' });
-export function decodeBase64(value) { if(typeof value!=='string'||!value||!/^[A-Za-z0-9+/]*={0,2}$/.test(value)||value.length%4)throw invalid();try{return Uint8Array.from(atob(value),c=>c.charCodeAt(0))}catch{throw invalid()} }
-export function validateEnvelope(e) { if(!e||e.version!==1||e.algorithm!=='AES-GCM'||e.kdf!=='PBKDF2-SHA-256'||!Number.isInteger(e.iterations)||e.iterations<100000||decodeBase64(e.salt).length!==16||decodeBase64(e.iv).length!==12||decodeBase64(e.ciphertext).length<17)throw invalid();return e }
-export async function decryptEnvelope(e,password,subtle=crypto.subtle){try{validateEnvelope(e);const material=await subtle.importKey('raw',new TextEncoder().encode(String(password)),'PBKDF2',false,['deriveKey']);const key=await subtle.deriveKey({name:'PBKDF2',hash:'SHA-256',salt:decodeBase64(e.salt),iterations:e.iterations},material,{name:'AES-GCM',length:256},false,['decrypt']);const plain=await subtle.decrypt({name:'AES-GCM',iv:decodeBase64(e.iv)},key,decodeBase64(e.ciphertext));return JSON.parse(new TextDecoder().decode(plain))}catch{throw invalid()}}
+const invalid = () =>
+  Object.assign(new Error(DAMAGED_FILE_MESSAGE), {
+    name: 'EncryptedFileError',
+  });
+export function decodeBase64(value) {
+  if (
+    typeof value !== 'string' ||
+    !value ||
+    !/^[A-Za-z0-9+/]*={0,2}$/.test(value) ||
+    value.length % 4
+  )
+    throw invalid();
+  try {
+    return Uint8Array.from(atob(value), (c) => c.charCodeAt(0));
+  } catch {
+    throw invalid();
+  }
+}
+export function validateEnvelope(e) {
+  if (
+    !e ||
+    e.version !== 1 ||
+    e.algorithm !== 'AES-GCM' ||
+    e.kdf !== 'PBKDF2-SHA-256' ||
+    !Number.isInteger(e.iterations) ||
+    e.iterations < 100000 ||
+    decodeBase64(e.salt).length !== 16 ||
+    decodeBase64(e.iv).length !== 12 ||
+    decodeBase64(e.ciphertext).length < 17
+  )
+    throw invalid();
+  return e;
+}
+export async function decryptEnvelope(e, password, subtle = crypto.subtle) {
+  try {
+    validateEnvelope(e);
+    const material = await subtle.importKey(
+      'raw',
+      new TextEncoder().encode(String(password)),
+      'PBKDF2',
+      false,
+      ['deriveKey'],
+    );
+    const key = await subtle.deriveKey(
+      {
+        name: 'PBKDF2',
+        hash: 'SHA-256',
+        salt: decodeBase64(e.salt),
+        iterations: e.iterations,
+      },
+      material,
+      { name: 'AES-GCM', length: 256 },
+      false,
+      ['decrypt'],
+    );
+    const plain = await subtle.decrypt(
+      { name: 'AES-GCM', iv: decodeBase64(e.iv) },
+      key,
+      decodeBase64(e.ciphertext),
+    );
+    return JSON.parse(new TextDecoder().decode(plain));
+  } catch {
+    throw invalid();
+  }
+}

--- a/UBTA/src/editor/default-template-data.js
+++ b/UBTA/src/editor/default-template-data.js
@@ -1,10 +1,11 @@
 // This ciphertext is deliberately shipped with the client so unlocking also works from file://.
-export const defaultTemplateEnvelope=Object.freeze({
-  version:1,
-  algorithm:'AES-GCM',
-  kdf:'PBKDF2-SHA-256',
-  iterations:310000,
-  salt:'EG5326HC6gLkkN2TxPdodg==',
-  iv:'NyQQS8ak6Y2E3WUG',
-  ciphertext:'VgziFV2P5dlFyYaBY3+oN5RpUx+0nqoK1jty5JHHz40YRcVuqNk0zaxzGO582YayTTI7XLl8LayWCeZx7y7yB71xE4/68pa1vcZCqg97tJI8bqRnsTDoZIJWdg0Sr4iFX+xWxYgMWDCtq6KHAabu+couoqS3qZ0bmdBBphyUMEHvPo1RLdQOLIyPE6+xa05GEON7iwUD8MSNsLfbwU7Y3MLuJu6+SpPdnvhu3oB2SmwT6ub+aRK3cJQKfoUffFni6dR9zgL1jJesPeM4xHCeoBpM3/1PPsYcpwccbsbX+Z7Hkd6XItPS1FPWn2UclHtsUSvE0FmgWgHpBb9uv43WpGgtsndet83Q483EeqGFfzUTdjaFg9keoIWdB4vJb1saQ0iwPekp9NPMKNPk8BdC2X4d8c827CH5jMEHHOBhOrEfedNERWEVpZmg6A=='
+export const defaultTemplateEnvelope = Object.freeze({
+  version: 1,
+  algorithm: 'AES-GCM',
+  kdf: 'PBKDF2-SHA-256',
+  iterations: 310000,
+  salt: 'EG5326HC6gLkkN2TxPdodg==',
+  iv: 'NyQQS8ak6Y2E3WUG',
+  ciphertext:
+    'VgziFV2P5dlFyYaBY3+oN5RpUx+0nqoK1jty5JHHz40YRcVuqNk0zaxzGO582YayTTI7XLl8LayWCeZx7y7yB71xE4/68pa1vcZCqg97tJI8bqRnsTDoZIJWdg0Sr4iFX+xWxYgMWDCtq6KHAabu+couoqS3qZ0bmdBBphyUMEHvPo1RLdQOLIyPE6+xa05GEON7iwUD8MSNsLfbwU7Y3MLuJu6+SpPdnvhu3oB2SmwT6ub+aRK3cJQKfoUffFni6dR9zgL1jJesPeM4xHCeoBpM3/1PPsYcpwccbsbX+Z7Hkd6XItPS1FPWn2UclHtsUSvE0FmgWgHpBb9uv43WpGgtsndet83Q483EeqGFfzUTdjaFg9keoIWdB4vJb1saQ0iwPekp9NPMKNPk8BdC2X4d8c827CH5jMEHHOBhOrEfedNERWEVpZmg6A==',
 });

--- a/UBTA/src/editor/default-templates.js
+++ b/UBTA/src/editor/default-templates.js
@@ -1,4 +1,53 @@
 import { decryptEnvelope } from './crypto.js';
-export function validateTemplatePayload(payload){if(!payload||payload.type!=='editor-defaults'||!Array.isArray(payload.templates)||!payload.templates.length)throw Error('The decrypted template database is malformed.');const ids=new Set();return payload.templates.map(t=>{if(!t||typeof t.id!=='string'||!t.id.trim()||ids.has(t.id)||typeof t.header!=='string'||!t.header.trim()||typeof t.body!=='string'||!t.body.trim())throw Error('The decrypted template database is malformed.');ids.add(t.id);return Object.freeze({id:t.id,header:t.header.trim(),body:t.body})})}
-export class EncryptedTemplateLoader{#templates=null;#decrypt;constructor({decrypt=decryptEnvelope}={}){this.#decrypt=decrypt}get cached(){return this.#templates!==null}async unlock(envelope,password){if(this.#templates)return this.#templates;const templates=validateTemplatePayload(await this.#decrypt(envelope,password));this.#templates=Object.freeze(templates);return this.#templates}}
-export const templateBlocks=(template,newId)=>[{id:newId('block'),type:'heading',level:2,runs:[{text:template.header}]},{id:newId('block'),type:'paragraph',runs:[{text:template.body}]}];
+export function validateTemplatePayload(payload) {
+  if (
+    !payload ||
+    payload.type !== 'editor-defaults' ||
+    !Array.isArray(payload.templates) ||
+    !payload.templates.length
+  )
+    throw Error('The decrypted template database is malformed.');
+  const ids = new Set();
+  return payload.templates.map((t) => {
+    if (
+      !t ||
+      typeof t.id !== 'string' ||
+      !t.id.trim() ||
+      ids.has(t.id) ||
+      typeof t.header !== 'string' ||
+      !t.header.trim() ||
+      typeof t.body !== 'string' ||
+      !t.body.trim()
+    )
+      throw Error('The decrypted template database is malformed.');
+    ids.add(t.id);
+    return Object.freeze({ id: t.id, header: t.header.trim(), body: t.body });
+  });
+}
+export class EncryptedTemplateLoader {
+  #templates = null;
+  #decrypt;
+  constructor({ decrypt = decryptEnvelope } = {}) {
+    this.#decrypt = decrypt;
+  }
+  get cached() {
+    return this.#templates !== null;
+  }
+  async unlock(envelope, password) {
+    if (this.#templates) return this.#templates;
+    const templates = validateTemplatePayload(
+      await this.#decrypt(envelope, password),
+    );
+    this.#templates = Object.freeze(templates);
+    return this.#templates;
+  }
+}
+export const templateBlocks = (template, newId) => [
+  {
+    id: newId('block'),
+    type: 'heading',
+    level: 2,
+    runs: [{ text: template.header }],
+  },
+  { id: newId('block'), type: 'paragraph', runs: [{ text: template.body }] },
+];

--- a/UBTA/src/editor/dom-runs.js
+++ b/UBTA/src/editor/dom-runs.js
@@ -1,14 +1,86 @@
 import { normaliseRuns, safeHref } from '../state/schema.js';
 
 export function runsFromElement(element) {
-  const runs=[];
-  const visit=(node,highlight=false,link=null)=>{if(node.nodeType===3){runs.push({text:node.nodeValue||'',highlight,link:link?{href:link}:null});return}if(node.nodeType!==1)return;const tag=node.tagName.toLowerCase();if(tag==='br'){runs.push({text:'\n',highlight,link:link?{href:link}:null});return}const nextHighlight=highlight||tag==='mark',nextLink=tag==='a'?(safeHref(node.getAttribute('href'))||link):link;[...node.childNodes].forEach(child=>visit(child,nextHighlight,nextLink));if(['div','p'].includes(tag)&&node.nextSibling&&runs.at(-1)?.text?.at(-1)!=='\n')runs.push({text:'\n',highlight:nextHighlight,link:nextLink?{href:nextLink}:null});};
-  [...element.childNodes].forEach(node=>visit(node));return normaliseRuns(runs);
+  const runs = [];
+  const visit = (node, highlight = false, link = null) => {
+    if (node.nodeType === 3) {
+      runs.push({
+        text: node.nodeValue || '',
+        highlight,
+        link: link ? { href: link } : null,
+      });
+      return;
+    }
+    if (node.nodeType !== 1) return;
+    const tag = node.tagName.toLowerCase();
+    if (tag === 'br') {
+      runs.push({ text: '\n', highlight, link: link ? { href: link } : null });
+      return;
+    }
+    const nextHighlight = highlight || tag === 'mark',
+      nextLink =
+        tag === 'a' ? safeHref(node.getAttribute('href')) || link : link;
+    [...node.childNodes].forEach((child) =>
+      visit(child, nextHighlight, nextLink),
+    );
+    if (
+      ['div', 'p'].includes(tag) &&
+      node.nextSibling &&
+      runs.at(-1)?.text?.at(-1) !== '\n'
+    )
+      runs.push({
+        text: '\n',
+        highlight: nextHighlight,
+        link: nextLink ? { href: nextLink } : null,
+      });
+  };
+  [...element.childNodes].forEach((node) => visit(node));
+  return normaliseRuns(runs);
 }
 
 export function transformRuns(runs, offsets, kind, value) {
-  if(!offsets)return runs;const collapsed=offsets[0]===offsets[1];if(collapsed&&kind!=='highlight')return runs;const [start,end]=collapsed?[0,runs.reduce((length,run)=>length+run.text.length,0)]:offsets;if(start===end)return runs;let position=0;const selected=runs.filter(run=>{const from=position,until=position+=run.text.length;return from<end&&until>start});const highlight=kind==='highlight'?!selected.every(run=>run.highlight):null;position=0;const output=[];
-  for(const run of runs){const from=position,until=position+run.text.length,a=Math.max(start,from),b=Math.min(end,until);if(from<a)output.push({...run,text:run.text.slice(0,a-from)});if(b>a){const part={...run,text:run.text.slice(a-from,b-from)};if(kind==='highlight')part.highlight=highlight;if(kind==='link')part.link={href:value};if(kind==='unlink')part.link=null;output.push(part)}if(b<until)output.push({...run,text:run.text.slice(Math.max(0,b-from))});position=until}return normaliseRuns(output);
+  if (!offsets) return runs;
+  const collapsed = offsets[0] === offsets[1];
+  if (collapsed && kind !== 'highlight') return runs;
+  const [start, end] = collapsed
+    ? [0, runs.reduce((length, run) => length + run.text.length, 0)]
+    : offsets;
+  if (start === end) return runs;
+  let position = 0;
+  const selected = runs.filter((run) => {
+    const from = position,
+      until = (position += run.text.length);
+    return from < end && until > start;
+  });
+  const highlight =
+    kind === 'highlight' ? !selected.every((run) => run.highlight) : null;
+  position = 0;
+  const output = [];
+  for (const run of runs) {
+    const from = position,
+      until = position + run.text.length,
+      a = Math.max(start, from),
+      b = Math.min(end, until);
+    if (from < a) output.push({ ...run, text: run.text.slice(0, a - from) });
+    if (b > a) {
+      const part = { ...run, text: run.text.slice(a - from, b - from) };
+      if (kind === 'highlight') part.highlight = highlight;
+      if (kind === 'link') part.link = { href: value };
+      if (kind === 'unlink') part.link = null;
+      output.push(part);
+    }
+    if (b < until)
+      output.push({ ...run, text: run.text.slice(Math.max(0, b - from)) });
+    position = until;
+  }
+  return normaliseRuns(output);
 }
 
-export function insertPlainText(event, documentObject=document) { event.preventDefault();documentObject.execCommand('insertText',false,event.clipboardData.getData('text/plain')); }
+export function insertPlainText(event, documentObject = document) {
+  event.preventDefault();
+  documentObject.execCommand(
+    'insertText',
+    false,
+    event.clipboardData.getData('text/plain'),
+  );
+}

--- a/UBTA/src/editor/excel-editor.js
+++ b/UBTA/src/editor/excel-editor.js
@@ -1,7 +1,26 @@
 import { History } from '../state/history.js';
-import { TYPES, classesOf, createCompany, parseShares, formatShares, cellKey, valueAt, resultingValues, totals, findBlocking, syncSteps } from '../state/excel-model.js';
+import {
+  TYPES,
+  classesOf,
+  createCompany,
+  parseShares,
+  formatShares,
+  cellKey,
+  valueAt,
+  resultingValues,
+  totals,
+  findBlocking,
+  syncSteps,
+} from '../state/excel-model.js';
 
-const escapeHtml = value => String(value).replace(/[&<>"']/g, character => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[character]));
+const escapeHtml = (value) =>
+  String(value).replace(
+    /[&<>"']/g,
+    (character) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[
+        character
+      ],
+  );
 
 const gridSelector = '[data-grid-row][data-grid-column]';
 
@@ -11,39 +30,233 @@ export function gridDestination(targets, current, key, shiftKey = false) {
   const index = targets.indexOf(current);
 
   if (key === 'Tab') {
-    return targets[(index + (shiftKey ? -1 : 1) + targets.length) % targets.length];
+    return targets[
+      (index + (shiftKey ? -1 : 1) + targets.length) % targets.length
+    ];
   }
 
-  const rowChange = key === 'ArrowUp' || (key === 'Enter' && shiftKey) ? -1
-    : key === 'ArrowDown' || key === 'Enter' ? 1 : 0;
+  const rowChange =
+    key === 'ArrowUp' || (key === 'Enter' && shiftKey)
+      ? -1
+      : key === 'ArrowDown' || key === 'Enter'
+        ? 1
+        : 0;
   const columnChange = key === 'ArrowLeft' ? -1 : key === 'ArrowRight' ? 1 : 0;
-  return targets.find(target => (
-    Number(target.dataset.gridRow) === row + rowChange
-    && Number(target.dataset.gridColumn) === column + columnChange
-  )) || current;
+  return (
+    targets.find(
+      (target) =>
+        Number(target.dataset.gridRow) === row + rowChange &&
+        Number(target.dataset.gridColumn) === column + columnChange,
+    ) || current
+  );
 }
 
 export class ExcelEditor {
-  constructor({ root, toolbar, getDocument, updateDocument, report }) { this.root=root;this.toolbar=toolbar;this.getDocument=getDocument;this.updateDocument=updateDocument;this.report=report;this.history=new History(getDocument().excel);this.focus={};this.bindToolbar(); }
-  get excel() { return this.getDocument().excel; }
-  get company() { return this.excel.companies.find(item=>item.id===this.excel.selectedCompanyId); }
-  replace(excel, record=true) { if(record)this.history.commit(excel);else this.history.replace(excel);this.updateDocument(excel);this.render(); }
-  mutate(change) { const excel=structuredClone(this.excel);change(excel);this.replace(excel); }
-  synchronize() { const next=syncSteps(this.excel,this.getDocument().steps);if(JSON.stringify(next)!==JSON.stringify(this.excel))this.replace(next);else this.render(); }
-  undo() { const next=syncSteps(this.history.undo(),this.getDocument().steps);this.history.replace(next);this.updateDocument(next);this.render(); }
-  redo() { const next=syncSteps(this.history.redo(),this.getDocument().steps);this.history.replace(next);this.updateDocument(next);this.render(); }
-  restore(excel) { this.history=new History(excel);this.render(); }
-  bindToolbar() { this.toolbar.addEventListener('click',event=>{const action=event.target.dataset.excelAction;if(!action)return;this[action]?.();}); }
-  addCompany() { const name=prompt('Company name:','New company');if(!name?.trim())return;this.mutate(excel=>{const company=createCompany(name.trim());excel.companies.push(company);excel.selectedCompanyId=company.id;}); }
-  deleteCompany() { const company=this.company;if(!company)return;const typed=prompt(`Type “${company.name}” to permanently delete this company. This can be undone.`);if(typed!==company.name){if(typed!==null)this.report('Company name did not match; nothing was deleted.');return;}this.mutate(excel=>{excel.companies=excel.companies.filter(item=>item.id!==company.id);excel.selectedCompanyId=excel.companies[0]?.id||null;}); }
-  addShareholder() { if(!this.company||this.company.shareholders.length>=100)return this.report('The 100-shareholder limit has been reached.');this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId),at=this.focus.holderId?company.shareholders.findIndex(item=>item.id===this.focus.holderId)+1:company.shareholders.length;const holder={id:`holder-${crypto.randomUUID()}`,name:'',type:'Individual'};company.shareholders.splice(at,0,holder);this.focus={holderId:holder.id};}); }
-  removeShareholder() { const company=this.company,holder=company?.shareholders.find(item=>item.id===this.focus.holderId);if(!holder)return this.report('Focus a shareholder row first.');const blocking=findBlocking(company,null,holder.id,this.getDocument().steps);if(blocking)return this.blocked(blocking);this.mutate(excel=>{const current=excel.companies.find(item=>item.id===company.id);current.shareholders=current.shareholders.filter(item=>item.id!==holder.id);}); }
-  addGroup() { if(!this.company)return; if(classesOf(this.company).length>=100)return this.report('The 100-share-class limit has been reached.');this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId);company.groups.push({id:`group-${crypto.randomUUID()}`,name:'New group',classes:[{id:`class-${crypto.randomUUID()}`,label:''}]});}); }
-  removeGroup() { const company=this.company,group=company?.groups.find(item=>item.id===this.focus.groupId);if(!group)return this.report('Focus a share-group header first.');const blocking=findBlocking(company,group.classes.map(item=>item.id),null,this.getDocument().steps);if(blocking)return this.blocked(blocking);this.mutate(excel=>excel.companies.find(item=>item.id===company.id).groups=company.groups.filter(item=>item.id!==group.id)); }
-  addClass() { if(!this.company)return;if(classesOf(this.company).length>=100)return this.report('The 100-share-class limit has been reached.');this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId),group=company.groups.find(item=>item.id===this.focus.groupId)||company.groups.at(-1);if(!group)return this.report('Add a share group first.');const at=this.focus.classId?group.classes.findIndex(item=>item.id===this.focus.classId)+1:group.classes.length;group.classes.splice(at,0,{id:`class-${crypto.randomUUID()}`,label:''});}); }
-  removeClass() { const company=this.company,shareClass=classesOf(company||{groups:[]}).find(item=>item.id===this.focus.classId);if(!shareClass)return this.report('Focus a share-class header first.');const blocking=findBlocking(company,[shareClass.id],null,this.getDocument().steps);if(blocking)return this.blocked(blocking);this.mutate(excel=>{for(const group of excel.companies.find(item=>item.id===company.id).groups)group.classes=group.classes.filter(item=>item.id!==shareClass.id);}); }
-  blocked(item) { this.report(`${this.company.name} — ${item.location}: ${item.holder.name}, ${item.shareClass.label||'unnamed share class'} contains data and blocks deletion.`); }
-  table(title, values, editable, stepId='') {
+  constructor({ root, toolbar, getDocument, updateDocument, report }) {
+    this.root = root;
+    this.toolbar = toolbar;
+    this.getDocument = getDocument;
+    this.updateDocument = updateDocument;
+    this.report = report;
+    this.history = new History(getDocument().excel);
+    this.focus = {};
+    this.bindToolbar();
+  }
+  get excel() {
+    return this.getDocument().excel;
+  }
+  get company() {
+    return this.excel.companies.find(
+      (item) => item.id === this.excel.selectedCompanyId,
+    );
+  }
+  replace(excel, record = true) {
+    if (record) this.history.commit(excel);
+    else this.history.replace(excel);
+    this.updateDocument(excel);
+    this.render();
+  }
+  mutate(change) {
+    const excel = structuredClone(this.excel);
+    change(excel);
+    this.replace(excel);
+  }
+  synchronize() {
+    const next = syncSteps(this.excel, this.getDocument().steps);
+    if (JSON.stringify(next) !== JSON.stringify(this.excel)) this.replace(next);
+    else this.render();
+  }
+  undo() {
+    const next = syncSteps(this.history.undo(), this.getDocument().steps);
+    this.history.replace(next);
+    this.updateDocument(next);
+    this.render();
+  }
+  redo() {
+    const next = syncSteps(this.history.redo(), this.getDocument().steps);
+    this.history.replace(next);
+    this.updateDocument(next);
+    this.render();
+  }
+  restore(excel) {
+    this.history = new History(excel);
+    this.render();
+  }
+  bindToolbar() {
+    this.toolbar.addEventListener('click', (event) => {
+      const action = event.target.dataset.excelAction;
+      if (!action) return;
+      this[action]?.();
+    });
+  }
+  addCompany() {
+    const name = prompt('Company name:', 'New company');
+    if (!name?.trim()) return;
+    this.mutate((excel) => {
+      const company = createCompany(name.trim());
+      excel.companies.push(company);
+      excel.selectedCompanyId = company.id;
+    });
+  }
+  deleteCompany() {
+    const company = this.company;
+    if (!company) return;
+    const typed = prompt(
+      `Type “${company.name}” to permanently delete this company. This can be undone.`,
+    );
+    if (typed !== company.name) {
+      if (typed !== null)
+        this.report('Company name did not match; nothing was deleted.');
+      return;
+    }
+    this.mutate((excel) => {
+      excel.companies = excel.companies.filter(
+        (item) => item.id !== company.id,
+      );
+      excel.selectedCompanyId = excel.companies[0]?.id || null;
+    });
+  }
+  addShareholder() {
+    if (!this.company || this.company.shareholders.length >= 100)
+      return this.report('The 100-shareholder limit has been reached.');
+    this.mutate((excel) => {
+      const company = excel.companies.find(
+          (item) => item.id === excel.selectedCompanyId,
+        ),
+        at = this.focus.holderId
+          ? company.shareholders.findIndex(
+              (item) => item.id === this.focus.holderId,
+            ) + 1
+          : company.shareholders.length;
+      const holder = {
+        id: `holder-${crypto.randomUUID()}`,
+        name: '',
+        type: 'Individual',
+      };
+      company.shareholders.splice(at, 0, holder);
+      this.focus = { holderId: holder.id };
+    });
+  }
+  removeShareholder() {
+    const company = this.company,
+      holder = company?.shareholders.find(
+        (item) => item.id === this.focus.holderId,
+      );
+    if (!holder) return this.report('Focus a shareholder row first.');
+    const blocking = findBlocking(
+      company,
+      null,
+      holder.id,
+      this.getDocument().steps,
+    );
+    if (blocking) return this.blocked(blocking);
+    this.mutate((excel) => {
+      const current = excel.companies.find((item) => item.id === company.id);
+      current.shareholders = current.shareholders.filter(
+        (item) => item.id !== holder.id,
+      );
+    });
+  }
+  addGroup() {
+    if (!this.company) return;
+    if (classesOf(this.company).length >= 100)
+      return this.report('The 100-share-class limit has been reached.');
+    this.mutate((excel) => {
+      const company = excel.companies.find(
+        (item) => item.id === excel.selectedCompanyId,
+      );
+      company.groups.push({
+        id: `group-${crypto.randomUUID()}`,
+        name: 'New group',
+        classes: [{ id: `class-${crypto.randomUUID()}`, label: '' }],
+      });
+    });
+  }
+  removeGroup() {
+    const company = this.company,
+      group = company?.groups.find((item) => item.id === this.focus.groupId);
+    if (!group) return this.report('Focus a share-group header first.');
+    const blocking = findBlocking(
+      company,
+      group.classes.map((item) => item.id),
+      null,
+      this.getDocument().steps,
+    );
+    if (blocking) return this.blocked(blocking);
+    this.mutate(
+      (excel) =>
+        (excel.companies.find((item) => item.id === company.id).groups =
+          company.groups.filter((item) => item.id !== group.id)),
+    );
+  }
+  addClass() {
+    if (!this.company) return;
+    if (classesOf(this.company).length >= 100)
+      return this.report('The 100-share-class limit has been reached.');
+    this.mutate((excel) => {
+      const company = excel.companies.find(
+          (item) => item.id === excel.selectedCompanyId,
+        ),
+        group =
+          company.groups.find((item) => item.id === this.focus.groupId) ||
+          company.groups.at(-1);
+      if (!group) return this.report('Add a share group first.');
+      const at = this.focus.classId
+        ? group.classes.findIndex((item) => item.id === this.focus.classId) + 1
+        : group.classes.length;
+      group.classes.splice(at, 0, {
+        id: `class-${crypto.randomUUID()}`,
+        label: '',
+      });
+    });
+  }
+  removeClass() {
+    const company = this.company,
+      shareClass = classesOf(company || { groups: [] }).find(
+        (item) => item.id === this.focus.classId,
+      );
+    if (!shareClass) return this.report('Focus a share-class header first.');
+    const blocking = findBlocking(
+      company,
+      [shareClass.id],
+      null,
+      this.getDocument().steps,
+    );
+    if (blocking) return this.blocked(blocking);
+    this.mutate((excel) => {
+      for (const group of excel.companies.find((item) => item.id === company.id)
+        .groups)
+        group.classes = group.classes.filter(
+          (item) => item.id !== shareClass.id,
+        );
+    });
+  }
+  blocked(item) {
+    this.report(
+      `${this.company.name} — ${item.location}: ${item.holder.name}, ${item.shareClass.label || 'unnamed share class'} contains data and blocks deletion.`,
+    );
+  }
+  table(title, values, editable, stepId = '') {
     const company = this.company;
     const classes = classesOf(company);
     const summary = totals(company, values);
@@ -53,45 +266,100 @@ export class ExcelEditor {
     for (const group of company.groups) {
       groupHeaders += `<th class="group-head" data-group-id="${escapeHtml(group.id)}" colspan="${Math.max(1, group.classes.length)}"><input data-group-name value="${escapeHtml(group.name)}" aria-label="Share group"></th>`;
       for (const item of group.classes) {
-        const column = classes.findIndex(shareClass => shareClass.id === item.id) + 1;
+        const column =
+          classes.findIndex((shareClass) => shareClass.id === item.id) + 1;
         classHeaders += `<th data-group-id="${escapeHtml(group.id)}" data-class-id="${escapeHtml(item.id)}"><input data-class-label data-grid-row="0" data-grid-column="${column}" value="${escapeHtml(item.label)}" aria-label="Share class"></th>`;
       }
     }
 
-    const rows = company.shareholders.map((holder, row) => {
-      const shareholder = `<th><input data-holder-name data-holder-id="${escapeHtml(holder.id)}" data-grid-row="${row + 1}" data-grid-column="0" value="${escapeHtml(holder.name)}" aria-label="Shareholder"></th>`;
-      const type = `<td><select data-holder-type data-holder-id="${escapeHtml(holder.id)}" tabindex="-1">${TYPES.map(item => `<option${item === holder.type ? ' selected' : ''}>${item}</option>`).join('')}</select></td>`;
-      const rowValues = classes.map((item, column) => {
-        const value = valueAt(values, holder.id, item.id);
-        const negative = value < 0 && (editable === 'opening' || !editable);
-        return `<td class="number ${negative ? 'negative' : ''}" tabindex="${editable ? '0' : '-1'}" ${editable ? 'contenteditable="true"' : ''} data-grid-row="${row + 1}" data-grid-column="${column + 1}" data-holder-id="${escapeHtml(holder.id)}" data-class-id="${escapeHtml(item.id)}" data-step-id="${escapeHtml(stepId)}" data-editable="${editable ? 'true' : 'false'}">${formatShares(value)}</td>`;
-      }).join('');
-      return `<tr>${shareholder}${type}${rowValues}<td class="number total">${formatShares(summary.rows[holder.id])}</td></tr>`;
-    }).join('');
+    const rows = company.shareholders
+      .map((holder, row) => {
+        const shareholder = `<th><input data-holder-name data-holder-id="${escapeHtml(holder.id)}" data-grid-row="${row + 1}" data-grid-column="0" value="${escapeHtml(holder.name)}" aria-label="Shareholder"></th>`;
+        const type = `<td><select data-holder-type data-holder-id="${escapeHtml(holder.id)}" tabindex="-1">${TYPES.map((item) => `<option${item === holder.type ? ' selected' : ''}>${item}</option>`).join('')}</select></td>`;
+        const rowValues = classes
+          .map((item, column) => {
+            const value = valueAt(values, holder.id, item.id);
+            const negative = value < 0 && (editable === 'opening' || !editable);
+            return `<td class="number ${negative ? 'negative' : ''}" tabindex="${editable ? '0' : '-1'}" ${editable ? 'contenteditable="true"' : ''} data-grid-row="${row + 1}" data-grid-column="${column + 1}" data-holder-id="${escapeHtml(holder.id)}" data-class-id="${escapeHtml(item.id)}" data-step-id="${escapeHtml(stepId)}" data-editable="${editable ? 'true' : 'false'}">${formatShares(value)}</td>`;
+          })
+          .join('');
+        return `<tr>${shareholder}${type}${rowValues}<td class="number total">${formatShares(summary.rows[holder.id])}</td></tr>`;
+      })
+      .join('');
 
-    const columnTotals = classes.map(item => `<td class="number">${formatShares(summary.columns[item.id])}</td>`).join('');
+    const columnTotals = classes
+      .map(
+        (item) =>
+          `<td class="number">${formatShares(summary.columns[item.id])}</td>`,
+      )
+      .join('');
     return `<section class="share-table"><h3>${escapeHtml(title)}</h3><div class="table-scroll"><table><thead><tr><th rowspan="2">Shareholder</th><th rowspan="2">Type</th>${groupHeaders}<th rowspan="2">Total</th></tr><tr>${classHeaders}</tr></thead><tbody>${rows}<tr class="total-row"><th colspan="2">Total</th>${columnTotals}<td class="number">${formatShares(summary.grand)}</td></tr></tbody></table></div></section>`;
   }
-  render() { const excel=this.excel,company=this.company;this.root.innerHTML=`<div class="company-tabs" role="tablist">${excel.companies.map(item=>`<button role="tab" aria-selected="${item.id===excel.selectedCompanyId}" data-company-id="${escapeHtml(item.id)}">${escapeHtml(item.name)}</button>`).join('')}</div>${company?this.table('Opening Position',company.opening,'opening')+this.getDocument().steps.map((step,index)=>`<section class="step-share-section"><button class="collapse-step" data-collapse="${escapeHtml(step.id)}" aria-expanded="${!company.collapsed[step.id]}">${company.collapsed[step.id]?'▸':'▾'} Step ${index+1}: ${escapeHtml(step.title)}</button><div ${company.collapsed[step.id]?'hidden':''}>${this.table(`Step ${index+1} Movement`,company.movements[step.id],true,step.id)}${this.table(`Step ${index+1} Resulting Position`,resultingValues(company,this.getDocument().steps,index),false,step.id)}</div></section>`).join(''):'<p>Add a company to begin.</p>'}`;this.bindGrid(); }
+  render() {
+    const excel = this.excel,
+      company = this.company;
+    this.root.innerHTML = `<div class="company-tabs" role="tablist">${excel.companies.map((item) => `<button role="tab" aria-selected="${item.id === excel.selectedCompanyId}" data-company-id="${escapeHtml(item.id)}">${escapeHtml(item.name)}</button>`).join('')}</div>${
+      company
+        ? this.table('Opening Position', company.opening, 'opening') +
+          this.getDocument()
+            .steps.map(
+              (step, index) =>
+                `<section class="step-share-section"><button class="collapse-step" data-collapse="${escapeHtml(step.id)}" aria-expanded="${!company.collapsed[step.id]}">${company.collapsed[step.id] ? '▸' : '▾'} Step ${index + 1}: ${escapeHtml(step.title)}</button><div ${company.collapsed[step.id] ? 'hidden' : ''}>${this.table(`Step ${index + 1} Movement`, company.movements[step.id], true, step.id)}${this.table(`Step ${index + 1} Resulting Position`, resultingValues(company, this.getDocument().steps, index), false, step.id)}</div></section>`,
+            )
+            .join('')
+        : '<p>Add a company to begin.</p>'
+    }`;
+    this.bindGrid();
+  }
   bindGrid() {
-    this.root.querySelectorAll('[data-company-id]').forEach(button => button.onclick = () => this.mutate(excel => excel.selectedCompanyId = button.dataset.companyId));
-    this.root.querySelectorAll('[data-collapse]').forEach(button => button.onclick = () => this.mutate(excel => {
-      const company = excel.companies.find(item => item.id === excel.selectedCompanyId);
-      company.collapsed[button.dataset.collapse] = !company.collapsed[button.dataset.collapse];
-    }));
-    this.root.querySelectorAll('[data-holder-id]').forEach(element => element.onfocus = () => {
-      this.focus.holderId = element.dataset.holderId;
-    });
-    this.root.querySelectorAll('[data-group-id]').forEach(element => element.onfocus = () => {
-      this.focus.groupId = element.dataset.groupId;
-      this.focus.classId = element.dataset.classId;
-    });
-    this.root.querySelectorAll(gridSelector).forEach(target => target.onkeydown = event => this.keydown(event, target));
-    this.root.querySelectorAll('td[data-editable=true]').forEach(cell => {
+    this.root
+      .querySelectorAll('[data-company-id]')
+      .forEach(
+        (button) =>
+          (button.onclick = () =>
+            this.mutate(
+              (excel) => (excel.selectedCompanyId = button.dataset.companyId),
+            )),
+      );
+    this.root.querySelectorAll('[data-collapse]').forEach(
+      (button) =>
+        (button.onclick = () =>
+          this.mutate((excel) => {
+            const company = excel.companies.find(
+              (item) => item.id === excel.selectedCompanyId,
+            );
+            company.collapsed[button.dataset.collapse] =
+              !company.collapsed[button.dataset.collapse];
+          })),
+    );
+    this.root.querySelectorAll('[data-holder-id]').forEach(
+      (element) =>
+        (element.onfocus = () => {
+          this.focus.holderId = element.dataset.holderId;
+        }),
+    );
+    this.root.querySelectorAll('[data-group-id]').forEach(
+      (element) =>
+        (element.onfocus = () => {
+          this.focus.groupId = element.dataset.groupId;
+          this.focus.classId = element.dataset.classId;
+        }),
+    );
+    this.root
+      .querySelectorAll(gridSelector)
+      .forEach(
+        (target) => (target.onkeydown = (event) => this.keydown(event, target)),
+      );
+    this.root.querySelectorAll('td[data-editable=true]').forEach((cell) => {
       cell.onfocus = () => {
-        const header = [...cell.closest('table').querySelectorAll('[data-class-id]')]
-          .find(item => item.dataset.classId === cell.dataset.classId);
-        this.focus = {holderId:cell.dataset.holderId, classId:cell.dataset.classId, groupId:header?.dataset.groupId};
+        const header = [
+          ...cell.closest('table').querySelectorAll('[data-class-id]'),
+        ].find((item) => item.dataset.classId === cell.dataset.classId);
+        this.focus = {
+          holderId: cell.dataset.holderId,
+          classId: cell.dataset.classId,
+          groupId: header?.dataset.groupId,
+        };
         if (cell.textContent.trim() === '0') cell.textContent = '';
       };
       cell.onblur = () => {
@@ -99,43 +367,98 @@ export class ExcelEditor {
         this.commitCell(cell);
       };
     });
-    const companyOf = excel => excel.companies.find(item => item.id === excel.selectedCompanyId);
-    this.root.querySelectorAll('[data-holder-name]').forEach(input => input.onchange = () => this.mutate(excel => {
-      const holder = companyOf(excel).shareholders.find(item => item.id === input.dataset.holderId);
-      if (holder) holder.name = input.value;
-    }));
-    this.root.querySelectorAll('[data-holder-type]').forEach(select => select.onchange = () => this.mutate(excel => {
-      const holder = companyOf(excel).shareholders.find(item => item.id === select.dataset.holderId);
-      if (holder) holder.type = select.value;
-    }));
-    this.root.querySelectorAll('[data-group-name]').forEach(input => input.onchange = () => this.mutate(excel => {
-      const group = companyOf(excel).groups.find(item => item.id === input.closest('[data-group-id]').dataset.groupId);
-      if (group) group.name = input.value;
-    }));
-    this.root.querySelectorAll('[data-class-label]').forEach(input => input.onchange = () => this.mutate(excel => {
-      const header = input.closest('[data-class-id]');
-      const shareClass = classesOf(companyOf(excel)).find(item => item.id === header.dataset.classId);
-      if (shareClass) shareClass.label = input.value;
-    }));
+    const companyOf = (excel) =>
+      excel.companies.find((item) => item.id === excel.selectedCompanyId);
+    this.root.querySelectorAll('[data-holder-name]').forEach(
+      (input) =>
+        (input.onchange = () =>
+          this.mutate((excel) => {
+            const holder = companyOf(excel).shareholders.find(
+              (item) => item.id === input.dataset.holderId,
+            );
+            if (holder) holder.name = input.value;
+          })),
+    );
+    this.root.querySelectorAll('[data-holder-type]').forEach(
+      (select) =>
+        (select.onchange = () =>
+          this.mutate((excel) => {
+            const holder = companyOf(excel).shareholders.find(
+              (item) => item.id === select.dataset.holderId,
+            );
+            if (holder) holder.type = select.value;
+          })),
+    );
+    this.root.querySelectorAll('[data-group-name]').forEach(
+      (input) =>
+        (input.onchange = () =>
+          this.mutate((excel) => {
+            const group = companyOf(excel).groups.find(
+              (item) =>
+                item.id === input.closest('[data-group-id]').dataset.groupId,
+            );
+            if (group) group.name = input.value;
+          })),
+    );
+    this.root.querySelectorAll('[data-class-label]').forEach(
+      (input) =>
+        (input.onchange = () =>
+          this.mutate((excel) => {
+            const header = input.closest('[data-class-id]');
+            const shareClass = classesOf(companyOf(excel)).find(
+              (item) => item.id === header.dataset.classId,
+            );
+            if (shareClass) shareClass.label = input.value;
+          })),
+    );
   }
-  commitCell(cell) { if(cell.contentEditable!=='true')return;const value=parseShares(cell.textContent);if(value===null){this.report('Only whole integers are permitted.');this.render();return;}this.mutate(excel=>{const company=excel.companies.find(item=>item.id===excel.selectedCompanyId),values=cell.dataset.stepId?company.movements[cell.dataset.stepId]:company.opening;values[cellKey(cell.dataset.holderId,cell.dataset.classId)]=value;}); }
+  commitCell(cell) {
+    if (cell.contentEditable !== 'true') return;
+    const value = parseShares(cell.textContent);
+    if (value === null) {
+      this.report('Only whole integers are permitted.');
+      this.render();
+      return;
+    }
+    this.mutate((excel) => {
+      const company = excel.companies.find(
+          (item) => item.id === excel.selectedCompanyId,
+        ),
+        values = cell.dataset.stepId
+          ? company.movements[cell.dataset.stepId]
+          : company.opening;
+      values[cellKey(cell.dataset.holderId, cell.dataset.classId)] = value;
+    });
+  }
   keydown(event, target) {
     if (event.key === 'Escape' && target.matches('td[data-editable=true]')) {
       event.preventDefault();
       this.render();
       return;
     }
-    const navigationKeys = ['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Enter', 'Tab'];
+    const navigationKeys = [
+      'ArrowUp',
+      'ArrowDown',
+      'ArrowLeft',
+      'ArrowRight',
+      'Enter',
+      'Tab',
+    ];
     if (!navigationKeys.includes(event.key)) return;
 
     const table = target.closest('table');
-    const targets = [...table.querySelectorAll(gridSelector)].filter(item => (
-      !item.matches('td[data-editable=false]')
-    ));
-    const destination = gridDestination(targets, target, event.key, event.shiftKey);
+    const targets = [...table.querySelectorAll(gridSelector)].filter(
+      (item) => !item.matches('td[data-editable=false]'),
+    );
+    const destination = gridDestination(
+      targets,
+      target,
+      event.key,
+      event.shiftKey,
+    );
     const destinationPosition = {
-      row:destination.dataset.gridRow,
-      column:destination.dataset.gridColumn
+      row: destination.dataset.gridRow,
+      column: destination.dataset.gridColumn,
     };
     const tables = [...this.root.querySelectorAll('.share-table table')];
     const tableIndex = tables.indexOf(table);
@@ -147,7 +470,12 @@ export class ExcelEditor {
     } else if (target.matches('[data-holder-name], [data-class-label]')) {
       target.onchange();
     }
-    const currentTable = this.root.querySelectorAll('.share-table table')[tableIndex] || table;
-    currentTable.querySelector(`${gridSelector}[data-grid-row="${destinationPosition.row}"][data-grid-column="${destinationPosition.column}"]`)?.focus();
+    const currentTable =
+      this.root.querySelectorAll('.share-table table')[tableIndex] || table;
+    currentTable
+      .querySelector(
+        `${gridSelector}[data-grid-row="${destinationPosition.row}"][data-grid-column="${destinationPosition.column}"]`,
+      )
+      ?.focus();
   }
 }

--- a/UBTA/src/editor/insertion-context.js
+++ b/UBTA/src/editor/insertion-context.js
@@ -1,20 +1,27 @@
 export function insertionIndex(group, context) {
   if (!group || group.id !== context?.groupId) return -1;
   if (!context.referenceBlockId) return group.blocks.length;
-  const referenceIndex = group.blocks.findIndex(block => block.id === context.referenceBlockId);
+  const referenceIndex = group.blocks.findIndex(
+    (block) => block.id === context.referenceBlockId,
+  );
   if (referenceIndex < 0) return group.blocks.length;
   return referenceIndex + (context.position === 'before' ? 0 : 1);
 }
 
 export function insertionContextFromPoint(groupId, blockElements, clientY) {
   const blocks = blockElements
-    .map(element => ({ id: element.dataset.blockId, rect: element.getBoundingClientRect() }))
-    .filter(item => item.id && item.rect.height > 0)
+    .map((element) => ({
+      id: element.dataset.blockId,
+      rect: element.getBoundingClientRect(),
+    }))
+    .filter((item) => item.id && item.rect.height > 0)
     .sort((a, b) => a.rect.top - b.rect.top);
-  const preceding = blocks.filter(item => item.rect.top <= clientY).at(-1);
-  if (preceding) return { groupId, referenceBlockId: preceding.id, position: 'after' };
-  const following = blocks.find(item => item.rect.top > clientY);
-  if (following) return { groupId, referenceBlockId: following.id, position: 'before' };
+  const preceding = blocks.filter((item) => item.rect.top <= clientY).at(-1);
+  if (preceding)
+    return { groupId, referenceBlockId: preceding.id, position: 'after' };
+  const following = blocks.find((item) => item.rect.top > clientY);
+  if (following)
+    return { groupId, referenceBlockId: following.id, position: 'before' };
   return { groupId, referenceBlockId: null, position: 'after' };
 }
 

--- a/UBTA/src/editor/interactions.js
+++ b/UBTA/src/editor/interactions.js
@@ -1,17 +1,141 @@
 import { normaliseRuns, safeHref } from '../state/schema.js';
-export function validatedLink(external,internal){const candidate=String(external||'').trim();return safeHref(candidate||internal);}
-export function containedSelectionOffsets(element,selection,documentObject=document){
-  if(!element||!selection?.rangeCount)return null;
-  const range=selection.getRangeAt(0);
-  if(!element.contains(range.startContainer)||!element.contains(range.endContainer))return null;
-  const before=documentObject.createRange();before.selectNodeContents(element);before.setEnd(range.startContainer,range.startOffset);
-  return [before.toString().length,before.toString().length+range.toString().length];
+export function validatedLink(external, internal) {
+  const candidate = String(external || '').trim();
+  return safeHref(candidate || internal);
 }
-export function confirmStepDeletion(steps,index,confirmAction){if(steps.length<=1||index<0||index>=steps.length)return false;return confirmAction(`Delete Step ${index+1}: ${steps[index].title}?`);}
-export function splitListRuns(runs,offset){let position=0,before=[],after=[];for(const run of runs){const split=Math.max(0,Math.min(run.text.length,offset-position));if(split)before.push({...run,text:run.text.slice(0,split)});if(split<run.text.length)after.push({...run,text:run.text.slice(split)});position+=run.text.length}return [normaliseRuns(before),normaliseRuns(after)];}
-export function removeEmptyListItem(block,index){const item=block?.items?.[index];if(!item||index<1||item.runs?.some(run=>run.text))return null;block.items.splice(index,1);const previous=block.items[index-1];return {itemId:previous.id,offset:(previous.runs||[]).reduce((length,run)=>length+run.text.length,0)};}
-export function insertTableRowBeforeTotals(block,makeId){let index=block.rows.reduce((last,row,i)=>row.isTotal?last:i,-1)+1;block.rows.splice(index,0,{id:makeId('row'),isTotal:false,cells:block.columns.map(()=>({id:makeId('cell'),runs:[]}))});return index;}
-export function insertTableRowAfter(block,rowIndex,makeId){const index=Number.isInteger(rowIndex)&&rowIndex>=0&&rowIndex<block.rows.length?rowIndex+1:block.rows.length;block.rows.splice(index,0,{id:makeId('row'),isTotal:false,cells:block.columns.map(()=>({id:makeId('cell'),runs:[]}))});return index;}
-export function insertTableColumnAfter(block,columnIndex,makeId){const index=Number.isInteger(columnIndex)&&columnIndex>=0&&columnIndex<block.columns.length?columnIndex+1:block.columns.length;block.columns.splice(index,0,{id:makeId('column'),headingRuns:[{text:`Column ${index+1}`}],width:100/(block.columns.length+1),format:'text',totalEnabled:false});block.rows.forEach(row=>row.cells.splice(index,0,{id:makeId('cell'),runs:[]}));return index;}
-export class GenerationGate{generation=0;next(){return ++this.generation}isCurrent(value){return value===this.generation}cancel(){this.generation++}}
-export function restoreTextSelection(element,offsets,environment=globalThis){if(!element||!offsets)return false;element.focus({preventScroll:true});const walker=environment.document.createTreeWalker(element,environment.NodeFilter.SHOW_TEXT);let position=0,start,end,node;while(node=walker.nextNode()){if(!start&&offsets[0]<=position+node.length)start=[node,offsets[0]-position];if(offsets[1]<=position+node.length){end=[node,offsets[1]-position];break}position+=node.length}if(!start)return false;const range=environment.document.createRange();range.setStart(...start);range.setEnd(...(end||start));const selection=environment.getSelection();selection.removeAllRanges();selection.addRange(range);return true;}
+export function containedSelectionOffsets(
+  element,
+  selection,
+  documentObject = document,
+) {
+  if (!element || !selection?.rangeCount) return null;
+  const range = selection.getRangeAt(0);
+  if (
+    !element.contains(range.startContainer) ||
+    !element.contains(range.endContainer)
+  )
+    return null;
+  const before = documentObject.createRange();
+  before.selectNodeContents(element);
+  before.setEnd(range.startContainer, range.startOffset);
+  return [
+    before.toString().length,
+    before.toString().length + range.toString().length,
+  ];
+}
+export function confirmStepDeletion(steps, index, confirmAction) {
+  if (steps.length <= 1 || index < 0 || index >= steps.length) return false;
+  return confirmAction(`Delete Step ${index + 1}: ${steps[index].title}?`);
+}
+export function splitListRuns(runs, offset) {
+  let position = 0,
+    before = [],
+    after = [];
+  for (const run of runs) {
+    const split = Math.max(0, Math.min(run.text.length, offset - position));
+    if (split) before.push({ ...run, text: run.text.slice(0, split) });
+    if (split < run.text.length)
+      after.push({ ...run, text: run.text.slice(split) });
+    position += run.text.length;
+  }
+  return [normaliseRuns(before), normaliseRuns(after)];
+}
+export function removeEmptyListItem(block, index) {
+  const item = block?.items?.[index];
+  if (!item || index < 1 || item.runs?.some((run) => run.text)) return null;
+  block.items.splice(index, 1);
+  const previous = block.items[index - 1];
+  return {
+    itemId: previous.id,
+    offset: (previous.runs || []).reduce(
+      (length, run) => length + run.text.length,
+      0,
+    ),
+  };
+}
+export function insertTableRowBeforeTotals(block, makeId) {
+  let index =
+    block.rows.reduce((last, row, i) => (row.isTotal ? last : i), -1) + 1;
+  block.rows.splice(index, 0, {
+    id: makeId('row'),
+    isTotal: false,
+    cells: block.columns.map(() => ({ id: makeId('cell'), runs: [] })),
+  });
+  return index;
+}
+export function insertTableRowAfter(block, rowIndex, makeId) {
+  const index =
+    Number.isInteger(rowIndex) && rowIndex >= 0 && rowIndex < block.rows.length
+      ? rowIndex + 1
+      : block.rows.length;
+  block.rows.splice(index, 0, {
+    id: makeId('row'),
+    isTotal: false,
+    cells: block.columns.map(() => ({ id: makeId('cell'), runs: [] })),
+  });
+  return index;
+}
+export function insertTableColumnAfter(block, columnIndex, makeId) {
+  const index =
+    Number.isInteger(columnIndex) &&
+    columnIndex >= 0 &&
+    columnIndex < block.columns.length
+      ? columnIndex + 1
+      : block.columns.length;
+  block.columns.splice(index, 0, {
+    id: makeId('column'),
+    headingRuns: [{ text: `Column ${index + 1}` }],
+    width: 100 / (block.columns.length + 1),
+    format: 'text',
+    totalEnabled: false,
+  });
+  block.rows.forEach((row) =>
+    row.cells.splice(index, 0, { id: makeId('cell'), runs: [] }),
+  );
+  return index;
+}
+export class GenerationGate {
+  generation = 0;
+  next() {
+    return ++this.generation;
+  }
+  isCurrent(value) {
+    return value === this.generation;
+  }
+  cancel() {
+    this.generation++;
+  }
+}
+export function restoreTextSelection(
+  element,
+  offsets,
+  environment = globalThis,
+) {
+  if (!element || !offsets) return false;
+  element.focus({ preventScroll: true });
+  const walker = environment.document.createTreeWalker(
+    element,
+    environment.NodeFilter.SHOW_TEXT,
+  );
+  let position = 0,
+    start,
+    end,
+    node;
+  while ((node = walker.nextNode())) {
+    if (!start && offsets[0] <= position + node.length)
+      start = [node, offsets[0] - position];
+    if (offsets[1] <= position + node.length) {
+      end = [node, offsets[1] - position];
+      break;
+    }
+    position += node.length;
+  }
+  if (!start) return false;
+  const range = environment.document.createRange();
+  range.setStart(...start);
+  range.setEnd(...(end || start));
+  const selection = environment.getSelection();
+  selection.removeAllRanges();
+  selection.addRange(range);
+  return true;
+}

--- a/UBTA/src/editor/link-actions.js
+++ b/UBTA/src/editor/link-actions.js
@@ -1,16 +1,34 @@
 import { safeHref } from '../state/schema.js';
 
-export function followEditorLink(href,{navigateInternal,openExternal,openMailto,report=()=>{}}){
-  const safe=safeHref(href);
-  if(!safe){report('This link is not safe to open');return false}
-  if(safe.startsWith('#')){const opened=navigateInternal(safe.slice(1));if(!opened)report('The linked document destination no longer exists');return opened}
-  if(/^https?:/i.test(safe)){openExternal(safe);return true}
-  if(/^mailto:/i.test(safe)){openMailto(safe);return true}
+export function followEditorLink(
+  href,
+  { navigateInternal, openExternal, openMailto, report = () => {} },
+) {
+  const safe = safeHref(href);
+  if (!safe) {
+    report('This link is not safe to open');
+    return false;
+  }
+  if (safe.startsWith('#')) {
+    const opened = navigateInternal(safe.slice(1));
+    if (!opened) report('The linked document destination no longer exists');
+    return opened;
+  }
+  if (/^https?:/i.test(safe)) {
+    openExternal(safe);
+    return true;
+  }
+  if (/^mailto:/i.test(safe)) {
+    openMailto(safe);
+    return true;
+  }
   return false;
 }
 
-export function handleEditableLinkClick(event,openLink){
-  const link=event.target?.closest?.('.editable-runs a');
-  if(!link||event.button!==0)return false;
-  event.preventDefault();openLink(link.getAttribute('href'));return true;
+export function handleEditableLinkClick(event, openLink) {
+  const link = event.target?.closest?.('.editable-runs a');
+  if (!link || event.button !== 0) return false;
+  event.preventDefault();
+  openLink(link.getAttribute('href'));
+  return true;
 }

--- a/UBTA/src/editor/list-rendering.js
+++ b/UBTA/src/editor/list-rendering.js
@@ -1,13 +1,20 @@
-export function renderList(block,renderRuns,escapeAttribute=String){
-  const tag=block.type==='numberList'?'ol':block.type==='bulletList'?'ul':null;
-  if(!tag)return '';
-  const counters=[0,0,0];
-  const items=block.items.map(item=>{
-    const level=Math.min(3,Math.max(1,Number(item.level)||1));
-    counters[level-1]++;
-    counters.fill(0,level);
-    const value=tag==='ol'?` value="${counters[level-1]}"`:'';
-    return `<li class="list-item" contenteditable="true" data-container="item" data-item-id="${escapeAttribute(item.id)}" data-level="${level}" aria-level="${level}"${value}>${renderRuns(item.runs)}</li>`;
-  }).join('');
+export function renderList(block, renderRuns, escapeAttribute = String) {
+  const tag =
+    block.type === 'numberList'
+      ? 'ol'
+      : block.type === 'bulletList'
+        ? 'ul'
+        : null;
+  if (!tag) return '';
+  const counters = [0, 0, 0];
+  const items = block.items
+    .map((item) => {
+      const level = Math.min(3, Math.max(1, Number(item.level) || 1));
+      counters[level - 1]++;
+      counters.fill(0, level);
+      const value = tag === 'ol' ? ` value="${counters[level - 1]}"` : '';
+      return `<li class="list-item" contenteditable="true" data-container="item" data-item-id="${escapeAttribute(item.id)}" data-level="${level}" aria-level="${level}"${value}>${renderRuns(item.runs)}</li>`;
+    })
+    .join('');
   return `<${tag} class="list-items" data-list-type="${block.type}">${items}</${tag}><button class="list-trailing-hit-area" type="button" aria-label="Add another list item" data-list-append></button>`;
 }

--- a/UBTA/src/editor/navigation-history.js
+++ b/UBTA/src/editor/navigation-history.js
@@ -1,6 +1,14 @@
 export class NavigationHistory {
-  constructor() { this.entries = []; }
-  push(view) { if (view) this.entries.push(structuredClone(view)); }
-  undo() { return this.entries.length ? this.entries.pop() : null; }
-  clear() { this.entries.length = 0; }
+  constructor() {
+    this.entries = [];
+  }
+  push(view) {
+    if (view) this.entries.push(structuredClone(view));
+  }
+  undo() {
+    return this.entries.length ? this.entries.pop() : null;
+  }
+  clear() {
+    this.entries.length = 0;
+  }
 }

--- a/UBTA/src/editor/printing.js
+++ b/UBTA/src/editor/printing.js
@@ -1,35 +1,63 @@
 export class PrintLifecycle {
-  constructor({flush,cancelPagination,render,prepare,clearPresentation,print,restore,onAfterPrint,onError=()=>{},setFallback=(callback)=>setTimeout(callback,1000),clearFallback=clearTimeout}) {
-    Object.assign(this,{flush,cancelPagination,render,prepare,clearPresentation,print,restore,onAfterPrint,onError,setFallback,clearFallback});
-    this.busy=false;
+  constructor({
+    flush,
+    cancelPagination,
+    render,
+    prepare,
+    clearPresentation,
+    print,
+    restore,
+    onAfterPrint,
+    onError = () => {},
+    setFallback = (callback) => setTimeout(callback, 1000),
+    clearFallback = clearTimeout,
+  }) {
+    Object.assign(this, {
+      flush,
+      cancelPagination,
+      render,
+      prepare,
+      clearPresentation,
+      print,
+      restore,
+      onAfterPrint,
+      onError,
+      setFallback,
+      clearFallback,
+    });
+    this.busy = false;
   }
 
-  async run(){
-    if(this.busy)return false;
-    this.busy=true;
-    const context=this.prepare();
+  async run() {
+    if (this.busy) return false;
+    this.busy = true;
+    const context = this.prepare();
     let fallback;
-    let removeAfterPrint=()=>{};
-    const cleanup=()=>{
-      if(!this.busy)return;
-      this.busy=false;
-      if(fallback!==undefined)this.clearFallback(fallback);
+    let removeAfterPrint = () => {};
+    const cleanup = () => {
+      if (!this.busy) return;
+      this.busy = false;
+      if (fallback !== undefined) this.clearFallback(fallback);
       removeAfterPrint();
       this.restore(context);
     };
-    try{
+    try {
       this.flush();
       this.cancelPagination();
-      if(!await this.render())throw new Error('The document could not be prepared for printing.');
+      if (!(await this.render()))
+        throw new Error('The document could not be prepared for printing.');
       // The first pass calculates the new page map. The second pass lays out the
       // contents page with that map, so the printed TOC matches the final pages.
-      if(!await this.render())throw new Error('The document contents could not be reconciled for printing.');
+      if (!(await this.render()))
+        throw new Error(
+          'The document contents could not be reconciled for printing.',
+        );
       this.clearPresentation();
-      removeAfterPrint=this.onAfterPrint(cleanup);
+      removeAfterPrint = this.onAfterPrint(cleanup);
       this.print();
-      if(this.busy)fallback=this.setFallback(cleanup);
+      if (this.busy) fallback = this.setFallback(cleanup);
       return true;
-    }catch(error){
+    } catch (error) {
       cleanup();
       this.onError(error);
       return false;

--- a/UBTA/src/editor/repagination.js
+++ b/UBTA/src/editor/repagination.js
@@ -1,7 +1,44 @@
 import { GenerationGate } from './interactions.js';
 export class RepaginationScheduler {
-  constructor(renderer,{delay=500,capture=()=>null,restore=()=>{}}={}){this.renderer=renderer;this.delay=delay;this.capture=capture;this.restore=restore;this.gate=new GenerationGate;this.timer=null;}
-  request({immediate=false}={}){this.cancel();const generation=this.gate.next(),view=this.capture();if(immediate)return this.run(generation,view);return new Promise(resolve=>{this.queuedResolve=resolve;this.timer=setTimeout(()=>{this.timer=null;this.queuedResolve=null;this.run(generation,view).then(resolve)},this.delay)});}
-  cancel(){if(this.timer){clearTimeout(this.timer);this.timer=null;this.queuedResolve?.(false);this.queuedResolve=null}this.gate.cancel()}
-  async run(generation,view){const isCurrent=()=>this.gate.isCurrent(generation);const completed=await this.renderer({isCurrent});if(!completed||!isCurrent())return false;await this.restore(view);return isCurrent();}
+  constructor(
+    renderer,
+    { delay = 500, capture = () => null, restore = () => {} } = {},
+  ) {
+    this.renderer = renderer;
+    this.delay = delay;
+    this.capture = capture;
+    this.restore = restore;
+    this.gate = new GenerationGate();
+    this.timer = null;
+  }
+  request({ immediate = false } = {}) {
+    this.cancel();
+    const generation = this.gate.next(),
+      view = this.capture();
+    if (immediate) return this.run(generation, view);
+    return new Promise((resolve) => {
+      this.queuedResolve = resolve;
+      this.timer = setTimeout(() => {
+        this.timer = null;
+        this.queuedResolve = null;
+        this.run(generation, view).then(resolve);
+      }, this.delay);
+    });
+  }
+  cancel() {
+    if (this.timer) {
+      clearTimeout(this.timer);
+      this.timer = null;
+      this.queuedResolve?.(false);
+      this.queuedResolve = null;
+    }
+    this.gate.cancel();
+  }
+  async run(generation, view) {
+    const isCurrent = () => this.gate.isCurrent(generation);
+    const completed = await this.renderer({ isCurrent });
+    if (!completed || !isCurrent()) return false;
+    await this.restore(view);
+    return isCurrent();
+  }
 }

--- a/UBTA/src/main.js
+++ b/UBTA/src/main.js
@@ -1,161 +1,2124 @@
-import { seedDocument, normaliseDocument, normaliseRuns, safeHref, transactionProposals, hasReview, newId, stableAnchor, METADATA_KEYS } from './state/schema.js';
+import {
+  seedDocument,
+  normaliseDocument,
+  normaliseRuns,
+  safeHref,
+  transactionProposals,
+  hasReview,
+  newId,
+  stableAnchor,
+  METADATA_KEYS,
+} from './state/schema.js';
 import { validateImageInput } from './state/image-model.js';
-import { parseTableNumber, formatTableNumber, tableColumnFormat, recalculateTableTotals } from './state/table-model.js';
-import { addStep as addStepOperation, moveStep as moveStepOperation, deleteStep as deleteStepOperation, addAppendix as addAppendixOperation, moveAppendix as moveAppendixOperation, deleteAppendix as deleteAppendixOperation, insertBlock as insertBlockOperation, moveBlock as moveBlockOperation, deleteBlock as deleteBlockOperation, insertTableRow as insertTableRowOperation, moveTableRow as moveTableRowOperation, deleteTableRow as deleteTableRowOperation, insertTableColumn as insertTableColumnOperation, moveTableColumn as moveTableColumnOperation, deleteTableColumn as deleteTableColumnOperation, setTableColumnFormat as setTableColumnFormatOperation, setTableColumnTotal as setTableColumnTotalOperation, convertBlockStyle as convertBlockStyleOperation } from './state/document-operations.js';
+import {
+  parseTableNumber,
+  formatTableNumber,
+  tableColumnFormat,
+  recalculateTableTotals,
+} from './state/table-model.js';
+import {
+  addStep as addStepOperation,
+  moveStep as moveStepOperation,
+  deleteStep as deleteStepOperation,
+  addAppendix as addAppendixOperation,
+  moveAppendix as moveAppendixOperation,
+  deleteAppendix as deleteAppendixOperation,
+  insertBlock as insertBlockOperation,
+  moveBlock as moveBlockOperation,
+  deleteBlock as deleteBlockOperation,
+  insertTableRow as insertTableRowOperation,
+  moveTableRow as moveTableRowOperation,
+  deleteTableRow as deleteTableRowOperation,
+  insertTableColumn as insertTableColumnOperation,
+  moveTableColumn as moveTableColumnOperation,
+  deleteTableColumn as deleteTableColumnOperation,
+  setTableColumnFormat as setTableColumnFormatOperation,
+  setTableColumnTotal as setTableColumnTotalOperation,
+  convertBlockStyle as convertBlockStyleOperation,
+} from './state/document-operations.js';
 import { History } from './state/history.js';
-import { readDraft, readRecovery, saveDraft, saveVersion, listVersions, deleteVersion, nextAvailableVersion, encodeSnapshot, snapshotFromLocation, updateSnapshotUrl } from './state/persistence.js';
-import { runsFromElement, transformRuns, insertPlainText } from './editor/dom-runs.js';
-import { validatedLink, containedSelectionOffsets, confirmStepDeletion, splitListRuns, removeEmptyListItem, restoreTextSelection } from './editor/interactions.js';
+import {
+  readDraft,
+  readRecovery,
+  saveDraft,
+  saveVersion,
+  listVersions,
+  deleteVersion,
+  nextAvailableVersion,
+  encodeSnapshot,
+  snapshotFromLocation,
+  updateSnapshotUrl,
+} from './state/persistence.js';
+import {
+  runsFromElement,
+  transformRuns,
+  insertPlainText,
+} from './editor/dom-runs.js';
+import {
+  validatedLink,
+  containedSelectionOffsets,
+  confirmStepDeletion,
+  splitListRuns,
+  removeEmptyListItem,
+  restoreTextSelection,
+} from './editor/interactions.js';
 import { RepaginationScheduler } from './editor/repagination.js';
 import { PrintLifecycle } from './editor/printing.js';
-import { routeInsertionCommand, canApplyBlockStyle, blockStyleChoices } from './editor/command-routing.js';
+import {
+  routeInsertionCommand,
+  canApplyBlockStyle,
+  blockStyleChoices,
+} from './editor/command-routing.js';
 import { renderList } from './editor/list-rendering.js';
 import { blockTypeLabel } from './editor/block-deletion.js';
-import { insertionIndex, insertionContextFromPoint, canOpenBlankSpaceInsertion } from './editor/insertion-context.js';
-import { EncryptedTemplateLoader, templateBlocks } from './editor/default-templates.js';
+import {
+  insertionIndex,
+  insertionContextFromPoint,
+  canOpenBlankSpaceInsertion,
+} from './editor/insertion-context.js';
+import {
+  EncryptedTemplateLoader,
+  templateBlocks,
+} from './editor/default-templates.js';
 import { defaultTemplateEnvelope } from './editor/default-template-data.js';
-import { followEditorLink, handleEditableLinkClick } from './editor/link-actions.js';
+import {
+  followEditorLink,
+  handleEditableLinkClick,
+} from './editor/link-actions.js';
 import { bindCallouts } from './editor/callouts.js';
 import { NavigationHistory } from './editor/navigation-history.js';
 import { ExcelEditor } from './editor/excel-editor.js';
 import { stepHasMovements } from './state/excel-model.js';
 
-let initial=seedDocument,loadedRevision=0;try{const draft=readDraft();initial=snapshotFromLocation()||draft?.document||readRecovery()?.document||seedDocument;loadedRevision=draft?.revision||0}catch(error){setTimeout(()=>alert(error.message),0)}const history = new History(initial); let state = history.checkout(); let currentPage = 1;let dirty=false,autosaveTimer=null;
-export const editorSelection = { activeGroupId:null, activeGroupType:null, activeStepId:null, activeBlockId:null, container:null, row:null, column:null, rowId:null, columnId:null, cellId:null, blockType:null, offsets:null, restoreFocus:false };
-let activeEditor='steps', excelController=null;
-const pending = new Map(), pendingStepTitles = new Map(); const $ = s => document.querySelector(s); const esc = x => String(x).replace(/[&<>"']/g,c=>({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[c]));
-const runText = runs => (runs||[]).map(r=>r.text).join('');
-const runsHTML = runs => (runs||[]).map(r=>{let text=esc(r.text).replace(/\n/g,'<br>');if(r.link)text=`<a href="${esc(r.link.href)}">${text}</a>`;return r.highlight?`<mark>${text}</mark>`:text}).join('');
-const editableRuns = (runs, attrs='') => `<span class="editable-runs" contenteditable="true" spellcheck="true" ${attrs}>${runsHTML(runs)}</span>`;
-const allGroups = () => [...state.sections,...state.steps,...state.appendices];
-const findBlock = id => { for(const group of allGroups()){const block=group.blocks.find(x=>x.id===id);if(block)return {group,block};} return {}; };
-const selectedEditableGroup = () => (editorSelection.activeGroupType==='appendix'?state.appendices:state.steps).find(x=>x.id===editorSelection.activeGroupId);
-const appendixLabel = index => `Appendix ${String.fromCharCode(65+index)}`;
-
-function header(){const x=document.createElement('header');x.className='page-header';x.innerHTML=`<span class="header-brand">UBTA</span><span class="header-details">${esc(state.meta.clientName)} · ${esc(state.meta.projectTitle)} · ${esc(state.meta.version)}</span>`;return x}
-function sheet(kind){const x=document.createElement('section');x.className=`sheet-source ${kind}`;x.append(header());return x}
-function footer(x,n,total){const f=document.createElement('footer');f.className='page-footer';f.textContent=`Page ${n} of ${total}`;x.append(f)}
-function blockElement(block){const x=document.createElement('div');x.className='editable-block';x.dataset.blockId=block.id;x.dataset.type=block.type;x.dataset.level=block.level||'';x.draggable=false;x.tabIndex=-1;
-  if(['heading','paragraph'].includes(block.type))x.innerHTML=editableRuns(block.runs,'data-container="block"');
-  else if(block.type.endsWith('List')){x.classList.add('list-block');x.dataset.listType=block.type;x.innerHTML=renderList(block,runsHTML,esc)}
-  else if(block.type==='table'){x.classList.add('table-block');recalculateTableTotals(block);const cellHTML=(cell,row,ri,ci)=>{const format=tableColumnFormat(block.columns[ci]),numeric=format!=='text',value=runText(cell.runs),parsed=numeric?parseTableNumber(value):null,display=parsed===null?value:formatTableNumber(parsed,format),attrs=`data-container="cell" data-row="${ri}" data-column="${ci}" data-row-id="${esc(row.id)}" data-column-id="${esc(block.columns[ci].id)}" data-cell-id="${esc(cell.id)}"`;return `<td class="format-${format}">${row.isTotal&&numeric?`<output ${attrs}>${esc(display)}</output>`:editableRuns(numeric?[{text:display}]:cell.runs,attrs)}</td>`};x.innerHTML=`<table><caption>${editableRuns(block.captionRuns,'data-container="caption"')}</caption><colgroup>${block.columns.map(c=>`<col style="width:${c.width}%">`).join('')}</colgroup><thead><tr>${block.columns.map((c,i)=>`<th class="format-${tableColumnFormat(c)}">${editableRuns(c.headingRuns,`data-container="heading" data-column="${i}"`)}</th>`).join('')}</tr></thead><tbody>${block.rows.map((r,ri)=>`<tr class="${r.isTotal?'total-row':''}" data-row="${ri}">${r.cells.map((c,ci)=>cellHTML(c,r,ri,ci)).join('')}</tr>`).join('')}</tbody></table>`}
-  else {x.classList.add('image-block');x.innerHTML=block.src?`<figure><img src="${esc(block.src)}" alt="${esc(block.alt||'')}" style="width:${block.width}%"><figcaption>${editableRuns(block.captionRuns,'data-container="image-caption"')}</figcaption></figure>`:'<p class="image-error">Image unavailable.</p>'}
-  x.insertAdjacentHTML('afterbegin',`<div class="block-controls" contenteditable="false"><button type="button" data-block-move="before" aria-label="Move block before">↑</button><button type="button" data-block-move="after" aria-label="Move block after">↓</button><button type="button" class="delete-block" data-block-delete aria-label="Delete ${blockTypeLabel(block.type)}">Delete</button></div>`);return x
+let initial = seedDocument,
+  loadedRevision = 0;
+try {
+  const draft = readDraft();
+  initial =
+    snapshotFromLocation() ||
+    draft?.document ||
+    readRecovery()?.document ||
+    seedDocument;
+  loadedRevision = draft?.revision || 0;
+} catch (error) {
+  setTimeout(() => alert(error.message), 0);
 }
-function groupSheet(group,title,kind){const x=sheet(kind);x.id=stableAnchor(group);x.tabIndex=-1;if(['step','appendix'].includes(kind)){x.dataset.editableGroupId=group.id;x.dataset.groupType=kind;if(group.id===editorSelection.activeGroupId)x.classList.add('is-selected');x.innerHTML+=`<div class="step-heading"><div class="step-label">${esc(kind==='step'?(title.match(/^Step \d+/)?.[0]||''):title.split('. ')[0])}</div><input class="step-title" data-group-title="${group.id}" value="${esc(group.title)}" aria-label="${kind==='step'?'Step':'Appendix'} title"><div class="step-title-print" aria-hidden="true">${esc(group.title)}</div></div>`}else x.innerHTML+=`<h1 class="section-title">${esc(title)}</h1>`;const body=document.createElement('div');body.className='document-body';group.blocks.forEach(b=>body.append(blockElement(b)));x.append(body);return x}
-function cover(){const x=sheet('cover');x.innerHTML+=`<div class="cover-kicker">${esc(state.meta.documentType)} · ${esc(state.meta.status)}</div><h1>${esc(state.meta.clientName)}</h1><h2>${esc(state.meta.projectTitle)}</h2><p>${esc(state.meta.subtitle)}</p><p>${esc(state.meta.date)} · ${esc(state.meta.adviser)} · ${esc(state.meta.version)}</p>`;return x}
-function contentsEntries(){return [...state.sections.map(group=>({group,type:'section',label:group.title})),...state.steps.map((group,index)=>({group,type:'step',label:`Step ${index+1}. ${group.title}`})),...state.appendices.map((group,index)=>({group,type:'appendix',label:`${appendixLabel(index)}. ${group.title}`}))]}
-function contents(map={}){const x=sheet('contents'),entries=contentsEntries();x.innerHTML+='<h1 class="doc-title">Contents</h1><ol class="toc">'+entries.map(({group,type,label})=>`<li class="toc-${type} ${hasReview(group)?'toc-review':''}"><a href="#${stableAnchor(group)}">${esc(label)}</a><span class="dots"></span><span class="toc-page">${map[stableAnchor(group)]||'—'}</span></li>`).join('')+'</ol>';return x}
-function captureSelection(){const offsets=containedSelectionOffsets(activeEditable(),getSelection(),document);if(offsets)editorSelection.offsets=offsets}
-function captureView(){captureSelection();return {currentPage,scrollX:window.scrollX,scrollY:window.scrollY,selection:structuredClone(editorSelection)}}
-async function restoreView(view){setCurrentPage(view.currentPage,{scroll:false,focus:false});Object.assign(editorSelection,view.selection);if(editorSelection.restoreFocus)restoreTextSelection(activeEditable(),editorSelection.offsets);window.scrollTo(view.scrollX,view.scrollY)}
-async function paginate({isCurrent}){const source=document.createElement('main'),staging=document.createElement('div');staging.className='pagedjs_pages';source.append(cover(),contents(window.__pageMap||{}));state.sections.forEach(g=>source.append(groupSheet(g,g.title,'section')));state.steps.forEach((g,i)=>source.append(groupSheet(g,`Step ${i+1}. ${g.title}`,'step')));state.appendices.forEach((g,i)=>source.append(groupSheet(g,`${appendixLabel(i)}. ${g.title}`,'appendix')));await new Paged.Previewer().preview(source,[],staging);if(!isCurrent())return false;const pages=[...staging.children],map={};pages.forEach((p,i)=>{footer(p.querySelector('.sheet-source'),i+1,pages.length);p.dataset.pageNumber=String(i+1);p.querySelectorAll('[id^=anchor-]').forEach(a=>map[a.id]??=i+1);if(p.dataset.anchorId)map[p.dataset.anchorId]??=i+1});if(!isCurrent())return false;window.__pageMap=map;disconnectPageObserver();$('#preview').replaceChildren(...pages);bindEditing();observePages();updateControls();setCurrentPage(currentPage,{scroll:false,focus:false});$('#total').textContent=pages.length;rebuildPageJump(pages);return true}
-const repagination=new RepaginationScheduler(paginate,{capture:captureView,restore:restoreView});
-const navigationHistory=new NavigationHistory();
-const render=({immediate=true}={})=>repagination.request({immediate});
+const history = new History(initial);
+let state = history.checkout();
+let currentPage = 1;
+let dirty = false,
+  autosaveTimer = null;
+export const editorSelection = {
+  activeGroupId: null,
+  activeGroupType: null,
+  activeStepId: null,
+  activeBlockId: null,
+  container: null,
+  row: null,
+  column: null,
+  rowId: null,
+  columnId: null,
+  cellId: null,
+  blockType: null,
+  offsets: null,
+  restoreFocus: false,
+};
+let activeEditor = 'steps',
+  excelController = null;
+const pending = new Map(),
+  pendingStepTitles = new Map();
+const $ = (s) => document.querySelector(s);
+const esc = (x) =>
+  String(x).replace(
+    /[&<>"']/g,
+    (c) =>
+      ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[
+        c
+      ],
+  );
+const runText = (runs) => (runs || []).map((r) => r.text).join('');
+const runsHTML = (runs) =>
+  (runs || [])
+    .map((r) => {
+      let text = esc(r.text).replace(/\n/g, '<br>');
+      if (r.link) text = `<a href="${esc(r.link.href)}">${text}</a>`;
+      return r.highlight ? `<mark>${text}</mark>` : text;
+    })
+    .join('');
+const editableRuns = (runs, attrs = '') =>
+  `<span class="editable-runs" contenteditable="true" spellcheck="true" ${attrs}>${runsHTML(runs)}</span>`;
+const allGroups = () => [
+  ...state.sections,
+  ...state.steps,
+  ...state.appendices,
+];
+const findBlock = (id) => {
+  for (const group of allGroups()) {
+    const block = group.blocks.find((x) => x.id === id);
+    if (block) return { group, block };
+  }
+  return {};
+};
+const selectedEditableGroup = () =>
+  (editorSelection.activeGroupType === 'appendix'
+    ? state.appendices
+    : state.steps
+  ).find((x) => x.id === editorSelection.activeGroupId);
+const appendixLabel = (index) => `Appendix ${String.fromCharCode(65 + index)}`;
 
-function activeEditable(){const id=editorSelection.activeBlockId;if(!id)return editorSelection.activeGroupId?document.querySelector(`[data-group-title="${editorSelection.activeGroupId}"]`):null;const block=document.querySelector(`[data-block-id="${id}"]`);if(!block)return null;const c=editorSelection.container;if(c==='block')return block.querySelector('[data-container=block]');if(c==='item')return block.querySelector(`li[data-container="item"][data-item-id="${editorSelection.itemId}"]`);if(c==='caption')return block.querySelector('[data-container=caption]');if(c==='image-caption')return block.querySelector('[data-container=image-caption]');if(c==='heading')return block.querySelector(`[data-container=heading][data-column="${editorSelection.column}"]`);if(c==='cell')return block.querySelector(`[data-container=cell][data-cell-id="${CSS.escape(editorSelection.cellId||'')}"]`)||block.querySelector(`[data-container=cell][data-row="${editorSelection.row}"][data-column="${editorSelection.column}"]`);return block}
-function setActive(target){const group=target.closest('[data-editable-group-id]');if(group){editorSelection.activeGroupId=group.dataset.editableGroupId;editorSelection.activeGroupType=group.dataset.groupType;editorSelection.activeStepId=group.dataset.groupType==='step'?group.dataset.editableGroupId:null}const block=target.closest('[data-block-id]'),item=target.closest('li[data-container="item"]');editorSelection.activeBlockId=block?.dataset.blockId||null;editorSelection.blockType=block?.dataset.type||null;editorSelection.container=item?.dataset.container||target.dataset.container||(['heading','paragraph'].includes(editorSelection.blockType)?'block':null);editorSelection.itemId=item?.dataset.itemId||null;editorSelection.row=target.dataset.row??null;editorSelection.column=target.dataset.column??null;editorSelection.rowId=target.dataset.rowId??null;editorSelection.columnId=target.dataset.columnId??null;editorSelection.cellId=target.dataset.cellId??null;editorSelection.restoreFocus=true;document.querySelectorAll('[data-editable-group-id]').forEach(x=>x.classList.toggle('is-selected',x.dataset.editableGroupId===editorSelection.activeGroupId));updateControls()}
-function syncElement(el, record=true){if(!el?.isConnected)return false;const blockEl=el.closest('[data-block-id]'), found=findBlock(blockEl?.dataset.blockId);if(!found.block)return false;const before=structuredClone(state);const b=found.block,c=el.dataset.container;if(c==='item'){const i=b.items.find(x=>x.id===el.dataset.itemId);if(i)i.runs=runsFromElement(el)}else if(c==='caption')b.captionRuns=runsFromElement(el);else if(c==='image-caption')b.captionRuns=runsFromElement(el);else if(c==='heading')b.columns[+el.dataset.column].headingRuns=runsFromElement(el);else if(c==='cell'){captureSelection();const row=b.rows.find(r=>r.id===el.dataset.rowId)||b.rows[+el.dataset.row],columnIndex=b.columns.findIndex(column=>column.id===el.dataset.columnId),cell=row?.cells.find(cell=>cell.id===el.dataset.cellId)||row?.cells[columnIndex<0?+el.dataset.column:columnIndex];if(cell)cell.runs=runsFromElement(el);editorSelection.cellId=cell?.id||editorSelection.cellId;}else {const peers=[...document.querySelectorAll(`[data-block-id="${b.id}"] [data-container="block"]`)];b.runs=peers.length>1?peers.flatMap(runsFromElement):runsFromElement(el)}state=normaliseDocument(state);if(record)history.commit(state);else history.replace(state);const changed=JSON.stringify(before)!==JSON.stringify(state);if(changed)markDirty();return changed}
-function schedule(el){const key=targetKey(el),old=pending.get(key);if(old)clearTimeout(old.timer);pending.set(key,{el,timer:setTimeout(()=>{const p=pending.get(key);if(!p||p.el!==el||!el.isConnected)return;syncElement(el);pending.delete(key);updateControls();render({immediate:false})},450)})}
-const targetKey=el=>[el.closest('[data-block-id]')?.dataset.blockId,el.dataset.container,el.dataset.itemId,el.dataset.row,el.dataset.column].join(':');
-function flushTarget(el,record=true){const key=targetKey(el),p=pending.get(key);if(!p)return;clearTimeout(p.timer);pending.delete(key);if(p.el.isConnected)syncElement(p.el,record)}
-function syncStepTitle(el,{renderAfter=true}={}){const pendingTitle=pendingStepTitles.get(el.dataset.groupTitle);if(pendingTitle)clearTimeout(pendingTitle.timer);pendingStepTitles.delete(el.dataset.groupTitle);if(!el.isConnected)return false;const group=allGroups().find(x=>x.id===el.dataset.groupTitle),title=el.value.trim()||'Untitled';if(!group||group.title===title)return false;group.title=title;history.commit(state);markDirty();updateControls();if(renderAfter)render({immediate:false});return true}
-function flushAll(record=true){[...pending.values()].forEach(p=>{clearTimeout(p.timer);if(p.el.isConnected)syncElement(p.el,record)});pending.clear();[...pendingStepTitles.values()].forEach(p=>syncStepTitle(p.el,{renderAfter:false}))}
-const hasPendingInputs=()=>pending.size>0||pendingStepTitles.size>0;
-function markDirty(){dirty=true;const indicator=$('#save-state');if(indicator){indicator.textContent='Unsaved changes';indicator.className='save-state dirty'}clearTimeout(autosaveTimer);autosaveTimer=setTimeout(()=>persistDraft(),1500)}
-function commit(mutator,{focus=true}={}){flushAll();const before=structuredClone(state);mutator();state=normaliseDocument(state);history.replace(before);history.commit(state);state=history.checkout();markDirty();editorSelection.restoreFocus=focus;return render({restore:focus})}
-function applyDocumentOperation(result,{focus=true}={}){if(!result?.changed)return false;const before=state;history.replace(before);history.commit(result.document);state=history.checkout();markDirty();if(result.selectedGroupId){editorSelection.activeGroupId=result.selectedGroupId;editorSelection.activeGroupType=state.steps.some(x=>x.id===result.selectedGroupId)?'step':'appendix';editorSelection.activeStepId=editorSelection.activeGroupType==='step'?result.selectedGroupId:null}if(result.selectedBlockId)editorSelection.activeBlockId=result.selectedBlockId;if('rowIndex'in result)editorSelection.row=result.rowIndex;if('columnIndex'in result)editorSelection.column=result.columnIndex;refreshSelectedTableCell(result);editorSelection.restoreFocus=focus;render({restore:focus});return true}
-function refreshSelectedTableCell(result){if(!('rowIndex'in result)&&!('columnIndex'in result))return;const {block}=findBlock(editorSelection.activeBlockId);if(block?.type!=='table')return;const row=block.rows[Number(editorSelection.row)],column=block.columns[Number(editorSelection.column)];editorSelection.rowId=row?.id||null;editorSelection.columnId=column?.id||null;editorSelection.cellId=row?.cells?.[Number(editorSelection.column)]?.id||null}
-function selectOperationResult(result,type){const group=state.steps.find(x=>x.id===result.selectedGroupId)||state.appendices.find(x=>x.id===result.selectedGroupId);if(!group)return;selectGroup(group,state.steps.includes(group)?'step':'appendix',{blockId:result.selectedBlockId});Object.assign(editorSelection,{activeBlockId:result.selectedBlockId||null,blockType:type||result.selectedBlockType||null,container:type==='table'?'cell':type?.endsWith('List')?'item':type==='image'?'image-caption':'block',row:type==='table'?0:null,column:type==='table'?0:null,rowId:type==='table'?group.blocks.find(b=>b.id===result.selectedBlockId)?.rows?.[0]?.id:null,columnId:type==='table'?group.blocks.find(b=>b.id===result.selectedBlockId)?.columns?.[0]?.id:null,cellId:type==='table'?group.blocks.find(b=>b.id===result.selectedBlockId)?.rows?.[0]?.cells?.[0]?.id:null,offsets:[0,0],restoreFocus:true})}
-
-function bindEditing(){document.querySelectorAll('[data-editable-group-id]').forEach(x=>{x.addEventListener('pointerdown',e=>{if(e.target.closest('.editable-block,.step-heading,button,input,select,textarea,[contenteditable="true"]'))setActive(e.target)});x.addEventListener('click',blankStepClick)});document.querySelectorAll('[contenteditable=true]').forEach(el=>{el.addEventListener('focusin',()=>setActive(el));el.addEventListener('input',()=>{repagination.cancel();schedule(el)});el.addEventListener('blur',()=>{flushTarget(el);editorSelection.restoreFocus=false});el.addEventListener('paste',e=>insertPlainText(e,document))});
- document.querySelectorAll('[data-group-title]').forEach(el=>{const sync=()=>syncStepTitle(el);el.addEventListener('focusin',()=>setActive(el));el.addEventListener('input',()=>{repagination.cancel();const old=pendingStepTitles.get(el.dataset.groupTitle);if(old)clearTimeout(old.timer);pendingStepTitles.set(el.dataset.groupTitle,{el,timer:setTimeout(sync,450)})});el.addEventListener('blur',()=>{sync();editorSelection.restoreFocus=false});el.addEventListener('keydown',e=>{if(e.key==='Enter'){e.preventDefault();el.blur()}else if(e.key==='Tab')editorSelection.restoreFocus=false})});
- document.querySelectorAll('.list-block > :is(ol,ul) > li[data-container="item"]').forEach(el=>{el.addEventListener('keydown',listKeydown);el.addEventListener('blur',event=>listBlur(event,el))});document.querySelectorAll('[data-list-append]').forEach(el=>el.addEventListener('click',appendListItem));document.querySelectorAll('[data-type="heading"] > [data-container="block"]').forEach(el=>el.addEventListener('keydown',headingEnter));document.querySelectorAll('[data-container=cell]').forEach(el=>el.addEventListener('keydown',tableTab));document.querySelectorAll('[data-block-move]').forEach(b=>b.onclick=()=>moveBlock(b.closest('[data-block-id]').dataset.blockId,b.dataset.blockMove));document.querySelectorAll('[data-block-delete]').forEach(b=>b.onclick=()=>deleteBlock(b.closest('[data-block-id]').dataset.blockId));document.querySelectorAll('.toc a').forEach(a=>a.onclick=e=>{e.preventDefault();navigateToAnchor(a.getAttribute('href').slice(1))})}
-function headingEnter(e){if(e.key!=='Enter'||e.shiftKey)return;e.preventDefault();const el=e.currentTarget;flushTarget(el);const {group,block}=findBlock(el.closest('[data-block-id]').dataset.blockId);if(!group||block?.type!=='heading')return;const id=newId('block'),index=group.blocks.indexOf(block);const result=insertBlockOperation(state,group.id,{id,type:'paragraph',runs:[]},index+1);if(applyDocumentOperation(result))Object.assign(editorSelection,{activeBlockId:id,blockType:'paragraph',container:'block',itemId:null,row:null,column:null,offsets:[0,0]})}
-function listKeydown(e){if(e.key==='Enter')return listEnter(e);const el=e.currentTarget,{block}=findBlock(el.closest('[data-block-id]').dataset.blockId),index=block?.items?.findIndex(item=>item.id===el.dataset.itemId),offsets=getOffsets(el),atBoundary=e.key==='ArrowUp'?offsets?.[0]===0:offsets?.[1]===runText(block?.items?.[index]?.runs||[]).length;if((e.key==='ArrowUp'||e.key==='ArrowDown')&&!e.shiftKey&&!e.ctrlKey&&!e.metaKey&&!e.altKey&&offsets?.[0]===offsets?.[1]&&atBoundary){const target=index+(e.key==='ArrowUp'?-1:1);if(target<0||target>=block.items.length)return;e.preventDefault();const offset=e.key==='ArrowUp'?runText(block.items[target].runs).length:0;editorSelection.itemId=block.items[target].id;editorSelection.offsets=[offset,offset];restoreTextSelection(el.parentElement.children[target],editorSelection.offsets);return}if(e.key!=='Backspace')return;flushTarget(el);if(!Number.isInteger(index)||index<1||runText(block.items[index].runs))return;e.preventDefault();commit(()=>{const target=removeEmptyListItem(block,index);editorSelection.itemId=target.itemId;editorSelection.offsets=[target.offset,target.offset]})}
-function listBlur(event,el){const blockEl=el.closest('[data-block-id]'),next=event.relatedTarget;if(next?.closest?.(`[data-block-id="${blockEl?.dataset.blockId}"] [data-item-id="${el.dataset.itemId}"]`))return;queueMicrotask(()=>{if(!el.isConnected)return;const {block}=findBlock(blockEl.dataset.blockId),index=block?.items?.findIndex(item=>item.id===el.dataset.itemId);if(block?.items.length>1&&index>=0&&!runText(block.items[index].runs)){commit(()=>{block.items.splice(index,1);const target=block.items[Math.max(0,index-1)];editorSelection.itemId=target.id;editorSelection.offsets=[runText(target.runs).length,runText(target.runs).length]},{focus:false})}})}
-function appendListItem(event){event.preventDefault();event.stopPropagation();flushAll();const blockId=event.currentTarget.closest('[data-block-id]').dataset.blockId,{block}=findBlock(blockId);if(!block?.items)return;const id=newId('item');Object.assign(editorSelection,{activeBlockId:blockId,blockType:block.type,container:'item',itemId:id,offsets:[0,0],restoreFocus:true});commit(()=>block.items.push({id,level:block.items.at(-1)?.level||1,runs:[]}))}
-function listEnter(e){if(e.key!=='Enter')return;e.preventDefault();const el=e.currentTarget;flushTarget(el);const {block}=findBlock(el.closest('[data-block-id]').dataset.blockId),index=block.items.findIndex(i=>i.id===el.dataset.itemId);const offsets=getOffsets(el)||[0,0],text=runText(block.items[index].runs);if(!text.trim()){commit(()=>{block.items.splice(index,1);if(!block.items.length){block.type='paragraph';block.runs=[];delete block.items}});return}const id=newId('item');commit(()=>{const item=block.items[index],[before,after]=splitListRuns(item.runs,offsets[0]);item.runs=before;block.items.splice(index+1,0,{id,level:item.level,runs:after});editorSelection.itemId=id;editorSelection.offsets=[0,0]})}
-function tableTab(e){if(e.key!=='Tab')return;const cells=[...document.querySelectorAll(`[data-block-id="${editorSelection.activeBlockId}"] [data-container=cell]`)],i=cells.indexOf(e.currentTarget);if(e.shiftKey||i<cells.length-1)return;e.preventDefault();flushTarget(e.currentTarget);const {block}=findBlock(editorSelection.activeBlockId);tableMutation('addRow')}
-const getOffsets=el=>containedSelectionOffsets(el,getSelection(),document);
-function resolveRuns(){const {block}=findBlock(editorSelection.activeBlockId);if(!block)return null;if(editorSelection.container==='block')return block.runs;if(editorSelection.container==='item')return block.items.find(x=>x.id===editorSelection.itemId)?.runs;if(editorSelection.container==='caption'||editorSelection.container==='image-caption')return block.captionRuns;if(editorSelection.container==='heading')return block.columns[editorSelection.column]?.headingRuns;if(editorSelection.container==='cell')return block.rows[editorSelection.row]?.cells[editorSelection.column]?.runs;return null}
-function replaceResolved(runs){const {block}=findBlock(editorSelection.activeBlockId);if(editorSelection.container==='block')block.runs=runs;else if(editorSelection.container==='item')block.items.find(x=>x.id===editorSelection.itemId).runs=runs;else if(['caption','image-caption'].includes(editorSelection.container))block.captionRuns=runs;else if(editorSelection.container==='heading')block.columns[editorSelection.column].headingRuns=runs;else if(editorSelection.container==='cell')block.rows[editorSelection.row].cells[editorSelection.column].runs=runs}
-function transformSelection(kind,value,{useCaptured=false}={}){flushAll();if(!useCaptured){const offsets=getOffsets(activeEditable());if(offsets)editorSelection.offsets=offsets}const runs=resolveRuns();if(!runs||!editorSelection.offsets)return false;if(kind==='highlight'&&editorSelection.offsets[0]===editorSelection.offsets[1])editorSelection.offsets=[0,runText(runs).length];commit(()=>replaceResolved(transformRuns(runs,editorSelection.offsets,kind,value)));return true}
-function defaultInsertionContext(){const group=selectedEditableGroup();return group?{groupId:group.id,referenceBlockId:editorSelection.activeBlockId,position:'after'}:null}
-function insertBlock(type,context=defaultInsertionContext(),headingLevel=2){if(typeof type!=='string'||!['paragraph','heading','bulletList','numberList','table'].includes(type))return false;const group=[...state.steps,...state.appendices].find(x=>x.id===context?.groupId);if(!group)return false;const index=insertionIndex(group,context);if(index<0)return false;const id=newId('block');let block={id,type,runs:[]};if(type==='heading')block.level=Math.min(4,Math.max(1,Number(headingLevel)||2));if(type.endsWith('List'))block={id,type,items:[{id:newId('item'),level:1,runs:[]}]};if(type==='table')block={id,type,captionRuns:[{text:'Table caption'}],columns:[{id:newId('column'),headingRuns:[{text:'Column 1'}],width:50},{id:newId('column'),headingRuns:[{text:'Column 2'}],width:50}],rows:[{id:newId('row'),cells:[{id:newId('cell'),runs:[]},{id:newId('cell'),runs:[]}]}]};const result=insertBlockOperation(state,group.id,block,index);selectOperationResult(result,type);editorSelection.restoreFocus=true;if(!applyDocumentOperation(result))return false;return true}
-function moveBlock(id,direction){flushAll();const result=moveBlockOperation(state,id,direction);if(!applyDocumentOperation(result))return false;editorSelection.activeBlockId=id;announce(`Block moved to position ${result.index+1}`);return true}
-function deleteBlock(id){flushAll();const found=findBlock(id);if(!found.block)return false;const label=blockTypeLabel(found.block.type),result=deleteBlockOperation(state,id);if(!applyDocumentOperation(result))return false;selectOperationResult(result,result.selectedBlockType);announce(`${label[0].toUpperCase()+label.slice(1)} deleted`);return true}
-function selectGroup(group,type,{blockId=null}={}){Object.assign(editorSelection,{activeGroupId:group?.id||null,activeGroupType:group?type:null,activeStepId:type==='step'?group?.id||null:null,activeBlockId:blockId,blockType:blockId?'paragraph':null,container:blockId?'block':null,offsets:[0,0]})}
-function manageStep(action){flushAll();const id=editorSelection.activeStepId,index=state.steps.findIndex(x=>x.id===id);if(index<0)return;if(action==='deleteStep'){if(stepHasMovements(state.excel,id)&&!confirm('Deleting this step will delete its nonzero Excel share movements from every company. Continue?'))return;if(!confirmStepDeletion(state.steps,index,confirm))return;const result=deleteStepOperation(state,id);if(applyDocumentOperation(result)){const target=state.steps.find(x=>x.id===result.selectedGroupId);if(target)selectGroup(target,'step');announce('Step deleted')}return}const result=moveStepOperation(state,id,action==='moveStepUp'?-1:1);if(applyDocumentOperation(result))announce(`Step moved to position ${result.index+1}`)}
-function addStep(where='after'){flushAll();const result=addStepOperation(state,{referenceId:editorSelection.activeStepId,position:where,idFactory:newId});if(!applyDocumentOperation(result))return false;selectOperationResult(result,'paragraph');return true}
-function addAppendix(){flushAll();const result=addAppendixOperation(state,{idFactory:newId});if(!applyDocumentOperation(result))return false;selectOperationResult(result,'paragraph');announce(`${appendixLabel(result.index)} added`);return true}
-function manageAppendix(action){flushAll();const id=editorSelection.activeGroupId,index=state.appendices.findIndex(x=>x.id===id);if(index<0)return;const appendix=state.appendices[index];if(action==='deleteAppendix'){if(!confirm(`Delete ${appendixLabel(index)}: ${appendix.title}? This can be undone.`))return;const result=deleteAppendixOperation(state,id);if(!applyDocumentOperation(result))return;const target=state.appendices.find(x=>x.id===result.selectedGroupId)||state.steps.at(-1);if(target)selectGroup(target,state.appendices.includes(target)?'appendix':'step');announce('Appendix deleted');return}const result=moveAppendixOperation(state,id,action==='moveAppendixUp'?-1:1);if(applyDocumentOperation(result))announce(`Appendix moved to ${appendixLabel(result.index)}`)}
-function tableMutation(action){flushAll();const {block}=findBlock(editorSelection.activeBlockId);if(block?.type!=='table')return false;const rowIndex=editorSelection.row==null?NaN:Number(editorSelection.row),columnIndex=editorSelection.column==null?NaN:Number(editorSelection.column),row=block.rows[rowIndex],column=block.columns[columnIndex];let result;if(action==='moveRowUp'||action==='moveRowDown')result=moveTableRowOperation(state,block.id,row?.id,action==='moveRowUp'?-1:1);else if(action==='moveColumnLeft'||action==='moveColumnRight')result=moveTableColumnOperation(state,block.id,column?.id,action==='moveColumnLeft'?-1:1);else if(action==='addRow')result=insertTableRowOperation(state,block.id,row?.id,{idFactory:newId});else if(action==='addColumn')result=insertTableColumnOperation(state,block.id,column?.id,{idFactory:newId});else if(action==='removeRow')result=deleteTableRowOperation(state,block.id,row?.id);else if(action==='removeColumn')result=deleteTableColumnOperation(state,block.id,column?.id);else return false;if(!applyDocumentOperation(result))return false;if('rowIndex'in result)editorSelection.row=result.rowIndex;if('columnIndex'in result)editorSelection.column=result.columnIndex;editorSelection.offsets=[0,0];if(action.startsWith('moveRow'))announce(`Row moved to position ${result.rowIndex+1}`);if(action.startsWith('moveColumn'))announce(`Column moved to position ${result.columnIndex+1}`);return true}
-function linkPicker(){captureSelection();const dialog=$('#link-picker'),list=$('#link-destination'),destinations=[...state.steps.map((group,index)=>({group,label:`Step ${index+1}. ${group.title}`})),...state.appendices.map((group,index)=>({group,label:`${appendixLabel(index)}. ${group.title}`}))];list.innerHTML=destinations.map(({group,label})=>`<option value="#${stableAnchor(group)}">${esc(label)}</option>`).join('');dialog.showModal()}
-let insertionContext=null,imageInsertionContext=null;
-function blankStepClick(event){
-  if(event.button!==0||event.defaultPrevented)return;
-  const stepElement=event.currentTarget;
-  const active=document.activeElement,editing=active?.matches?.('[contenteditable=true],[data-group-title]');
-  if(editing&&!event.target.closest('[contenteditable=true],[data-group-title],button,input,select,textarea,a')){flushAll();active.blur();getSelection()?.removeAllRanges();Object.assign(editorSelection,{activeBlockId:null,blockType:null,container:null,itemId:null,row:null,column:null,rowId:null,columnId:null,cellId:null,offsets:null,restoreFocus:false});return}
-  if(event.target.closest('.editable-block,.step-heading,.page-header,.page-footer,a,button,input,select,textarea,[contenteditable="true"],.block-controls,.toolbar'))return;
-  const body=event.target.closest('.document-body')||stepElement.querySelector('.document-body');
-  if(!body||!stepElement.contains(event.target))return;
-  const group=[...state.steps,...state.appendices].find(item=>item.id===stepElement.dataset.editableGroupId);
-  if(!group)return;
-  const canInsert=canOpenBlankSpaceInsertion(editorSelection.activeGroupId,group.id);
-  selectGroup(group,stepElement.dataset.groupType);
-  document.querySelectorAll('[data-editable-group-id]').forEach(element=>element.classList.toggle('is-selected',element.dataset.editableGroupId===group.id));
-  if(!canInsert)return;
-  insertionContext=insertionContextFromPoint(group.id,[...stepElement.querySelectorAll('[data-block-id]')],event.clientY);
-  const chooser=$('#insertion-chooser');
-  if(!chooser.open)chooser.showModal();
-  queueMicrotask(()=>chooser.querySelector('[data-insert-choice="paragraph"]').focus());
+function header() {
+  const x = document.createElement('header');
+  x.className = 'page-header';
+  x.innerHTML = `<span class="header-brand">UBTA</span><span class="header-details">${esc(state.meta.clientName)} · ${esc(state.meta.projectTitle)} · ${esc(state.meta.version)}</span>`;
+  return x;
 }
-function addImage(context=defaultInsertionContext()){if(![...state.steps,...state.appendices].some(group=>group.id===context?.groupId))return;imageInsertionContext=context;const form=$('#image-form'),error=$('#image-form-error');form.reset();error.hidden=true;error.textContent='';$('#image-dialog').showModal();form.elements.src.focus()}
-function historyChangeTarget(next){if(!next)return null;const currentGroups=allGroups(),nextGroups=[...next.sections,...next.steps,...next.appendices];for(const nextGroup of nextGroups){const currentGroup=currentGroups.find(group=>group.id===nextGroup.id);if(!currentGroup)return {groupId:nextGroup.id};if(currentGroup.title!==nextGroup.title)return {groupId:currentGroup.id};const ids=new Set([...currentGroup.blocks.map(block=>block.id),...nextGroup.blocks.map(block=>block.id)]);for(const id of ids){const before=currentGroup.blocks.find(block=>block.id===id),after=nextGroup.blocks.find(block=>block.id===id);if(JSON.stringify(before)!==JSON.stringify(after))return {groupId:currentGroup.id,blockId:before?.id||null}}}const removed=currentGroups.find(group=>!nextGroups.some(item=>item.id===group.id));return removed?{groupId:removed.id}:null}
-function revealHistoryChange(next){const target=historyChangeTarget(next);if(!target)return;const node=(target.blockId&&document.querySelector(`[data-block-id="${CSS.escape(target.blockId)}"]`))||document.querySelector(`[data-editable-group-id="${CSS.escape(target.groupId)}"]`)||document.querySelector(`.pagedjs_page[data-group-id="${CSS.escape(target.groupId)}"]`);const page=node?.closest('.pagedjs_page')||(node?.matches('.pagedjs_page')?node:null);if(!page)return;const pages=[...document.querySelectorAll('.pagedjs_page')];setCurrentPage(pages.indexOf(page)+1,{scroll:false,focus:false});page.scrollIntoView({behavior:'auto',block:'center'})}
-function command(action){flushAll();if((action==='undo'||action==='redo')&&activeEditor==='excel'){excelController[action]();markDirty();return}if(action==='undo'){const previousView=navigationHistory.undo();if(previousView){restoreView(previousView);announce('Returned to the previous location');return}}if(action==='undo'||action==='redo'){navigationHistory.clear();pending.forEach(x=>clearTimeout(x.timer));pending.clear();const next=action==='undo'?history.peekUndo():history.peekRedo();revealHistoryChange(next);const currentExcel=state.excel,stepsState=action==='undo'?history.undo():history.redo();state=normaliseDocument({...stepsState,excel:currentExcel});history.replace(state);markDirty();if(![...state.steps,...state.appendices].some(x=>x.id===editorSelection.activeGroupId)){const group=state.steps[0]||state.appendices[0];selectGroup(group,state.steps.includes(group)?'step':'appendix')}return render()}if(action==='addStepBefore'||action==='addStepAfter')return addStep(action.endsWith('After')?'after':'before');if(['moveStepUp','moveStepDown','deleteStep'].includes(action))return manageStep(action);if(action==='addAppendix')return addAppendix();if(['moveAppendixUp','moveAppendixDown','deleteAppendix'].includes(action))return manageAppendix(action);const insertion=routeInsertionCommand(action);if(insertion?.kind==='table')return tableMutation(insertion.action);if(insertion?.kind==='block'&&typeof insertion.blockType==='string')return insertBlock(insertion.blockType);if(action==='addImage')return addImage();if(action==='highlight'||action==='unlink')return transformSelection(action==='unlink'?'unlink':'highlight');if(action==='link')return linkPicker();if(editorSelection.blockType==='image')return;const {block}=findBlock(editorSelection.activeBlockId);if(!block||!['heading','paragraph','bulletList','numberList'].includes(block.type))return;if(canApplyBlockStyle(block.type,action)){const result=convertBlockStyleOperation(state,block.id,action,{idFactory:newId});if(applyDocumentOperation(result))editorSelection.blockType=result.selectedBlockType}}
-function announce(message){$('#editor-status').textContent='';requestAnimationFrame(()=>$('#editor-status').textContent=message)}
-function updateControls(){const i=state.steps.findIndex(x=>x.id===editorSelection.activeStepId),step=i>=0,appendixIndex=editorSelection.activeGroupType==='appendix'?state.appendices.findIndex(x=>x.id===editorSelection.activeGroupId):-1,editable=!!selectedEditableGroup();document.querySelectorAll('[data-command=moveStepUp]').forEach(x=>x.disabled=!step||i===0);document.querySelectorAll('[data-command=moveStepDown]').forEach(x=>x.disabled=!step||i===state.steps.length-1);document.querySelectorAll('[data-command=deleteStep]').forEach(x=>x.disabled=!step||state.steps.length===1);document.querySelectorAll('[data-requires-step]').forEach(x=>x.disabled=!step);document.querySelectorAll('[data-requires-group]').forEach(x=>x.disabled=!editable);document.querySelectorAll('[data-command=moveAppendixUp]').forEach(x=>x.disabled=appendixIndex<=0);document.querySelectorAll('[data-command=moveAppendixDown]').forEach(x=>x.disabled=appendixIndex<0||appendixIndex===state.appendices.length-1);document.querySelectorAll('[data-command=deleteAppendix]').forEach(x=>x.disabled=appendixIndex<0);const runs=resolveRuns(),text=!!runs;document.querySelectorAll('[data-text-command]').forEach(x=>x.disabled=!text);const {block}=findBlock(editorSelection.activeBlockId),style=$('#style'),choices=blockStyleChoices(block?.type);if(style.dataset.choices!==JSON.stringify(choices)){style.replaceChildren(...choices.map(([value,label])=>{const option=document.createElement('option');option.value=value;option.textContent=label;return option}));style.dataset.choices=JSON.stringify(choices)}document.querySelectorAll('[data-table-command]').forEach(x=>x.hidden=block?.type!=='table');document.querySelectorAll('[data-table-group]').forEach(x=>x.hidden=block?.type!=='table');style.disabled=!text;if(block?.type==='heading')style.value=`heading${block.level}`;else if(block?.type==='paragraph')style.value='body';else if(['bulletList','numberList'].includes(block?.type))style.value=block.type;const row=editorSelection.row==null?NaN:Number(editorSelection.row),column=editorSelection.column==null?NaN:Number(editorSelection.column),selectedRow=block?.rows?.[row];document.querySelectorAll('[data-command=moveRowUp]').forEach(x=>x.disabled=!selectedRow||row===0||block.rows[row-1]?.isTotal!==selectedRow.isTotal);document.querySelectorAll('[data-command=moveRowDown]').forEach(x=>x.disabled=!selectedRow||row===block.rows.length-1||block.rows[row+1]?.isTotal!==selectedRow.isTotal);document.querySelectorAll('[data-command=moveColumnLeft]').forEach(x=>x.disabled=!block?.columns?.[column]||column===0);document.querySelectorAll('[data-command=moveColumnRight]').forEach(x=>x.disabled=!block?.columns?.[column]||column===block.columns.length-1);const format=$('#column-format'),selectedColumn=block?.columns?.[column];format.disabled=!selectedColumn;if(selectedColumn)format.value=tableColumnFormat(selectedColumn);const total=$('#column-total-enabled');total.disabled=!selectedColumn||tableColumnFormat(selectedColumn)==='text';total.checked=!!selectedColumn?.totalEnabled}
-document.querySelectorAll('[data-command]').forEach(b=>{b.addEventListener('pointerdown',e=>{if(b.dataset.textCommand!==undefined){e.preventDefault();captureSelection()}});b.addEventListener('click',()=>command(b.dataset.command))});$('#style').onchange=e=>command(e.target.value);$('#column-format').onchange=e=>{const {block}=findBlock(editorSelection.activeBlockId),column=block?.columns?.[editorSelection.column==null?NaN:Number(editorSelection.column)];if(!column)return;const result=setTableColumnFormatOperation(state,block.id,column.id,e.target.value);if(applyDocumentOperation(result))announce(`Column format changed to ${e.target.selectedOptions[0].textContent}`)};$('#column-total-enabled').onchange=e=>{captureSelection();const {block}=findBlock(editorSelection.activeBlockId),column=block?.columns?.find(c=>c.id===editorSelection.columnId)||block?.columns?.[Number(editorSelection.column)];if(!column)return;applyDocumentOperation(setTableColumnTotalOperation(state,block.id,column.id,e.target.checked));};const linkDialog=$('#link-picker');let applyingLink=false;$('#link-form').onsubmit=e=>{e.preventDefault();const external=$('#external-link').value,href=validatedLink(external,$('#link-destination').value);if(href){applyingLink=true;linkDialog.close();transformSelection('link',href,{useCaptured:true});applyingLink=false;editorSelection.offsets=null}else announce('Enter a valid HTTPS, HTTP, mailto, or internal destination.')};linkDialog.addEventListener('close',()=>{if(!applyingLink)editorSelection.offsets=null;$('#link-form').reset()});
-const insertionChooser=$('#insertion-chooser'),templateLoader=new EncryptedTemplateLoader();
-function showInsertionPanel(name,focus=true){insertionChooser.querySelectorAll('[data-insertion-panel]').forEach(panel=>panel.hidden=panel.dataset.insertionPanel!==name);if(focus)queueMicrotask(()=>insertionChooser.querySelector(`[data-insertion-panel="${name}"] button, [data-insertion-panel="${name}"] input`)?.focus())}
-function finishInsertion(callback){const context=insertionContext;insertionContext=null;insertionChooser.close();callback(context)}
-insertionChooser.querySelectorAll('[data-open-insertion-panel]').forEach(button=>button.onclick=()=>{showInsertionPanel(button.dataset.openInsertionPanel);if(button.dataset.openInsertionPanel==='defaults')openDefaults()});
-insertionChooser.querySelectorAll('[data-insertion-back]').forEach(button=>button.onclick=()=>showInsertionPanel('main'));
-insertionChooser.querySelectorAll('[data-insert-choice]').forEach(button=>button.onclick=()=>finishInsertion(context=>button.dataset.insertChoice==='image'?addImage(context):insertBlock(button.dataset.insertChoice,context)));
-insertionChooser.querySelectorAll('[data-insert-heading]').forEach(button=>button.onclick=()=>finishInsertion(context=>insertBlock('heading',context,button.dataset.insertHeading)));
-function renderTemplates(templates){const choices=$('#default-template-choices');choices.replaceChildren(...templates.map(template=>{const button=document.createElement('button');button.type='button';button.textContent=template.header;button.onclick=()=>finishInsertion(context=>insertTemplate(template,context));return button}));$('#default-unlock').hidden=true;choices.querySelector('button')?.focus()}
-async function openDefaults(){const error=$('#default-error');error.hidden=true;if(templateLoader.cached){renderTemplates(await templateLoader.unlock());return}$('#default-unlock').hidden=false;$('#default-password').focus()}
-$('#unlock-defaults').onclick=async()=>{const input=$('#default-password'),button=$('#unlock-defaults'),error=$('#default-error'),password=input.value;input.value='';button.disabled=true;error.hidden=true;try{renderTemplates(await templateLoader.unlock(defaultTemplateEnvelope,password))}catch(failure){error.textContent=failure.message;error.hidden=false;input.focus()}finally{button.disabled=false}};
-$('#default-password').addEventListener('keydown',event=>{if(event.key!=='Enter')return;event.preventDefault();event.stopPropagation();$('#unlock-defaults').click()});
-function insertTemplate(template,context){const group=[...state.steps,...state.appendices].find(item=>item.id===context?.groupId),at=insertionIndex(group,context);if(!group||at<0){announce('That insertion location is no longer available.');return false}const blocks=templateBlocks(template,newId);let result;for(const [offset,block] of blocks.entries()){result=insertBlockOperation(result?.document||state,group.id,block,at+offset);if(!result.changed)return false}applyDocumentOperation(result);Object.assign(editorSelection,{activeBlockId:blocks[0].id,blockType:'heading',container:'block',itemId:null,row:null,column:null,offsets:[0,template.header.length]});announce(`${template.header} inserted`);return true}
-insertionChooser.addEventListener('close',()=>{insertionContext=null;$('#default-password').value='';showInsertionPanel('main',false)});
+function sheet(kind) {
+  const x = document.createElement('section');
+  x.className = `sheet-source ${kind}`;
+  x.append(header());
+  return x;
+}
+function footer(x, n, total) {
+  const f = document.createElement('footer');
+  f.className = 'page-footer';
+  f.textContent = `Page ${n} of ${total}`;
+  x.append(f);
+}
+function blockElement(block) {
+  const x = document.createElement('div');
+  x.className = 'editable-block';
+  x.dataset.blockId = block.id;
+  x.dataset.type = block.type;
+  x.dataset.level = block.level || '';
+  x.draggable = false;
+  x.tabIndex = -1;
+  if (['heading', 'paragraph'].includes(block.type))
+    x.innerHTML = editableRuns(block.runs, 'data-container="block"');
+  else if (block.type.endsWith('List')) {
+    x.classList.add('list-block');
+    x.dataset.listType = block.type;
+    x.innerHTML = renderList(block, runsHTML, esc);
+  } else if (block.type === 'table') {
+    x.classList.add('table-block');
+    recalculateTableTotals(block);
+    const cellHTML = (cell, row, ri, ci) => {
+      const format = tableColumnFormat(block.columns[ci]),
+        numeric = format !== 'text',
+        value = runText(cell.runs),
+        parsed = numeric ? parseTableNumber(value) : null,
+        display = parsed === null ? value : formatTableNumber(parsed, format),
+        attrs = `data-container="cell" data-row="${ri}" data-column="${ci}" data-row-id="${esc(row.id)}" data-column-id="${esc(block.columns[ci].id)}" data-cell-id="${esc(cell.id)}"`;
+      return `<td class="format-${format}">${row.isTotal && numeric ? `<output ${attrs}>${esc(display)}</output>` : editableRuns(numeric ? [{ text: display }] : cell.runs, attrs)}</td>`;
+    };
+    x.innerHTML = `<table><caption>${editableRuns(block.captionRuns, 'data-container="caption"')}</caption><colgroup>${block.columns.map((c) => `<col style="width:${c.width}%">`).join('')}</colgroup><thead><tr>${block.columns.map((c, i) => `<th class="format-${tableColumnFormat(c)}">${editableRuns(c.headingRuns, `data-container="heading" data-column="${i}"`)}</th>`).join('')}</tr></thead><tbody>${block.rows.map((r, ri) => `<tr class="${r.isTotal ? 'total-row' : ''}" data-row="${ri}">${r.cells.map((c, ci) => cellHTML(c, r, ri, ci)).join('')}</tr>`).join('')}</tbody></table>`;
+  } else {
+    x.classList.add('image-block');
+    x.innerHTML = block.src
+      ? `<figure><img src="${esc(block.src)}" alt="${esc(block.alt || '')}" style="width:${block.width}%"><figcaption>${editableRuns(block.captionRuns, 'data-container="image-caption"')}</figcaption></figure>`
+      : '<p class="image-error">Image unavailable.</p>';
+  }
+  x.insertAdjacentHTML(
+    'afterbegin',
+    `<div class="block-controls" contenteditable="false"><button type="button" data-block-move="before" aria-label="Move block before">↑</button><button type="button" data-block-move="after" aria-label="Move block after">↓</button><button type="button" class="delete-block" data-block-delete aria-label="Delete ${blockTypeLabel(block.type)}">Delete</button></div>`,
+  );
+  return x;
+}
+function groupSheet(group, title, kind) {
+  const x = sheet(kind);
+  x.id = stableAnchor(group);
+  x.tabIndex = -1;
+  if (['step', 'appendix'].includes(kind)) {
+    x.dataset.editableGroupId = group.id;
+    x.dataset.groupType = kind;
+    if (group.id === editorSelection.activeGroupId)
+      x.classList.add('is-selected');
+    x.innerHTML += `<div class="step-heading"><div class="step-label">${esc(kind === 'step' ? title.match(/^Step \d+/)?.[0] || '' : title.split('. ')[0])}</div><input class="step-title" data-group-title="${group.id}" value="${esc(group.title)}" aria-label="${kind === 'step' ? 'Step' : 'Appendix'} title"><div class="step-title-print" aria-hidden="true">${esc(group.title)}</div></div>`;
+  } else x.innerHTML += `<h1 class="section-title">${esc(title)}</h1>`;
+  const body = document.createElement('div');
+  body.className = 'document-body';
+  group.blocks.forEach((b) => body.append(blockElement(b)));
+  x.append(body);
+  return x;
+}
+function cover() {
+  const x = sheet('cover');
+  x.innerHTML += `<div class="cover-kicker">${esc(state.meta.documentType)} · ${esc(state.meta.status)}</div><h1>${esc(state.meta.clientName)}</h1><h2>${esc(state.meta.projectTitle)}</h2><p>${esc(state.meta.subtitle)}</p><p>${esc(state.meta.date)} · ${esc(state.meta.adviser)} · ${esc(state.meta.version)}</p>`;
+  return x;
+}
+function contentsEntries() {
+  return [
+    ...state.sections.map((group) => ({
+      group,
+      type: 'section',
+      label: group.title,
+    })),
+    ...state.steps.map((group, index) => ({
+      group,
+      type: 'step',
+      label: `Step ${index + 1}. ${group.title}`,
+    })),
+    ...state.appendices.map((group, index) => ({
+      group,
+      type: 'appendix',
+      label: `${appendixLabel(index)}. ${group.title}`,
+    })),
+  ];
+}
+function contents(map = {}) {
+  const x = sheet('contents'),
+    entries = contentsEntries();
+  x.innerHTML +=
+    '<h1 class="doc-title">Contents</h1><ol class="toc">' +
+    entries
+      .map(
+        ({ group, type, label }) =>
+          `<li class="toc-${type} ${hasReview(group) ? 'toc-review' : ''}"><a href="#${stableAnchor(group)}">${esc(label)}</a><span class="dots"></span><span class="toc-page">${map[stableAnchor(group)] || '—'}</span></li>`,
+      )
+      .join('') +
+    '</ol>';
+  return x;
+}
+function captureSelection() {
+  const offsets = containedSelectionOffsets(
+    activeEditable(),
+    getSelection(),
+    document,
+  );
+  if (offsets) editorSelection.offsets = offsets;
+}
+function captureView() {
+  captureSelection();
+  return {
+    currentPage,
+    scrollX: window.scrollX,
+    scrollY: window.scrollY,
+    selection: structuredClone(editorSelection),
+  };
+}
+async function restoreView(view) {
+  setCurrentPage(view.currentPage, { scroll: false, focus: false });
+  Object.assign(editorSelection, view.selection);
+  if (editorSelection.restoreFocus)
+    restoreTextSelection(activeEditable(), editorSelection.offsets);
+  window.scrollTo(view.scrollX, view.scrollY);
+}
+async function paginate({ isCurrent }) {
+  const source = document.createElement('main'),
+    staging = document.createElement('div');
+  staging.className = 'pagedjs_pages';
+  source.append(cover(), contents(window.__pageMap || {}));
+  state.sections.forEach((g) =>
+    source.append(groupSheet(g, g.title, 'section')),
+  );
+  state.steps.forEach((g, i) =>
+    source.append(groupSheet(g, `Step ${i + 1}. ${g.title}`, 'step')),
+  );
+  state.appendices.forEach((g, i) =>
+    source.append(groupSheet(g, `${appendixLabel(i)}. ${g.title}`, 'appendix')),
+  );
+  await new Paged.Previewer().preview(source, [], staging);
+  if (!isCurrent()) return false;
+  const pages = [...staging.children],
+    map = {};
+  pages.forEach((p, i) => {
+    footer(p.querySelector('.sheet-source'), i + 1, pages.length);
+    p.dataset.pageNumber = String(i + 1);
+    p.querySelectorAll('[id^=anchor-]').forEach((a) => (map[a.id] ??= i + 1));
+    if (p.dataset.anchorId) map[p.dataset.anchorId] ??= i + 1;
+  });
+  if (!isCurrent()) return false;
+  window.__pageMap = map;
+  disconnectPageObserver();
+  $('#preview').replaceChildren(...pages);
+  bindEditing();
+  observePages();
+  updateControls();
+  setCurrentPage(currentPage, { scroll: false, focus: false });
+  $('#total').textContent = pages.length;
+  rebuildPageJump(pages);
+  return true;
+}
+const repagination = new RepaginationScheduler(paginate, {
+  capture: captureView,
+  restore: restoreView,
+});
+const navigationHistory = new NavigationHistory();
+const render = ({ immediate = true } = {}) =>
+  repagination.request({ immediate });
+
+function activeEditable() {
+  const id = editorSelection.activeBlockId;
+  if (!id)
+    return editorSelection.activeGroupId
+      ? document.querySelector(
+          `[data-group-title="${editorSelection.activeGroupId}"]`,
+        )
+      : null;
+  const block = document.querySelector(`[data-block-id="${id}"]`);
+  if (!block) return null;
+  const c = editorSelection.container;
+  if (c === 'block') return block.querySelector('[data-container=block]');
+  if (c === 'item')
+    return block.querySelector(
+      `li[data-container="item"][data-item-id="${editorSelection.itemId}"]`,
+    );
+  if (c === 'caption') return block.querySelector('[data-container=caption]');
+  if (c === 'image-caption')
+    return block.querySelector('[data-container=image-caption]');
+  if (c === 'heading')
+    return block.querySelector(
+      `[data-container=heading][data-column="${editorSelection.column}"]`,
+    );
+  if (c === 'cell')
+    return (
+      block.querySelector(
+        `[data-container=cell][data-cell-id="${CSS.escape(editorSelection.cellId || '')}"]`,
+      ) ||
+      block.querySelector(
+        `[data-container=cell][data-row="${editorSelection.row}"][data-column="${editorSelection.column}"]`,
+      )
+    );
+  return block;
+}
+function setActive(target) {
+  const group = target.closest('[data-editable-group-id]');
+  if (group) {
+    editorSelection.activeGroupId = group.dataset.editableGroupId;
+    editorSelection.activeGroupType = group.dataset.groupType;
+    editorSelection.activeStepId =
+      group.dataset.groupType === 'step' ? group.dataset.editableGroupId : null;
+  }
+  const block = target.closest('[data-block-id]'),
+    item = target.closest('li[data-container="item"]');
+  editorSelection.activeBlockId = block?.dataset.blockId || null;
+  editorSelection.blockType = block?.dataset.type || null;
+  editorSelection.container =
+    item?.dataset.container ||
+    target.dataset.container ||
+    (['heading', 'paragraph'].includes(editorSelection.blockType)
+      ? 'block'
+      : null);
+  editorSelection.itemId = item?.dataset.itemId || null;
+  editorSelection.row = target.dataset.row ?? null;
+  editorSelection.column = target.dataset.column ?? null;
+  editorSelection.rowId = target.dataset.rowId ?? null;
+  editorSelection.columnId = target.dataset.columnId ?? null;
+  editorSelection.cellId = target.dataset.cellId ?? null;
+  editorSelection.restoreFocus = true;
+  document
+    .querySelectorAll('[data-editable-group-id]')
+    .forEach((x) =>
+      x.classList.toggle(
+        'is-selected',
+        x.dataset.editableGroupId === editorSelection.activeGroupId,
+      ),
+    );
+  updateControls();
+}
+function syncElement(el, record = true) {
+  if (!el?.isConnected) return false;
+  const blockEl = el.closest('[data-block-id]'),
+    found = findBlock(blockEl?.dataset.blockId);
+  if (!found.block) return false;
+  const before = structuredClone(state);
+  const b = found.block,
+    c = el.dataset.container;
+  if (c === 'item') {
+    const i = b.items.find((x) => x.id === el.dataset.itemId);
+    if (i) i.runs = runsFromElement(el);
+  } else if (c === 'caption') b.captionRuns = runsFromElement(el);
+  else if (c === 'image-caption') b.captionRuns = runsFromElement(el);
+  else if (c === 'heading')
+    b.columns[+el.dataset.column].headingRuns = runsFromElement(el);
+  else if (c === 'cell') {
+    captureSelection();
+    const row =
+        b.rows.find((r) => r.id === el.dataset.rowId) ||
+        b.rows[+el.dataset.row],
+      columnIndex = b.columns.findIndex(
+        (column) => column.id === el.dataset.columnId,
+      ),
+      cell =
+        row?.cells.find((cell) => cell.id === el.dataset.cellId) ||
+        row?.cells[columnIndex < 0 ? +el.dataset.column : columnIndex];
+    if (cell) cell.runs = runsFromElement(el);
+    editorSelection.cellId = cell?.id || editorSelection.cellId;
+  } else {
+    const peers = [
+      ...document.querySelectorAll(
+        `[data-block-id="${b.id}"] [data-container="block"]`,
+      ),
+    ];
+    b.runs =
+      peers.length > 1 ? peers.flatMap(runsFromElement) : runsFromElement(el);
+  }
+  state = normaliseDocument(state);
+  if (record) history.commit(state);
+  else history.replace(state);
+  const changed = JSON.stringify(before) !== JSON.stringify(state);
+  if (changed) markDirty();
+  return changed;
+}
+function schedule(el) {
+  const key = targetKey(el),
+    old = pending.get(key);
+  if (old) clearTimeout(old.timer);
+  pending.set(key, {
+    el,
+    timer: setTimeout(() => {
+      const p = pending.get(key);
+      if (!p || p.el !== el || !el.isConnected) return;
+      syncElement(el);
+      pending.delete(key);
+      updateControls();
+      render({ immediate: false });
+    }, 450),
+  });
+}
+const targetKey = (el) =>
+  [
+    el.closest('[data-block-id]')?.dataset.blockId,
+    el.dataset.container,
+    el.dataset.itemId,
+    el.dataset.row,
+    el.dataset.column,
+  ].join(':');
+function flushTarget(el, record = true) {
+  const key = targetKey(el),
+    p = pending.get(key);
+  if (!p) return;
+  clearTimeout(p.timer);
+  pending.delete(key);
+  if (p.el.isConnected) syncElement(p.el, record);
+}
+function syncStepTitle(el, { renderAfter = true } = {}) {
+  const pendingTitle = pendingStepTitles.get(el.dataset.groupTitle);
+  if (pendingTitle) clearTimeout(pendingTitle.timer);
+  pendingStepTitles.delete(el.dataset.groupTitle);
+  if (!el.isConnected) return false;
+  const group = allGroups().find((x) => x.id === el.dataset.groupTitle),
+    title = el.value.trim() || 'Untitled';
+  if (!group || group.title === title) return false;
+  group.title = title;
+  history.commit(state);
+  markDirty();
+  updateControls();
+  if (renderAfter) render({ immediate: false });
+  return true;
+}
+function flushAll(record = true) {
+  [...pending.values()].forEach((p) => {
+    clearTimeout(p.timer);
+    if (p.el.isConnected) syncElement(p.el, record);
+  });
+  pending.clear();
+  [...pendingStepTitles.values()].forEach((p) =>
+    syncStepTitle(p.el, { renderAfter: false }),
+  );
+}
+const hasPendingInputs = () => pending.size > 0 || pendingStepTitles.size > 0;
+function markDirty() {
+  dirty = true;
+  const indicator = $('#save-state');
+  if (indicator) {
+    indicator.textContent = 'Unsaved changes';
+    indicator.className = 'save-state dirty';
+  }
+  clearTimeout(autosaveTimer);
+  autosaveTimer = setTimeout(() => persistDraft(), 1500);
+}
+function commit(mutator, { focus = true } = {}) {
+  flushAll();
+  const before = structuredClone(state);
+  mutator();
+  state = normaliseDocument(state);
+  history.replace(before);
+  history.commit(state);
+  state = history.checkout();
+  markDirty();
+  editorSelection.restoreFocus = focus;
+  return render({ restore: focus });
+}
+function applyDocumentOperation(result, { focus = true } = {}) {
+  if (!result?.changed) return false;
+  const before = state;
+  history.replace(before);
+  history.commit(result.document);
+  state = history.checkout();
+  markDirty();
+  if (result.selectedGroupId) {
+    editorSelection.activeGroupId = result.selectedGroupId;
+    editorSelection.activeGroupType = state.steps.some(
+      (x) => x.id === result.selectedGroupId,
+    )
+      ? 'step'
+      : 'appendix';
+    editorSelection.activeStepId =
+      editorSelection.activeGroupType === 'step'
+        ? result.selectedGroupId
+        : null;
+  }
+  if (result.selectedBlockId)
+    editorSelection.activeBlockId = result.selectedBlockId;
+  if ('rowIndex' in result) editorSelection.row = result.rowIndex;
+  if ('columnIndex' in result) editorSelection.column = result.columnIndex;
+  refreshSelectedTableCell(result);
+  editorSelection.restoreFocus = focus;
+  render({ restore: focus });
+  return true;
+}
+function refreshSelectedTableCell(result) {
+  if (!('rowIndex' in result) && !('columnIndex' in result)) return;
+  const { block } = findBlock(editorSelection.activeBlockId);
+  if (block?.type !== 'table') return;
+  const row = block.rows[Number(editorSelection.row)],
+    column = block.columns[Number(editorSelection.column)];
+  editorSelection.rowId = row?.id || null;
+  editorSelection.columnId = column?.id || null;
+  editorSelection.cellId =
+    row?.cells?.[Number(editorSelection.column)]?.id || null;
+}
+function selectOperationResult(result, type) {
+  const group =
+    state.steps.find((x) => x.id === result.selectedGroupId) ||
+    state.appendices.find((x) => x.id === result.selectedGroupId);
+  if (!group) return;
+  selectGroup(group, state.steps.includes(group) ? 'step' : 'appendix', {
+    blockId: result.selectedBlockId,
+  });
+  Object.assign(editorSelection, {
+    activeBlockId: result.selectedBlockId || null,
+    blockType: type || result.selectedBlockType || null,
+    container:
+      type === 'table'
+        ? 'cell'
+        : type?.endsWith('List')
+          ? 'item'
+          : type === 'image'
+            ? 'image-caption'
+            : 'block',
+    row: type === 'table' ? 0 : null,
+    column: type === 'table' ? 0 : null,
+    rowId:
+      type === 'table'
+        ? group.blocks.find((b) => b.id === result.selectedBlockId)?.rows?.[0]
+            ?.id
+        : null,
+    columnId:
+      type === 'table'
+        ? group.blocks.find((b) => b.id === result.selectedBlockId)
+            ?.columns?.[0]?.id
+        : null,
+    cellId:
+      type === 'table'
+        ? group.blocks.find((b) => b.id === result.selectedBlockId)?.rows?.[0]
+            ?.cells?.[0]?.id
+        : null,
+    offsets: [0, 0],
+    restoreFocus: true,
+  });
+}
+
+function bindEditing() {
+  document.querySelectorAll('[data-editable-group-id]').forEach((x) => {
+    x.addEventListener('pointerdown', (e) => {
+      if (
+        e.target.closest(
+          '.editable-block,.step-heading,button,input,select,textarea,[contenteditable="true"]',
+        )
+      )
+        setActive(e.target);
+    });
+    x.addEventListener('click', blankStepClick);
+  });
+  document.querySelectorAll('[contenteditable=true]').forEach((el) => {
+    el.addEventListener('focusin', () => setActive(el));
+    el.addEventListener('input', () => {
+      repagination.cancel();
+      schedule(el);
+    });
+    el.addEventListener('blur', () => {
+      flushTarget(el);
+      editorSelection.restoreFocus = false;
+    });
+    el.addEventListener('paste', (e) => insertPlainText(e, document));
+  });
+  document.querySelectorAll('[data-group-title]').forEach((el) => {
+    const sync = () => syncStepTitle(el);
+    el.addEventListener('focusin', () => setActive(el));
+    el.addEventListener('input', () => {
+      repagination.cancel();
+      const old = pendingStepTitles.get(el.dataset.groupTitle);
+      if (old) clearTimeout(old.timer);
+      pendingStepTitles.set(el.dataset.groupTitle, {
+        el,
+        timer: setTimeout(sync, 450),
+      });
+    });
+    el.addEventListener('blur', () => {
+      sync();
+      editorSelection.restoreFocus = false;
+    });
+    el.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        el.blur();
+      } else if (e.key === 'Tab') editorSelection.restoreFocus = false;
+    });
+  });
+  document
+    .querySelectorAll('.list-block > :is(ol,ul) > li[data-container="item"]')
+    .forEach((el) => {
+      el.addEventListener('keydown', listKeydown);
+      el.addEventListener('blur', (event) => listBlur(event, el));
+    });
+  document
+    .querySelectorAll('[data-list-append]')
+    .forEach((el) => el.addEventListener('click', appendListItem));
+  document
+    .querySelectorAll('[data-type="heading"] > [data-container="block"]')
+    .forEach((el) => el.addEventListener('keydown', headingEnter));
+  document
+    .querySelectorAll('[data-container=cell]')
+    .forEach((el) => el.addEventListener('keydown', tableTab));
+  document
+    .querySelectorAll('[data-block-move]')
+    .forEach(
+      (b) =>
+        (b.onclick = () =>
+          moveBlock(
+            b.closest('[data-block-id]').dataset.blockId,
+            b.dataset.blockMove,
+          )),
+    );
+  document
+    .querySelectorAll('[data-block-delete]')
+    .forEach(
+      (b) =>
+        (b.onclick = () =>
+          deleteBlock(b.closest('[data-block-id]').dataset.blockId)),
+    );
+  document.querySelectorAll('.toc a').forEach(
+    (a) =>
+      (a.onclick = (e) => {
+        e.preventDefault();
+        navigateToAnchor(a.getAttribute('href').slice(1));
+      }),
+  );
+}
+function headingEnter(e) {
+  if (e.key !== 'Enter' || e.shiftKey) return;
+  e.preventDefault();
+  const el = e.currentTarget;
+  flushTarget(el);
+  const { group, block } = findBlock(
+    el.closest('[data-block-id]').dataset.blockId,
+  );
+  if (!group || block?.type !== 'heading') return;
+  const id = newId('block'),
+    index = group.blocks.indexOf(block);
+  const result = insertBlockOperation(
+    state,
+    group.id,
+    { id, type: 'paragraph', runs: [] },
+    index + 1,
+  );
+  if (applyDocumentOperation(result))
+    Object.assign(editorSelection, {
+      activeBlockId: id,
+      blockType: 'paragraph',
+      container: 'block',
+      itemId: null,
+      row: null,
+      column: null,
+      offsets: [0, 0],
+    });
+}
+function listKeydown(e) {
+  if (e.key === 'Enter') return listEnter(e);
+  const el = e.currentTarget,
+    { block } = findBlock(el.closest('[data-block-id]').dataset.blockId),
+    index = block?.items?.findIndex((item) => item.id === el.dataset.itemId),
+    offsets = getOffsets(el),
+    atBoundary =
+      e.key === 'ArrowUp'
+        ? offsets?.[0] === 0
+        : offsets?.[1] === runText(block?.items?.[index]?.runs || []).length;
+  if (
+    (e.key === 'ArrowUp' || e.key === 'ArrowDown') &&
+    !e.shiftKey &&
+    !e.ctrlKey &&
+    !e.metaKey &&
+    !e.altKey &&
+    offsets?.[0] === offsets?.[1] &&
+    atBoundary
+  ) {
+    const target = index + (e.key === 'ArrowUp' ? -1 : 1);
+    if (target < 0 || target >= block.items.length) return;
+    e.preventDefault();
+    const offset =
+      e.key === 'ArrowUp' ? runText(block.items[target].runs).length : 0;
+    editorSelection.itemId = block.items[target].id;
+    editorSelection.offsets = [offset, offset];
+    restoreTextSelection(
+      el.parentElement.children[target],
+      editorSelection.offsets,
+    );
+    return;
+  }
+  if (e.key !== 'Backspace') return;
+  flushTarget(el);
+  if (!Number.isInteger(index) || index < 1 || runText(block.items[index].runs))
+    return;
+  e.preventDefault();
+  commit(() => {
+    const target = removeEmptyListItem(block, index);
+    editorSelection.itemId = target.itemId;
+    editorSelection.offsets = [target.offset, target.offset];
+  });
+}
+function listBlur(event, el) {
+  const blockEl = el.closest('[data-block-id]'),
+    next = event.relatedTarget;
+  if (
+    next?.closest?.(
+      `[data-block-id="${blockEl?.dataset.blockId}"] [data-item-id="${el.dataset.itemId}"]`,
+    )
+  )
+    return;
+  queueMicrotask(() => {
+    if (!el.isConnected) return;
+    const { block } = findBlock(blockEl.dataset.blockId),
+      index = block?.items?.findIndex((item) => item.id === el.dataset.itemId);
+    if (
+      block?.items.length > 1 &&
+      index >= 0 &&
+      !runText(block.items[index].runs)
+    ) {
+      commit(
+        () => {
+          block.items.splice(index, 1);
+          const target = block.items[Math.max(0, index - 1)];
+          editorSelection.itemId = target.id;
+          editorSelection.offsets = [
+            runText(target.runs).length,
+            runText(target.runs).length,
+          ];
+        },
+        { focus: false },
+      );
+    }
+  });
+}
+function appendListItem(event) {
+  event.preventDefault();
+  event.stopPropagation();
+  flushAll();
+  const blockId =
+      event.currentTarget.closest('[data-block-id]').dataset.blockId,
+    { block } = findBlock(blockId);
+  if (!block?.items) return;
+  const id = newId('item');
+  Object.assign(editorSelection, {
+    activeBlockId: blockId,
+    blockType: block.type,
+    container: 'item',
+    itemId: id,
+    offsets: [0, 0],
+    restoreFocus: true,
+  });
+  commit(() =>
+    block.items.push({ id, level: block.items.at(-1)?.level || 1, runs: [] }),
+  );
+}
+function listEnter(e) {
+  if (e.key !== 'Enter') return;
+  e.preventDefault();
+  const el = e.currentTarget;
+  flushTarget(el);
+  const { block } = findBlock(el.closest('[data-block-id]').dataset.blockId),
+    index = block.items.findIndex((i) => i.id === el.dataset.itemId);
+  const offsets = getOffsets(el) || [0, 0],
+    text = runText(block.items[index].runs);
+  if (!text.trim()) {
+    commit(() => {
+      block.items.splice(index, 1);
+      if (!block.items.length) {
+        block.type = 'paragraph';
+        block.runs = [];
+        delete block.items;
+      }
+    });
+    return;
+  }
+  const id = newId('item');
+  commit(() => {
+    const item = block.items[index],
+      [before, after] = splitListRuns(item.runs, offsets[0]);
+    item.runs = before;
+    block.items.splice(index + 1, 0, { id, level: item.level, runs: after });
+    editorSelection.itemId = id;
+    editorSelection.offsets = [0, 0];
+  });
+}
+function tableTab(e) {
+  if (e.key !== 'Tab') return;
+  const cells = [
+      ...document.querySelectorAll(
+        `[data-block-id="${editorSelection.activeBlockId}"] [data-container=cell]`,
+      ),
+    ],
+    i = cells.indexOf(e.currentTarget);
+  if (e.shiftKey || i < cells.length - 1) return;
+  e.preventDefault();
+  flushTarget(e.currentTarget);
+  const { block } = findBlock(editorSelection.activeBlockId);
+  tableMutation('addRow');
+}
+const getOffsets = (el) =>
+  containedSelectionOffsets(el, getSelection(), document);
+function resolveRuns() {
+  const { block } = findBlock(editorSelection.activeBlockId);
+  if (!block) return null;
+  if (editorSelection.container === 'block') return block.runs;
+  if (editorSelection.container === 'item')
+    return block.items.find((x) => x.id === editorSelection.itemId)?.runs;
+  if (
+    editorSelection.container === 'caption' ||
+    editorSelection.container === 'image-caption'
+  )
+    return block.captionRuns;
+  if (editorSelection.container === 'heading')
+    return block.columns[editorSelection.column]?.headingRuns;
+  if (editorSelection.container === 'cell')
+    return block.rows[editorSelection.row]?.cells[editorSelection.column]?.runs;
+  return null;
+}
+function replaceResolved(runs) {
+  const { block } = findBlock(editorSelection.activeBlockId);
+  if (editorSelection.container === 'block') block.runs = runs;
+  else if (editorSelection.container === 'item')
+    block.items.find((x) => x.id === editorSelection.itemId).runs = runs;
+  else if (['caption', 'image-caption'].includes(editorSelection.container))
+    block.captionRuns = runs;
+  else if (editorSelection.container === 'heading')
+    block.columns[editorSelection.column].headingRuns = runs;
+  else if (editorSelection.container === 'cell')
+    block.rows[editorSelection.row].cells[editorSelection.column].runs = runs;
+}
+function transformSelection(kind, value, { useCaptured = false } = {}) {
+  flushAll();
+  if (!useCaptured) {
+    const offsets = getOffsets(activeEditable());
+    if (offsets) editorSelection.offsets = offsets;
+  }
+  const runs = resolveRuns();
+  if (!runs || !editorSelection.offsets) return false;
+  if (
+    kind === 'highlight' &&
+    editorSelection.offsets[0] === editorSelection.offsets[1]
+  )
+    editorSelection.offsets = [0, runText(runs).length];
+  commit(() =>
+    replaceResolved(transformRuns(runs, editorSelection.offsets, kind, value)),
+  );
+  return true;
+}
+function defaultInsertionContext() {
+  const group = selectedEditableGroup();
+  return group
+    ? {
+        groupId: group.id,
+        referenceBlockId: editorSelection.activeBlockId,
+        position: 'after',
+      }
+    : null;
+}
+function insertBlock(
+  type,
+  context = defaultInsertionContext(),
+  headingLevel = 2,
+) {
+  if (
+    typeof type !== 'string' ||
+    !['paragraph', 'heading', 'bulletList', 'numberList', 'table'].includes(
+      type,
+    )
+  )
+    return false;
+  const group = [...state.steps, ...state.appendices].find(
+    (x) => x.id === context?.groupId,
+  );
+  if (!group) return false;
+  const index = insertionIndex(group, context);
+  if (index < 0) return false;
+  const id = newId('block');
+  let block = { id, type, runs: [] };
+  if (type === 'heading')
+    block.level = Math.min(4, Math.max(1, Number(headingLevel) || 2));
+  if (type.endsWith('List'))
+    block = { id, type, items: [{ id: newId('item'), level: 1, runs: [] }] };
+  if (type === 'table')
+    block = {
+      id,
+      type,
+      captionRuns: [{ text: 'Table caption' }],
+      columns: [
+        { id: newId('column'), headingRuns: [{ text: 'Column 1' }], width: 50 },
+        { id: newId('column'), headingRuns: [{ text: 'Column 2' }], width: 50 },
+      ],
+      rows: [
+        {
+          id: newId('row'),
+          cells: [
+            { id: newId('cell'), runs: [] },
+            { id: newId('cell'), runs: [] },
+          ],
+        },
+      ],
+    };
+  const result = insertBlockOperation(state, group.id, block, index);
+  selectOperationResult(result, type);
+  editorSelection.restoreFocus = true;
+  if (!applyDocumentOperation(result)) return false;
+  return true;
+}
+function moveBlock(id, direction) {
+  flushAll();
+  const result = moveBlockOperation(state, id, direction);
+  if (!applyDocumentOperation(result)) return false;
+  editorSelection.activeBlockId = id;
+  announce(`Block moved to position ${result.index + 1}`);
+  return true;
+}
+function deleteBlock(id) {
+  flushAll();
+  const found = findBlock(id);
+  if (!found.block) return false;
+  const label = blockTypeLabel(found.block.type),
+    result = deleteBlockOperation(state, id);
+  if (!applyDocumentOperation(result)) return false;
+  selectOperationResult(result, result.selectedBlockType);
+  announce(`${label[0].toUpperCase() + label.slice(1)} deleted`);
+  return true;
+}
+function selectGroup(group, type, { blockId = null } = {}) {
+  Object.assign(editorSelection, {
+    activeGroupId: group?.id || null,
+    activeGroupType: group ? type : null,
+    activeStepId: type === 'step' ? group?.id || null : null,
+    activeBlockId: blockId,
+    blockType: blockId ? 'paragraph' : null,
+    container: blockId ? 'block' : null,
+    offsets: [0, 0],
+  });
+}
+function manageStep(action) {
+  flushAll();
+  const id = editorSelection.activeStepId,
+    index = state.steps.findIndex((x) => x.id === id);
+  if (index < 0) return;
+  if (action === 'deleteStep') {
+    if (
+      stepHasMovements(state.excel, id) &&
+      !confirm(
+        'Deleting this step will delete its nonzero Excel share movements from every company. Continue?',
+      )
+    )
+      return;
+    if (!confirmStepDeletion(state.steps, index, confirm)) return;
+    const result = deleteStepOperation(state, id);
+    if (applyDocumentOperation(result)) {
+      const target = state.steps.find((x) => x.id === result.selectedGroupId);
+      if (target) selectGroup(target, 'step');
+      announce('Step deleted');
+    }
+    return;
+  }
+  const result = moveStepOperation(state, id, action === 'moveStepUp' ? -1 : 1);
+  if (applyDocumentOperation(result))
+    announce(`Step moved to position ${result.index + 1}`);
+}
+function addStep(where = 'after') {
+  flushAll();
+  const result = addStepOperation(state, {
+    referenceId: editorSelection.activeStepId,
+    position: where,
+    idFactory: newId,
+  });
+  if (!applyDocumentOperation(result)) return false;
+  selectOperationResult(result, 'paragraph');
+  return true;
+}
+function addAppendix() {
+  flushAll();
+  const result = addAppendixOperation(state, { idFactory: newId });
+  if (!applyDocumentOperation(result)) return false;
+  selectOperationResult(result, 'paragraph');
+  announce(`${appendixLabel(result.index)} added`);
+  return true;
+}
+function manageAppendix(action) {
+  flushAll();
+  const id = editorSelection.activeGroupId,
+    index = state.appendices.findIndex((x) => x.id === id);
+  if (index < 0) return;
+  const appendix = state.appendices[index];
+  if (action === 'deleteAppendix') {
+    if (
+      !confirm(
+        `Delete ${appendixLabel(index)}: ${appendix.title}? This can be undone.`,
+      )
+    )
+      return;
+    const result = deleteAppendixOperation(state, id);
+    if (!applyDocumentOperation(result)) return;
+    const target =
+      state.appendices.find((x) => x.id === result.selectedGroupId) ||
+      state.steps.at(-1);
+    if (target)
+      selectGroup(
+        target,
+        state.appendices.includes(target) ? 'appendix' : 'step',
+      );
+    announce('Appendix deleted');
+    return;
+  }
+  const result = moveAppendixOperation(
+    state,
+    id,
+    action === 'moveAppendixUp' ? -1 : 1,
+  );
+  if (applyDocumentOperation(result))
+    announce(`Appendix moved to ${appendixLabel(result.index)}`);
+}
+function tableMutation(action) {
+  flushAll();
+  const { block } = findBlock(editorSelection.activeBlockId);
+  if (block?.type !== 'table') return false;
+  const rowIndex =
+      editorSelection.row == null ? NaN : Number(editorSelection.row),
+    columnIndex =
+      editorSelection.column == null ? NaN : Number(editorSelection.column),
+    row = block.rows[rowIndex],
+    column = block.columns[columnIndex];
+  let result;
+  if (action === 'moveRowUp' || action === 'moveRowDown')
+    result = moveTableRowOperation(
+      state,
+      block.id,
+      row?.id,
+      action === 'moveRowUp' ? -1 : 1,
+    );
+  else if (action === 'moveColumnLeft' || action === 'moveColumnRight')
+    result = moveTableColumnOperation(
+      state,
+      block.id,
+      column?.id,
+      action === 'moveColumnLeft' ? -1 : 1,
+    );
+  else if (action === 'addRow')
+    result = insertTableRowOperation(state, block.id, row?.id, {
+      idFactory: newId,
+    });
+  else if (action === 'addColumn')
+    result = insertTableColumnOperation(state, block.id, column?.id, {
+      idFactory: newId,
+    });
+  else if (action === 'removeRow')
+    result = deleteTableRowOperation(state, block.id, row?.id);
+  else if (action === 'removeColumn')
+    result = deleteTableColumnOperation(state, block.id, column?.id);
+  else return false;
+  if (!applyDocumentOperation(result)) return false;
+  if ('rowIndex' in result) editorSelection.row = result.rowIndex;
+  if ('columnIndex' in result) editorSelection.column = result.columnIndex;
+  editorSelection.offsets = [0, 0];
+  if (action.startsWith('moveRow'))
+    announce(`Row moved to position ${result.rowIndex + 1}`);
+  if (action.startsWith('moveColumn'))
+    announce(`Column moved to position ${result.columnIndex + 1}`);
+  return true;
+}
+function linkPicker() {
+  captureSelection();
+  const dialog = $('#link-picker'),
+    list = $('#link-destination'),
+    destinations = [
+      ...state.steps.map((group, index) => ({
+        group,
+        label: `Step ${index + 1}. ${group.title}`,
+      })),
+      ...state.appendices.map((group, index) => ({
+        group,
+        label: `${appendixLabel(index)}. ${group.title}`,
+      })),
+    ];
+  list.innerHTML = destinations
+    .map(
+      ({ group, label }) =>
+        `<option value="#${stableAnchor(group)}">${esc(label)}</option>`,
+    )
+    .join('');
+  dialog.showModal();
+}
+let insertionContext = null,
+  imageInsertionContext = null;
+function blankStepClick(event) {
+  if (event.button !== 0 || event.defaultPrevented) return;
+  const stepElement = event.currentTarget;
+  const active = document.activeElement,
+    editing = active?.matches?.('[contenteditable=true],[data-group-title]');
+  if (
+    editing &&
+    !event.target.closest(
+      '[contenteditable=true],[data-group-title],button,input,select,textarea,a',
+    )
+  ) {
+    flushAll();
+    active.blur();
+    getSelection()?.removeAllRanges();
+    Object.assign(editorSelection, {
+      activeBlockId: null,
+      blockType: null,
+      container: null,
+      itemId: null,
+      row: null,
+      column: null,
+      rowId: null,
+      columnId: null,
+      cellId: null,
+      offsets: null,
+      restoreFocus: false,
+    });
+    return;
+  }
+  if (
+    event.target.closest(
+      '.editable-block,.step-heading,.page-header,.page-footer,a,button,input,select,textarea,[contenteditable="true"],.block-controls,.toolbar',
+    )
+  )
+    return;
+  const body =
+    event.target.closest('.document-body') ||
+    stepElement.querySelector('.document-body');
+  if (!body || !stepElement.contains(event.target)) return;
+  const group = [...state.steps, ...state.appendices].find(
+    (item) => item.id === stepElement.dataset.editableGroupId,
+  );
+  if (!group) return;
+  const canInsert = canOpenBlankSpaceInsertion(
+    editorSelection.activeGroupId,
+    group.id,
+  );
+  selectGroup(group, stepElement.dataset.groupType);
+  document
+    .querySelectorAll('[data-editable-group-id]')
+    .forEach((element) =>
+      element.classList.toggle(
+        'is-selected',
+        element.dataset.editableGroupId === group.id,
+      ),
+    );
+  if (!canInsert) return;
+  insertionContext = insertionContextFromPoint(
+    group.id,
+    [...stepElement.querySelectorAll('[data-block-id]')],
+    event.clientY,
+  );
+  const chooser = $('#insertion-chooser');
+  if (!chooser.open) chooser.showModal();
+  queueMicrotask(() =>
+    chooser.querySelector('[data-insert-choice="paragraph"]').focus(),
+  );
+}
+function addImage(context = defaultInsertionContext()) {
+  if (
+    ![...state.steps, ...state.appendices].some(
+      (group) => group.id === context?.groupId,
+    )
+  )
+    return;
+  imageInsertionContext = context;
+  const form = $('#image-form'),
+    error = $('#image-form-error');
+  form.reset();
+  error.hidden = true;
+  error.textContent = '';
+  $('#image-dialog').showModal();
+  form.elements.src.focus();
+}
+function historyChangeTarget(next) {
+  if (!next) return null;
+  const currentGroups = allGroups(),
+    nextGroups = [...next.sections, ...next.steps, ...next.appendices];
+  for (const nextGroup of nextGroups) {
+    const currentGroup = currentGroups.find(
+      (group) => group.id === nextGroup.id,
+    );
+    if (!currentGroup) return { groupId: nextGroup.id };
+    if (currentGroup.title !== nextGroup.title)
+      return { groupId: currentGroup.id };
+    const ids = new Set([
+      ...currentGroup.blocks.map((block) => block.id),
+      ...nextGroup.blocks.map((block) => block.id),
+    ]);
+    for (const id of ids) {
+      const before = currentGroup.blocks.find((block) => block.id === id),
+        after = nextGroup.blocks.find((block) => block.id === id);
+      if (JSON.stringify(before) !== JSON.stringify(after))
+        return { groupId: currentGroup.id, blockId: before?.id || null };
+    }
+  }
+  const removed = currentGroups.find(
+    (group) => !nextGroups.some((item) => item.id === group.id),
+  );
+  return removed ? { groupId: removed.id } : null;
+}
+function revealHistoryChange(next) {
+  const target = historyChangeTarget(next);
+  if (!target) return;
+  const node =
+    (target.blockId &&
+      document.querySelector(
+        `[data-block-id="${CSS.escape(target.blockId)}"]`,
+      )) ||
+    document.querySelector(
+      `[data-editable-group-id="${CSS.escape(target.groupId)}"]`,
+    ) ||
+    document.querySelector(
+      `.pagedjs_page[data-group-id="${CSS.escape(target.groupId)}"]`,
+    );
+  const page =
+    node?.closest('.pagedjs_page') ||
+    (node?.matches('.pagedjs_page') ? node : null);
+  if (!page) return;
+  const pages = [...document.querySelectorAll('.pagedjs_page')];
+  setCurrentPage(pages.indexOf(page) + 1, { scroll: false, focus: false });
+  page.scrollIntoView({ behavior: 'auto', block: 'center' });
+}
+function command(action) {
+  flushAll();
+  if ((action === 'undo' || action === 'redo') && activeEditor === 'excel') {
+    excelController[action]();
+    markDirty();
+    return;
+  }
+  if (action === 'undo') {
+    const previousView = navigationHistory.undo();
+    if (previousView) {
+      restoreView(previousView);
+      announce('Returned to the previous location');
+      return;
+    }
+  }
+  if (action === 'undo' || action === 'redo') {
+    navigationHistory.clear();
+    pending.forEach((x) => clearTimeout(x.timer));
+    pending.clear();
+    const next = action === 'undo' ? history.peekUndo() : history.peekRedo();
+    revealHistoryChange(next);
+    const currentExcel = state.excel,
+      stepsState = action === 'undo' ? history.undo() : history.redo();
+    state = normaliseDocument({ ...stepsState, excel: currentExcel });
+    history.replace(state);
+    markDirty();
+    if (
+      ![...state.steps, ...state.appendices].some(
+        (x) => x.id === editorSelection.activeGroupId,
+      )
+    ) {
+      const group = state.steps[0] || state.appendices[0];
+      selectGroup(group, state.steps.includes(group) ? 'step' : 'appendix');
+    }
+    return render();
+  }
+  if (action === 'addStepBefore' || action === 'addStepAfter')
+    return addStep(action.endsWith('After') ? 'after' : 'before');
+  if (['moveStepUp', 'moveStepDown', 'deleteStep'].includes(action))
+    return manageStep(action);
+  if (action === 'addAppendix') return addAppendix();
+  if (['moveAppendixUp', 'moveAppendixDown', 'deleteAppendix'].includes(action))
+    return manageAppendix(action);
+  const insertion = routeInsertionCommand(action);
+  if (insertion?.kind === 'table') return tableMutation(insertion.action);
+  if (insertion?.kind === 'block' && typeof insertion.blockType === 'string')
+    return insertBlock(insertion.blockType);
+  if (action === 'addImage') return addImage();
+  if (action === 'highlight' || action === 'unlink')
+    return transformSelection(action === 'unlink' ? 'unlink' : 'highlight');
+  if (action === 'link') return linkPicker();
+  if (editorSelection.blockType === 'image') return;
+  const { block } = findBlock(editorSelection.activeBlockId);
+  if (
+    !block ||
+    !['heading', 'paragraph', 'bulletList', 'numberList'].includes(block.type)
+  )
+    return;
+  if (canApplyBlockStyle(block.type, action)) {
+    const result = convertBlockStyleOperation(state, block.id, action, {
+      idFactory: newId,
+    });
+    if (applyDocumentOperation(result))
+      editorSelection.blockType = result.selectedBlockType;
+  }
+}
+function announce(message) {
+  $('#editor-status').textContent = '';
+  requestAnimationFrame(() => ($('#editor-status').textContent = message));
+}
+function updateControls() {
+  const i = state.steps.findIndex((x) => x.id === editorSelection.activeStepId),
+    step = i >= 0,
+    appendixIndex =
+      editorSelection.activeGroupType === 'appendix'
+        ? state.appendices.findIndex(
+            (x) => x.id === editorSelection.activeGroupId,
+          )
+        : -1,
+    editable = !!selectedEditableGroup();
+  document
+    .querySelectorAll('[data-command=moveStepUp]')
+    .forEach((x) => (x.disabled = !step || i === 0));
+  document
+    .querySelectorAll('[data-command=moveStepDown]')
+    .forEach((x) => (x.disabled = !step || i === state.steps.length - 1));
+  document
+    .querySelectorAll('[data-command=deleteStep]')
+    .forEach((x) => (x.disabled = !step || state.steps.length === 1));
+  document
+    .querySelectorAll('[data-requires-step]')
+    .forEach((x) => (x.disabled = !step));
+  document
+    .querySelectorAll('[data-requires-group]')
+    .forEach((x) => (x.disabled = !editable));
+  document
+    .querySelectorAll('[data-command=moveAppendixUp]')
+    .forEach((x) => (x.disabled = appendixIndex <= 0));
+  document
+    .querySelectorAll('[data-command=moveAppendixDown]')
+    .forEach(
+      (x) =>
+        (x.disabled =
+          appendixIndex < 0 || appendixIndex === state.appendices.length - 1),
+    );
+  document
+    .querySelectorAll('[data-command=deleteAppendix]')
+    .forEach((x) => (x.disabled = appendixIndex < 0));
+  const runs = resolveRuns(),
+    text = !!runs;
+  document
+    .querySelectorAll('[data-text-command]')
+    .forEach((x) => (x.disabled = !text));
+  const { block } = findBlock(editorSelection.activeBlockId),
+    style = $('#style'),
+    choices = blockStyleChoices(block?.type);
+  if (style.dataset.choices !== JSON.stringify(choices)) {
+    style.replaceChildren(
+      ...choices.map(([value, label]) => {
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = label;
+        return option;
+      }),
+    );
+    style.dataset.choices = JSON.stringify(choices);
+  }
+  document
+    .querySelectorAll('[data-table-command]')
+    .forEach((x) => (x.hidden = block?.type !== 'table'));
+  document
+    .querySelectorAll('[data-table-group]')
+    .forEach((x) => (x.hidden = block?.type !== 'table'));
+  style.disabled = !text;
+  if (block?.type === 'heading') style.value = `heading${block.level}`;
+  else if (block?.type === 'paragraph') style.value = 'body';
+  else if (['bulletList', 'numberList'].includes(block?.type))
+    style.value = block.type;
+  const row = editorSelection.row == null ? NaN : Number(editorSelection.row),
+    column =
+      editorSelection.column == null ? NaN : Number(editorSelection.column),
+    selectedRow = block?.rows?.[row];
+  document
+    .querySelectorAll('[data-command=moveRowUp]')
+    .forEach(
+      (x) =>
+        (x.disabled =
+          !selectedRow ||
+          row === 0 ||
+          block.rows[row - 1]?.isTotal !== selectedRow.isTotal),
+    );
+  document
+    .querySelectorAll('[data-command=moveRowDown]')
+    .forEach(
+      (x) =>
+        (x.disabled =
+          !selectedRow ||
+          row === block.rows.length - 1 ||
+          block.rows[row + 1]?.isTotal !== selectedRow.isTotal),
+    );
+  document
+    .querySelectorAll('[data-command=moveColumnLeft]')
+    .forEach((x) => (x.disabled = !block?.columns?.[column] || column === 0));
+  document
+    .querySelectorAll('[data-command=moveColumnRight]')
+    .forEach(
+      (x) =>
+        (x.disabled =
+          !block?.columns?.[column] || column === block.columns.length - 1),
+    );
+  const format = $('#column-format'),
+    selectedColumn = block?.columns?.[column];
+  format.disabled = !selectedColumn;
+  if (selectedColumn) format.value = tableColumnFormat(selectedColumn);
+  const total = $('#column-total-enabled');
+  total.disabled =
+    !selectedColumn || tableColumnFormat(selectedColumn) === 'text';
+  total.checked = !!selectedColumn?.totalEnabled;
+}
+document.querySelectorAll('[data-command]').forEach((b) => {
+  b.addEventListener('pointerdown', (e) => {
+    if (b.dataset.textCommand !== undefined) {
+      e.preventDefault();
+      captureSelection();
+    }
+  });
+  b.addEventListener('click', () => command(b.dataset.command));
+});
+$('#style').onchange = (e) => command(e.target.value);
+$('#column-format').onchange = (e) => {
+  const { block } = findBlock(editorSelection.activeBlockId),
+    column =
+      block?.columns?.[
+        editorSelection.column == null ? NaN : Number(editorSelection.column)
+      ];
+  if (!column) return;
+  const result = setTableColumnFormatOperation(
+    state,
+    block.id,
+    column.id,
+    e.target.value,
+  );
+  if (applyDocumentOperation(result))
+    announce(
+      `Column format changed to ${e.target.selectedOptions[0].textContent}`,
+    );
+};
+$('#column-total-enabled').onchange = (e) => {
+  captureSelection();
+  const { block } = findBlock(editorSelection.activeBlockId),
+    column =
+      block?.columns?.find((c) => c.id === editorSelection.columnId) ||
+      block?.columns?.[Number(editorSelection.column)];
+  if (!column) return;
+  applyDocumentOperation(
+    setTableColumnTotalOperation(state, block.id, column.id, e.target.checked),
+  );
+};
+const linkDialog = $('#link-picker');
+let applyingLink = false;
+$('#link-form').onsubmit = (e) => {
+  e.preventDefault();
+  const external = $('#external-link').value,
+    href = validatedLink(external, $('#link-destination').value);
+  if (href) {
+    applyingLink = true;
+    linkDialog.close();
+    transformSelection('link', href, { useCaptured: true });
+    applyingLink = false;
+    editorSelection.offsets = null;
+  } else
+    announce('Enter a valid HTTPS, HTTP, mailto, or internal destination.');
+};
+linkDialog.addEventListener('close', () => {
+  if (!applyingLink) editorSelection.offsets = null;
+  $('#link-form').reset();
+});
+const insertionChooser = $('#insertion-chooser'),
+  templateLoader = new EncryptedTemplateLoader();
+function showInsertionPanel(name, focus = true) {
+  insertionChooser
+    .querySelectorAll('[data-insertion-panel]')
+    .forEach((panel) => (panel.hidden = panel.dataset.insertionPanel !== name));
+  if (focus)
+    queueMicrotask(() =>
+      insertionChooser
+        .querySelector(
+          `[data-insertion-panel="${name}"] button, [data-insertion-panel="${name}"] input`,
+        )
+        ?.focus(),
+    );
+}
+function finishInsertion(callback) {
+  const context = insertionContext;
+  insertionContext = null;
+  insertionChooser.close();
+  callback(context);
+}
+insertionChooser.querySelectorAll('[data-open-insertion-panel]').forEach(
+  (button) =>
+    (button.onclick = () => {
+      showInsertionPanel(button.dataset.openInsertionPanel);
+      if (button.dataset.openInsertionPanel === 'defaults') openDefaults();
+    }),
+);
+insertionChooser
+  .querySelectorAll('[data-insertion-back]')
+  .forEach((button) => (button.onclick = () => showInsertionPanel('main')));
+insertionChooser
+  .querySelectorAll('[data-insert-choice]')
+  .forEach(
+    (button) =>
+      (button.onclick = () =>
+        finishInsertion((context) =>
+          button.dataset.insertChoice === 'image'
+            ? addImage(context)
+            : insertBlock(button.dataset.insertChoice, context),
+        )),
+  );
+insertionChooser
+  .querySelectorAll('[data-insert-heading]')
+  .forEach(
+    (button) =>
+      (button.onclick = () =>
+        finishInsertion((context) =>
+          insertBlock('heading', context, button.dataset.insertHeading),
+        )),
+  );
+function renderTemplates(templates) {
+  const choices = $('#default-template-choices');
+  choices.replaceChildren(
+    ...templates.map((template) => {
+      const button = document.createElement('button');
+      button.type = 'button';
+      button.textContent = template.header;
+      button.onclick = () =>
+        finishInsertion((context) => insertTemplate(template, context));
+      return button;
+    }),
+  );
+  $('#default-unlock').hidden = true;
+  choices.querySelector('button')?.focus();
+}
+async function openDefaults() {
+  const error = $('#default-error');
+  error.hidden = true;
+  if (templateLoader.cached) {
+    renderTemplates(await templateLoader.unlock());
+    return;
+  }
+  $('#default-unlock').hidden = false;
+  $('#default-password').focus();
+}
+$('#unlock-defaults').onclick = async () => {
+  const input = $('#default-password'),
+    button = $('#unlock-defaults'),
+    error = $('#default-error'),
+    password = input.value;
+  input.value = '';
+  button.disabled = true;
+  error.hidden = true;
+  try {
+    renderTemplates(
+      await templateLoader.unlock(defaultTemplateEnvelope, password),
+    );
+  } catch (failure) {
+    error.textContent = failure.message;
+    error.hidden = false;
+    input.focus();
+  } finally {
+    button.disabled = false;
+  }
+};
+$('#default-password').addEventListener('keydown', (event) => {
+  if (event.key !== 'Enter') return;
+  event.preventDefault();
+  event.stopPropagation();
+  $('#unlock-defaults').click();
+});
+function insertTemplate(template, context) {
+  const group = [...state.steps, ...state.appendices].find(
+      (item) => item.id === context?.groupId,
+    ),
+    at = insertionIndex(group, context);
+  if (!group || at < 0) {
+    announce('That insertion location is no longer available.');
+    return false;
+  }
+  const blocks = templateBlocks(template, newId);
+  let result;
+  for (const [offset, block] of blocks.entries()) {
+    result = insertBlockOperation(
+      result?.document || state,
+      group.id,
+      block,
+      at + offset,
+    );
+    if (!result.changed) return false;
+  }
+  applyDocumentOperation(result);
+  Object.assign(editorSelection, {
+    activeBlockId: blocks[0].id,
+    blockType: 'heading',
+    container: 'block',
+    itemId: null,
+    row: null,
+    column: null,
+    offsets: [0, template.header.length],
+  });
+  announce(`${template.header} inserted`);
+  return true;
+}
+insertionChooser.addEventListener('close', () => {
+  insertionContext = null;
+  $('#default-password').value = '';
+  showInsertionPanel('main', false);
+});
 bindCallouts();
-function persistDraft({quiet=false,updateUrl=false}={}){flushAll(false);clearTimeout(autosaveTimer);let result;try{result=saveDraft(state,loadedRevision)}catch(error){const indicator=$('#save-state');indicator.textContent='Save failed';indicator.className='save-state error';if(!quiet)alert(`Could not save this draft: ${error.message}`);return false}if(!result.ok){const indicator=$('#save-state');indicator.textContent='Newer draft in another tab';indicator.className='save-state error';if(!quiet)alert('This draft was changed in another tab. Reload before saving so that the newer draft and recovery copy are not overwritten.');return false}loadedRevision=result.revision;dirty=false;if(updateUrl)updateSnapshotUrl(result.record.document,window.location,window.history);const indicator=$('#save-state');indicator.textContent=`Saved locally ${new Date(result.record.savedAt).toLocaleTimeString([], {hour:'2-digit',minute:'2-digit'})}`;indicator.className='save-state';return true}
-function versionsDialog(){const dialog=$('#versions-dialog'),list=$('#versions-list'),versions=listVersions();list.innerHTML=versions.length?versions.map(v=>`<div class="version-row"><span><b>${esc(v.label)}</b><small>${new Date(v.savedAt).toLocaleString()}</small></span><button type="button" data-restore-version="${esc(v.id)}">Restore</button><button type="button" data-delete-version="${esc(v.id)}">Delete</button></div>`).join(''):'<p>No saved versions yet.</p>';list.querySelectorAll('[data-restore-version]').forEach(button=>button.onclick=async()=>{const version=listVersions().find(v=>v.id===button.dataset.restoreVersion);if(!version)return;if(!persistDraft())return;state=normaliseDocument(version.document);history.commit(state);excelController?.restore(state.excel);markDirty();dialog.close();await render({restore:false});announce('Saved version restored')});list.querySelectorAll('[data-delete-version]').forEach(button=>button.onclick=()=>{deleteVersion(button.dataset.deleteVersion);versionsDialog()});if(!dialog.open)dialog.showModal()}
-const propertiesDialog=$('#properties-dialog'),propertiesForm=$('#properties-form');$('#document-properties').onclick=()=>{for(const key of METADATA_KEYS)propertiesForm.elements[key].value=state.meta[key];propertiesDialog.showModal()};propertiesForm.onsubmit=async event=>{event.preventDefault();for(const key of METADATA_KEYS)propertiesForm.elements[key].value=propertiesForm.elements[key].value.trim();if(!propertiesForm.reportValidity())return;await commit(()=>{for(const key of METADATA_KEYS)state.meta[key]=propertiesForm.elements[key].value},{focus:false});propertiesDialog.close();announce('Document properties updated')};
-const imageDialog=$('#image-dialog'),imageForm=$('#image-form'),imageError=$('#image-form-error');imageDialog.addEventListener('close',()=>imageInsertionContext=null);imageForm.onsubmit=event=>{event.preventDefault();const caption=imageForm.elements.caption.value.trim(),widthValue=imageForm.elements.width.value,result=validateImageInput({source:imageForm.elements.src.value,altText:imageForm.elements.alt.value,width:widthValue});if(!result.ok||!imageForm.checkValidity()){const messages={'missing-source':'Enter an image URL and alternative text, and use a width between 20 and 100.','missing-alt-text':'Enter an image URL and alternative text, and use a width between 20 and 100.','malformed-source':'Enter a complete, well-formed image URL.','unsupported-protocol':'Unsupported protocol. Image URLs must use HTTPS.','unsupported-extension':'Unsupported image extension. Use a PNG, JPEG, GIF or WebP URL.'};imageError.textContent=messages[result.error]||'Enter an image URL and alternative text, and use a width between 20 and 100.';imageError.hidden=false;return}const context=imageInsertionContext,group=[...state.steps,...state.appendices].find(item=>item.id===context?.groupId),at=insertionIndex(group,context),id=newId('image'),{source,altText,width}=result.image;if(!group||at<0){imageError.textContent='That insertion location is no longer available.';imageError.hidden=false;return}const operation=insertBlockOperation(state,group.id,{id,type:'image',src:source,alt:altText,captionRuns:caption?[{text:caption}]:[],width},at);if(!applyDocumentOperation(operation))return;selectOperationResult(operation,'image');imageDialog.close();announce('Published image added')};
-$('#save-draft').onclick=()=>persistDraft({updateUrl:true});$('#save-version').onclick=()=>{if(!persistDraft())return;const label=prompt('Name this saved version:',`${state.meta.version||'Version'} — ${state.meta.status||'Draft'}`);if(label===null)return;const nextVersion=nextAvailableVersion(state.meta.version,listVersions());saveVersion(state,label);commit(()=>{state.meta.version=nextVersion},{focus:false});announce(`Named version saved; document advanced to ${nextVersion}`)};$('#show-versions').onclick=versionsDialog;$('#share-snapshot').onclick=async()=>{flushAll(false);const url=`${location.href.split('#')[0]}#snapshot=${encodeSnapshot(state)}`;try{await navigator.clipboard.writeText(url);announce('Snapshot link copied')}catch{prompt('Copy this validated snapshot link:',url)}};$('#open-selected-link').onpointerdown=event=>event.preventDefault();$('#open-selected-link').onclick=()=>openEditorLink($('#link-context').dataset.href);$('#preview').addEventListener('click',editableLinkClick);document.addEventListener('selectionchange',updateLinkContext);
-const printButton=$('#print-document');
-const printing=new PrintLifecycle({flush:()=>flushAll(false),cancelPagination:()=>repagination.cancel(),render:()=>render({immediate:true}),prepare:()=>{const view=captureView();document.documentElement.classList.add('preparing-print');printButton.disabled=true;announce('Preparing complete document for printing');return view},clearPresentation:()=>{getSelection()?.removeAllRanges();document.activeElement?.blur?.()},print:()=>window.print(),onAfterPrint:cleanup=>{window.addEventListener('afterprint',cleanup,{once:true});return()=>window.removeEventListener('afterprint',cleanup)},restore:view=>{document.documentElement.classList.remove('preparing-print');printButton.disabled=false;restoreView(view);announce('Print preparation finished')},onError:error=>announce(`Print preparation failed: ${error.message}`)});
-const exportDocument=()=>printing.run();printButton.onclick=exportDocument;$('#export-document').onclick=exportDocument;document.addEventListener('keydown',event=>{if(!(event.ctrlKey||event.metaKey)||event.altKey)return;const key=event.key.toLowerCase();let action=null;if(key==='z')action=event.shiftKey?'redo':'undo';else if(key==='y'&&!event.shiftKey)action='redo';else if(key==='s')action=event.shiftKey?'export':'save';if(!action)return;event.preventDefault();flushAll();if(action==='save')persistDraft({updateUrl:true});else if(action==='export')exportDocument();else command(action)});
-addEventListener('pagehide',()=>{if(dirty||hasPendingInputs())persistDraft({quiet:true})});document.addEventListener('visibilitychange',()=>{if(document.visibilityState==='hidden'&&(dirty||hasPendingInputs()))persistDraft({quiet:true})});addEventListener('storage',event=>{if(event.key==='ubta:draft'&&readDraft()?.revision!==loadedRevision){const indicator=$('#save-state');indicator.textContent='Newer draft in another tab';indicator.className='save-state error'}});
-let pageObserver=null,observedAreas=new Map();
-function pageLabel(page,index){const type=page.dataset.groupType,groupId=page.dataset.groupId,continued=Number(page.dataset.pageFragment)>0;if(type==='step'){const i=state.steps.findIndex(x=>x.id===groupId);return `Page ${index+1} — Step ${i+1}${continued?' (continued)':''}`}if(type==='appendix'){const i=state.appendices.findIndex(x=>x.id===groupId);return `Page ${index+1} — ${appendixLabel(i)}${continued?' (continued)':''}`}const sheet=page.querySelector('.sheet-source');return `Page ${index+1} — ${sheet?.classList.contains('cover')?'Cover':sheet?.classList.contains('contents')?'Contents':type==='section'?'Section':'Document'}`}
-function rebuildPageJump(pages=[...document.querySelectorAll('.pagedjs_page')]){const jump=$('#page-jump');jump.replaceChildren(...pages.map((page,index)=>{const option=document.createElement('option');option.value=String(index+1);option.textContent=pageLabel(page,index);return option}));jump.value=String(Math.min(currentPage,pages.length||1))}
-function setCurrentPage(page,{scroll=false,focus=false}={}){const pages=[...document.querySelectorAll('.pagedjs_page')];currentPage=Math.max(1,Math.min(pages.length||1,Number(page)||1));$('#current').textContent=currentPage;const jump=$('#page-jump');if(jump)jump.value=String(currentPage);$('#prev').disabled=currentPage<=1;$('#next').disabled=currentPage>=pages.length;if(scroll)pages[currentPage-1]?.scrollIntoView({behavior:'smooth',block:'center'});if(focus)setTimeout(()=>focusPageContext(pages[currentPage-1]),scroll?350:0)}
-function focusPageContext(page){if(!page)return;const type=page.dataset.groupType,id=page.dataset.groupId;if(type==='step'||type==='appendix'){const group=(type==='step'?state.steps:state.appendices).find(x=>x.id===id);selectGroup(group,type);const target=Number(page.dataset.pageFragment)===0?page.querySelector('[data-group-title]'):page.querySelector('[contenteditable=true], [data-group-title]');target?.focus({preventScroll:true});document.querySelectorAll('[data-editable-group-id]').forEach(x=>x.classList.toggle('is-selected',x.dataset.editableGroupId===id));announce(`${pageLabel(page,currentPage-1)}, ${group?.title||''}`)}else{Object.assign(editorSelection,{activeGroupId:null,activeGroupType:null,activeStepId:null,activeBlockId:null,container:null});page.focus({preventScroll:true});announce(pageLabel(page,currentPage-1))}updateControls()}
-function navigateToAnchor(anchor){const pages=[...document.querySelectorAll('.pagedjs_page')],index=pages.findIndex(page=>page.dataset.anchorId===anchor||page.querySelector(`#${CSS.escape(anchor)}`));if(index<0)return false;navigationHistory.push(captureView());setCurrentPage(index+1,{scroll:true,focus:true});return true}
-const openEditorLink=href=>followEditorLink(href,{navigateInternal:navigateToAnchor,openExternal:url=>{const opened=window.open(url,'_blank','noopener,noreferrer');if(opened)opened.opener=null},openMailto:url=>{window.location.href=url},report:announce});
-function editableLinkClick(event){handleEditableLinkClick(event,openEditorLink)}
-function selectedEditableLink(){const selection=getSelection(),node=selection?.anchorNode;return (node?.nodeType===Node.ELEMENT_NODE?node:node?.parentElement)?.closest?.('.editable-runs a')||null}
-function updateLinkContext(){const link=selectedEditableLink(),control=$('#link-context');control.hidden=!link;control.dataset.href=link?.getAttribute('href')||''}
-function disconnectPageObserver(){pageObserver?.disconnect();pageObserver=null;observedAreas.clear()}
-function observePages(){if(!('IntersectionObserver'in window))return;const pages=[...document.querySelectorAll('.pagedjs_page')];pageObserver=new IntersectionObserver(entries=>{for(const entry of entries)observedAreas.set(entry.target,entry.intersectionRect.width*entry.intersectionRect.height);let best=null;for(const page of pages){const area=observedAreas.get(page)||0,center=Math.abs(page.getBoundingClientRect().top+page.getBoundingClientRect().height/2-innerHeight/2);if(!best||area>best.area||(area===best.area&&center<best.center))best={page,area,center}}if(best?.area>0)setCurrentPage(pages.indexOf(best.page)+1)}, {threshold:[0,.1,.25,.5,.75,1]});pages.forEach(page=>pageObserver.observe(page))}
-function go(page){setCurrentPage(page,{scroll:true,focus:true})}$('#prev').onclick=()=>go(currentPage-1);$('#next').onclick=()=>go(currentPage+1);$('#page-jump').onchange=e=>go(Number(e.target.value));
-excelController=new ExcelEditor({root:$('#excel-editor'),toolbar:$('#excel-toolbar'),getDocument:()=>state,updateDocument:excel=>{state={...state,excel};history.replace(state);markDirty();},report:message=>{announce(message);alert(message);}});
-document.querySelectorAll('[data-editor]').forEach(button=>button.onclick=()=>{activeEditor=button.dataset.editor;document.querySelectorAll('[data-editor]').forEach(item=>item.toggleAttribute('aria-current',item===button));const excel=activeEditor==='excel';$('#preview').hidden=excel;$('#excel-editor').hidden=!excel;$('#excel-toolbar').hidden=!excel;if(excel)excelController.synchronize();});
-render({restore:false});
+function persistDraft({ quiet = false, updateUrl = false } = {}) {
+  flushAll(false);
+  clearTimeout(autosaveTimer);
+  let result;
+  try {
+    result = saveDraft(state, loadedRevision);
+  } catch (error) {
+    const indicator = $('#save-state');
+    indicator.textContent = 'Save failed';
+    indicator.className = 'save-state error';
+    if (!quiet) alert(`Could not save this draft: ${error.message}`);
+    return false;
+  }
+  if (!result.ok) {
+    const indicator = $('#save-state');
+    indicator.textContent = 'Newer draft in another tab';
+    indicator.className = 'save-state error';
+    if (!quiet)
+      alert(
+        'This draft was changed in another tab. Reload before saving so that the newer draft and recovery copy are not overwritten.',
+      );
+    return false;
+  }
+  loadedRevision = result.revision;
+  dirty = false;
+  if (updateUrl)
+    updateSnapshotUrl(result.record.document, window.location, window.history);
+  const indicator = $('#save-state');
+  indicator.textContent = `Saved locally ${new Date(result.record.savedAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}`;
+  indicator.className = 'save-state';
+  return true;
+}
+function versionsDialog() {
+  const dialog = $('#versions-dialog'),
+    list = $('#versions-list'),
+    versions = listVersions();
+  list.innerHTML = versions.length
+    ? versions
+        .map(
+          (v) =>
+            `<div class="version-row"><span><b>${esc(v.label)}</b><small>${new Date(v.savedAt).toLocaleString()}</small></span><button type="button" data-restore-version="${esc(v.id)}">Restore</button><button type="button" data-delete-version="${esc(v.id)}">Delete</button></div>`,
+        )
+        .join('')
+    : '<p>No saved versions yet.</p>';
+  list.querySelectorAll('[data-restore-version]').forEach(
+    (button) =>
+      (button.onclick = async () => {
+        const version = listVersions().find(
+          (v) => v.id === button.dataset.restoreVersion,
+        );
+        if (!version) return;
+        if (!persistDraft()) return;
+        state = normaliseDocument(version.document);
+        history.commit(state);
+        excelController?.restore(state.excel);
+        markDirty();
+        dialog.close();
+        await render({ restore: false });
+        announce('Saved version restored');
+      }),
+  );
+  list.querySelectorAll('[data-delete-version]').forEach(
+    (button) =>
+      (button.onclick = () => {
+        deleteVersion(button.dataset.deleteVersion);
+        versionsDialog();
+      }),
+  );
+  if (!dialog.open) dialog.showModal();
+}
+const propertiesDialog = $('#properties-dialog'),
+  propertiesForm = $('#properties-form');
+$('#document-properties').onclick = () => {
+  for (const key of METADATA_KEYS)
+    propertiesForm.elements[key].value = state.meta[key];
+  propertiesDialog.showModal();
+};
+propertiesForm.onsubmit = async (event) => {
+  event.preventDefault();
+  for (const key of METADATA_KEYS)
+    propertiesForm.elements[key].value =
+      propertiesForm.elements[key].value.trim();
+  if (!propertiesForm.reportValidity()) return;
+  await commit(
+    () => {
+      for (const key of METADATA_KEYS)
+        state.meta[key] = propertiesForm.elements[key].value;
+    },
+    { focus: false },
+  );
+  propertiesDialog.close();
+  announce('Document properties updated');
+};
+const imageDialog = $('#image-dialog'),
+  imageForm = $('#image-form'),
+  imageError = $('#image-form-error');
+imageDialog.addEventListener('close', () => (imageInsertionContext = null));
+imageForm.onsubmit = (event) => {
+  event.preventDefault();
+  const caption = imageForm.elements.caption.value.trim(),
+    widthValue = imageForm.elements.width.value,
+    result = validateImageInput({
+      source: imageForm.elements.src.value,
+      altText: imageForm.elements.alt.value,
+      width: widthValue,
+    });
+  if (!result.ok || !imageForm.checkValidity()) {
+    const messages = {
+      'missing-source':
+        'Enter an image URL and alternative text, and use a width between 20 and 100.',
+      'missing-alt-text':
+        'Enter an image URL and alternative text, and use a width between 20 and 100.',
+      'malformed-source': 'Enter a complete, well-formed image URL.',
+      'unsupported-protocol':
+        'Unsupported protocol. Image URLs must use HTTPS.',
+      'unsupported-extension':
+        'Unsupported image extension. Use a PNG, JPEG, GIF or WebP URL.',
+    };
+    imageError.textContent =
+      messages[result.error] ||
+      'Enter an image URL and alternative text, and use a width between 20 and 100.';
+    imageError.hidden = false;
+    return;
+  }
+  const context = imageInsertionContext,
+    group = [...state.steps, ...state.appendices].find(
+      (item) => item.id === context?.groupId,
+    ),
+    at = insertionIndex(group, context),
+    id = newId('image'),
+    { source, altText, width } = result.image;
+  if (!group || at < 0) {
+    imageError.textContent = 'That insertion location is no longer available.';
+    imageError.hidden = false;
+    return;
+  }
+  const operation = insertBlockOperation(
+    state,
+    group.id,
+    {
+      id,
+      type: 'image',
+      src: source,
+      alt: altText,
+      captionRuns: caption ? [{ text: caption }] : [],
+      width,
+    },
+    at,
+  );
+  if (!applyDocumentOperation(operation)) return;
+  selectOperationResult(operation, 'image');
+  imageDialog.close();
+  announce('Published image added');
+};
+$('#save-draft').onclick = () => persistDraft({ updateUrl: true });
+$('#save-version').onclick = () => {
+  if (!persistDraft()) return;
+  const label = prompt(
+    'Name this saved version:',
+    `${state.meta.version || 'Version'} — ${state.meta.status || 'Draft'}`,
+  );
+  if (label === null) return;
+  const nextVersion = nextAvailableVersion(state.meta.version, listVersions());
+  saveVersion(state, label);
+  commit(
+    () => {
+      state.meta.version = nextVersion;
+    },
+    { focus: false },
+  );
+  announce(`Named version saved; document advanced to ${nextVersion}`);
+};
+$('#show-versions').onclick = versionsDialog;
+$('#share-snapshot').onclick = async () => {
+  flushAll(false);
+  const url = `${location.href.split('#')[0]}#snapshot=${encodeSnapshot(state)}`;
+  try {
+    await navigator.clipboard.writeText(url);
+    announce('Snapshot link copied');
+  } catch {
+    prompt('Copy this validated snapshot link:', url);
+  }
+};
+$('#open-selected-link').onpointerdown = (event) => event.preventDefault();
+$('#open-selected-link').onclick = () =>
+  openEditorLink($('#link-context').dataset.href);
+$('#preview').addEventListener('click', editableLinkClick);
+document.addEventListener('selectionchange', updateLinkContext);
+const printButton = $('#print-document');
+const printing = new PrintLifecycle({
+  flush: () => flushAll(false),
+  cancelPagination: () => repagination.cancel(),
+  render: () => render({ immediate: true }),
+  prepare: () => {
+    const view = captureView();
+    document.documentElement.classList.add('preparing-print');
+    printButton.disabled = true;
+    announce('Preparing complete document for printing');
+    return view;
+  },
+  clearPresentation: () => {
+    getSelection()?.removeAllRanges();
+    document.activeElement?.blur?.();
+  },
+  print: () => window.print(),
+  onAfterPrint: (cleanup) => {
+    window.addEventListener('afterprint', cleanup, { once: true });
+    return () => window.removeEventListener('afterprint', cleanup);
+  },
+  restore: (view) => {
+    document.documentElement.classList.remove('preparing-print');
+    printButton.disabled = false;
+    restoreView(view);
+    announce('Print preparation finished');
+  },
+  onError: (error) => announce(`Print preparation failed: ${error.message}`),
+});
+const exportDocument = () => printing.run();
+printButton.onclick = exportDocument;
+$('#export-document').onclick = exportDocument;
+document.addEventListener('keydown', (event) => {
+  if (!(event.ctrlKey || event.metaKey) || event.altKey) return;
+  const key = event.key.toLowerCase();
+  let action = null;
+  if (key === 'z') action = event.shiftKey ? 'redo' : 'undo';
+  else if (key === 'y' && !event.shiftKey) action = 'redo';
+  else if (key === 's') action = event.shiftKey ? 'export' : 'save';
+  if (!action) return;
+  event.preventDefault();
+  flushAll();
+  if (action === 'save') persistDraft({ updateUrl: true });
+  else if (action === 'export') exportDocument();
+  else command(action);
+});
+addEventListener('pagehide', () => {
+  if (dirty || hasPendingInputs()) persistDraft({ quiet: true });
+});
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'hidden' && (dirty || hasPendingInputs()))
+    persistDraft({ quiet: true });
+});
+addEventListener('storage', (event) => {
+  if (event.key === 'ubta:draft' && readDraft()?.revision !== loadedRevision) {
+    const indicator = $('#save-state');
+    indicator.textContent = 'Newer draft in another tab';
+    indicator.className = 'save-state error';
+  }
+});
+let pageObserver = null,
+  observedAreas = new Map();
+function pageLabel(page, index) {
+  const type = page.dataset.groupType,
+    groupId = page.dataset.groupId,
+    continued = Number(page.dataset.pageFragment) > 0;
+  if (type === 'step') {
+    const i = state.steps.findIndex((x) => x.id === groupId);
+    return `Page ${index + 1} — Step ${i + 1}${continued ? ' (continued)' : ''}`;
+  }
+  if (type === 'appendix') {
+    const i = state.appendices.findIndex((x) => x.id === groupId);
+    return `Page ${index + 1} — ${appendixLabel(i)}${continued ? ' (continued)' : ''}`;
+  }
+  const sheet = page.querySelector('.sheet-source');
+  return `Page ${index + 1} — ${sheet?.classList.contains('cover') ? 'Cover' : sheet?.classList.contains('contents') ? 'Contents' : type === 'section' ? 'Section' : 'Document'}`;
+}
+function rebuildPageJump(
+  pages = [...document.querySelectorAll('.pagedjs_page')],
+) {
+  const jump = $('#page-jump');
+  jump.replaceChildren(
+    ...pages.map((page, index) => {
+      const option = document.createElement('option');
+      option.value = String(index + 1);
+      option.textContent = pageLabel(page, index);
+      return option;
+    }),
+  );
+  jump.value = String(Math.min(currentPage, pages.length || 1));
+}
+function setCurrentPage(page, { scroll = false, focus = false } = {}) {
+  const pages = [...document.querySelectorAll('.pagedjs_page')];
+  currentPage = Math.max(1, Math.min(pages.length || 1, Number(page) || 1));
+  $('#current').textContent = currentPage;
+  const jump = $('#page-jump');
+  if (jump) jump.value = String(currentPage);
+  $('#prev').disabled = currentPage <= 1;
+  $('#next').disabled = currentPage >= pages.length;
+  if (scroll)
+    pages[currentPage - 1]?.scrollIntoView({
+      behavior: 'smooth',
+      block: 'center',
+    });
+  if (focus)
+    setTimeout(
+      () => focusPageContext(pages[currentPage - 1]),
+      scroll ? 350 : 0,
+    );
+}
+function focusPageContext(page) {
+  if (!page) return;
+  const type = page.dataset.groupType,
+    id = page.dataset.groupId;
+  if (type === 'step' || type === 'appendix') {
+    const group = (type === 'step' ? state.steps : state.appendices).find(
+      (x) => x.id === id,
+    );
+    selectGroup(group, type);
+    const target =
+      Number(page.dataset.pageFragment) === 0
+        ? page.querySelector('[data-group-title]')
+        : page.querySelector('[contenteditable=true], [data-group-title]');
+    target?.focus({ preventScroll: true });
+    document
+      .querySelectorAll('[data-editable-group-id]')
+      .forEach((x) =>
+        x.classList.toggle('is-selected', x.dataset.editableGroupId === id),
+      );
+    announce(`${pageLabel(page, currentPage - 1)}, ${group?.title || ''}`);
+  } else {
+    Object.assign(editorSelection, {
+      activeGroupId: null,
+      activeGroupType: null,
+      activeStepId: null,
+      activeBlockId: null,
+      container: null,
+    });
+    page.focus({ preventScroll: true });
+    announce(pageLabel(page, currentPage - 1));
+  }
+  updateControls();
+}
+function navigateToAnchor(anchor) {
+  const pages = [...document.querySelectorAll('.pagedjs_page')],
+    index = pages.findIndex(
+      (page) =>
+        page.dataset.anchorId === anchor ||
+        page.querySelector(`#${CSS.escape(anchor)}`),
+    );
+  if (index < 0) return false;
+  navigationHistory.push(captureView());
+  setCurrentPage(index + 1, { scroll: true, focus: true });
+  return true;
+}
+const openEditorLink = (href) =>
+  followEditorLink(href, {
+    navigateInternal: navigateToAnchor,
+    openExternal: (url) => {
+      const opened = window.open(url, '_blank', 'noopener,noreferrer');
+      if (opened) opened.opener = null;
+    },
+    openMailto: (url) => {
+      window.location.href = url;
+    },
+    report: announce,
+  });
+function editableLinkClick(event) {
+  handleEditableLinkClick(event, openEditorLink);
+}
+function selectedEditableLink() {
+  const selection = getSelection(),
+    node = selection?.anchorNode;
+  return (
+    (node?.nodeType === Node.ELEMENT_NODE
+      ? node
+      : node?.parentElement
+    )?.closest?.('.editable-runs a') || null
+  );
+}
+function updateLinkContext() {
+  const link = selectedEditableLink(),
+    control = $('#link-context');
+  control.hidden = !link;
+  control.dataset.href = link?.getAttribute('href') || '';
+}
+function disconnectPageObserver() {
+  pageObserver?.disconnect();
+  pageObserver = null;
+  observedAreas.clear();
+}
+function observePages() {
+  if (!('IntersectionObserver' in window)) return;
+  const pages = [...document.querySelectorAll('.pagedjs_page')];
+  pageObserver = new IntersectionObserver(
+    (entries) => {
+      for (const entry of entries)
+        observedAreas.set(
+          entry.target,
+          entry.intersectionRect.width * entry.intersectionRect.height,
+        );
+      let best = null;
+      for (const page of pages) {
+        const area = observedAreas.get(page) || 0,
+          center = Math.abs(
+            page.getBoundingClientRect().top +
+              page.getBoundingClientRect().height / 2 -
+              innerHeight / 2,
+          );
+        if (
+          !best ||
+          area > best.area ||
+          (area === best.area && center < best.center)
+        )
+          best = { page, area, center };
+      }
+      if (best?.area > 0) setCurrentPage(pages.indexOf(best.page) + 1);
+    },
+    { threshold: [0, 0.1, 0.25, 0.5, 0.75, 1] },
+  );
+  pages.forEach((page) => pageObserver.observe(page));
+}
+function go(page) {
+  setCurrentPage(page, { scroll: true, focus: true });
+}
+$('#prev').onclick = () => go(currentPage - 1);
+$('#next').onclick = () => go(currentPage + 1);
+$('#page-jump').onchange = (e) => go(Number(e.target.value));
+excelController = new ExcelEditor({
+  root: $('#excel-editor'),
+  toolbar: $('#excel-toolbar'),
+  getDocument: () => state,
+  updateDocument: (excel) => {
+    state = { ...state, excel };
+    history.replace(state);
+    markDirty();
+  },
+  report: (message) => {
+    announce(message);
+    alert(message);
+  },
+});
+document.querySelectorAll('[data-editor]').forEach(
+  (button) =>
+    (button.onclick = () => {
+      activeEditor = button.dataset.editor;
+      document
+        .querySelectorAll('[data-editor]')
+        .forEach((item) =>
+          item.toggleAttribute('aria-current', item === button),
+        );
+      const excel = activeEditor === 'excel';
+      $('#preview').hidden = excel;
+      $('#excel-editor').hidden = !excel;
+      $('#excel-toolbar').hidden = !excel;
+      if (excel) excelController.synchronize();
+    }),
+);
+render({ restore: false });

--- a/UBTA/src/state/document-operations.js
+++ b/UBTA/src/state/document-operations.js
@@ -1,14 +1,33 @@
-import { newId, normaliseBlock, normaliseDocument, normaliseTableWidths } from './schema.js';
+import {
+  newId,
+  normaliseBlock,
+  normaliseDocument,
+  normaliseTableWidths,
+} from './schema.js';
 import { recalculateTableTotals, tableColumnFormat } from './table-model.js';
 
 const unchanged = (document, reason) => ({ changed: false, document, reason });
-const changed = (document, details = {}) => ({ changed: true, document: normaliseDocument(document), ...details });
-const copy = document => structuredClone(document);
-const directionOffset = direction => direction === 'before' || direction === 'up' || direction === 'left' ? -1 : direction === 'after' || direction === 'down' || direction === 'right' ? 1 : Number(direction);
-const groups = document => [...(document.sections || []), ...(document.steps || []), ...(document.appendices || [])];
+const changed = (document, details = {}) => ({
+  changed: true,
+  document: normaliseDocument(document),
+  ...details,
+});
+const copy = (document) => structuredClone(document);
+const directionOffset = (direction) =>
+  direction === 'before' || direction === 'up' || direction === 'left'
+    ? -1
+    : direction === 'after' || direction === 'down' || direction === 'right'
+      ? 1
+      : Number(direction);
+const groups = (document) => [
+  ...(document.sections || []),
+  ...(document.steps || []),
+  ...(document.appendices || []),
+];
 const locateBlock = (document, blockId) => {
   for (const group of groups(document)) {
-    const index = group.blocks?.findIndex(block => block.id === blockId) ?? -1;
+    const index =
+      group.blocks?.findIndex((block) => block.id === blockId) ?? -1;
     if (index >= 0) return { group, index, block: group.blocks[index] };
   }
   return null;
@@ -21,83 +40,165 @@ const locateTable = (document, blockId) => {
 function addGroup(document, collection, options = {}) {
   const noun = collection === 'appendices' ? 'appendix' : 'step';
   const source = document[collection] || [];
-  const referenceIndex = options.referenceId == null ? source.length - 1 : source.findIndex(group => group.id === options.referenceId);
-  if (options.referenceId != null && referenceIndex < 0) return unchanged(document, `${noun}-not-found`);
+  const referenceIndex =
+    options.referenceId == null
+      ? source.length - 1
+      : source.findIndex((group) => group.id === options.referenceId);
+  if (options.referenceId != null && referenceIndex < 0)
+    return unchanged(document, `${noun}-not-found`);
   const makeId = options.idFactory || newId;
   const id = options.id || makeId(noun);
   const blockId = options.blockId || makeId('block');
   const next = copy(document);
-  const index = options.referenceId == null ? source.length : referenceIndex + (options.position === 'before' ? 0 : 1);
-  next[collection].splice(index, 0, { id, title: options.title || (collection === 'steps' ? 'New transaction step' : 'New appendix'), blocks: [{ id: blockId, type: 'paragraph', runs: [] }] });
-  return changed(next, { selectedGroupId: id, selectedBlockId: blockId, index });
+  const index =
+    options.referenceId == null
+      ? source.length
+      : referenceIndex + (options.position === 'before' ? 0 : 1);
+  next[collection].splice(index, 0, {
+    id,
+    title:
+      options.title ||
+      (collection === 'steps' ? 'New transaction step' : 'New appendix'),
+    blocks: [{ id: blockId, type: 'paragraph', runs: [] }],
+  });
+  return changed(next, {
+    selectedGroupId: id,
+    selectedBlockId: blockId,
+    index,
+  });
 }
 
 function moveGroup(document, collection, id, direction) {
   const noun = collection === 'appendices' ? 'appendix' : 'step';
-  const currentIndex = (document[collection] || []).findIndex(group => group.id === id);
+  const currentIndex = (document[collection] || []).findIndex(
+    (group) => group.id === id,
+  );
   if (currentIndex < 0) return unchanged(document, `${noun}-not-found`);
   const nextIndex = currentIndex + directionOffset(direction);
-  if (nextIndex < 0 || nextIndex >= document[collection].length) return unchanged(document, `${noun}-cannot-move`);
+  if (nextIndex < 0 || nextIndex >= document[collection].length)
+    return unchanged(document, `${noun}-cannot-move`);
   const next = copy(document);
-  [next[collection][currentIndex], next[collection][nextIndex]] = [next[collection][nextIndex], next[collection][currentIndex]];
+  [next[collection][currentIndex], next[collection][nextIndex]] = [
+    next[collection][nextIndex],
+    next[collection][currentIndex],
+  ];
   return changed(next, { selectedGroupId: id, index: nextIndex });
 }
 
 function deleteGroup(document, collection, id) {
   const noun = collection === 'appendices' ? 'appendix' : 'step';
-  const index = (document[collection] || []).findIndex(group => group.id === id);
+  const index = (document[collection] || []).findIndex(
+    (group) => group.id === id,
+  );
   if (index < 0) return unchanged(document, `${noun}-not-found`);
   const next = copy(document);
   next[collection].splice(index, 1);
-  const selected = next[collection][Math.min(index, next[collection].length - 1)];
+  const selected =
+    next[collection][Math.min(index, next[collection].length - 1)];
   return changed(next, { selectedGroupId: selected?.id || null, index });
 }
 
-const addStepOperation = (document, options) => addGroup(document, 'steps', options);
-const moveStepOperation = (document, stepId, direction) => moveGroup(document, 'steps', stepId, direction);
-const deleteStepOperation = (document, stepId) => deleteGroup(document, 'steps', stepId);
-const addAppendixOperation = (document, options) => addGroup(document, 'appendices', options);
-const moveAppendixOperation = (document, appendixId, direction) => moveGroup(document, 'appendices', appendixId, direction);
-const deleteAppendixOperation = (document, appendixId) => deleteGroup(document, 'appendices', appendixId);
+const addStepOperation = (document, options) =>
+  addGroup(document, 'steps', options);
+const moveStepOperation = (document, stepId, direction) =>
+  moveGroup(document, 'steps', stepId, direction);
+const deleteStepOperation = (document, stepId) =>
+  deleteGroup(document, 'steps', stepId);
+const addAppendixOperation = (document, options) =>
+  addGroup(document, 'appendices', options);
+const moveAppendixOperation = (document, appendixId, direction) =>
+  moveGroup(document, 'appendices', appendixId, direction);
+const deleteAppendixOperation = (document, appendixId) =>
+  deleteGroup(document, 'appendices', appendixId);
 
 function insertBlockOperation(document, groupId, block, index) {
-  const original = groups(document).find(group => group.id === groupId);
+  const original = groups(document).find((group) => group.id === groupId);
   if (!original) return unchanged(document, 'group-not-found');
-  if (!Number.isInteger(index) || index < 0 || index > original.blocks.length) return unchanged(document, 'block-index-invalid');
-  const next = copy(document), group = groups(next).find(item => item.id === groupId);
+  if (!Number.isInteger(index) || index < 0 || index > original.blocks.length)
+    return unchanged(document, 'block-index-invalid');
+  const next = copy(document),
+    group = groups(next).find((item) => item.id === groupId);
   const value = normaliseBlock(block);
   group.blocks.splice(index, 0, value);
-  return changed(next, { selectedGroupId: groupId, selectedBlockId: value.id, index });
+  return changed(next, {
+    selectedGroupId: groupId,
+    selectedBlockId: value.id,
+    index,
+  });
 }
 
 function moveBlockOperation(document, blockId, direction) {
   const found = locateBlock(document, blockId);
   if (!found) return unchanged(document, 'block-not-found');
   const nextIndex = found.index + directionOffset(direction);
-  if (nextIndex < 0 || nextIndex >= found.group.blocks.length) return unchanged(document, 'block-cannot-move');
-  const next = copy(document), target = locateBlock(next, blockId);
-  [target.group.blocks[target.index], target.group.blocks[nextIndex]] = [target.group.blocks[nextIndex], target.group.blocks[target.index]];
-  return changed(next, { selectedGroupId: target.group.id, selectedBlockId: blockId, index: nextIndex });
+  if (nextIndex < 0 || nextIndex >= found.group.blocks.length)
+    return unchanged(document, 'block-cannot-move');
+  const next = copy(document),
+    target = locateBlock(next, blockId);
+  [target.group.blocks[target.index], target.group.blocks[nextIndex]] = [
+    target.group.blocks[nextIndex],
+    target.group.blocks[target.index],
+  ];
+  return changed(next, {
+    selectedGroupId: target.group.id,
+    selectedBlockId: blockId,
+    index: nextIndex,
+  });
 }
 
 function deleteBlockOperation(document, blockId, options = {}) {
   const found = locateBlock(document, blockId);
   if (!found) return unchanged(document, 'block-not-found');
-  const next = copy(document), target = locateBlock(next, blockId);
+  const next = copy(document),
+    target = locateBlock(next, blockId);
   target.group.blocks.splice(target.index, 1);
-  if (!target.group.blocks.length) target.group.blocks.push({ id: (options.idFactory || newId)('block'), type: 'paragraph', runs: [] });
-  const selected = target.group.blocks[Math.min(target.index, target.group.blocks.length - 1)];
-  return changed(next, { selectedGroupId: target.group.id, selectedBlockId: selected.id, selectedBlockType: selected.type, index: target.index });
+  if (!target.group.blocks.length)
+    target.group.blocks.push({
+      id: (options.idFactory || newId)('block'),
+      type: 'paragraph',
+      runs: [],
+    });
+  const selected =
+    target.group.blocks[Math.min(target.index, target.group.blocks.length - 1)];
+  return changed(next, {
+    selectedGroupId: target.group.id,
+    selectedBlockId: selected.id,
+    selectedBlockType: selected.type,
+    index: target.index,
+  });
 }
 
-function insertTableRowOperation(document, blockId, afterRowId = null, options = {}) {
+function insertTableRowOperation(
+  document,
+  blockId,
+  afterRowId = null,
+  options = {},
+) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  const rowIndex = afterRowId == null ? found.block.rows.findIndex(row => row.isTotal) - 1 : found.block.rows.findIndex(row => row.id === afterRowId);
-  if (afterRowId != null && rowIndex < 0) return unchanged(document, 'row-not-found');
-  const next = copy(document), block = locateTable(next, blockId).block, makeId = options.idFactory || newId;
-  const totalIndex = block.rows.findIndex(row => row.isTotal), index = afterRowId == null ? (totalIndex < 0 ? block.rows.length : totalIndex) : Math.min(rowIndex + 1, totalIndex < 0 ? block.rows.length : totalIndex);
-  block.rows.splice(index, 0, { id: options.id || makeId('row'), cells: block.columns.map(() => ({ id: makeId('cell'), runs: [] })) });
+  const rowIndex =
+    afterRowId == null
+      ? found.block.rows.findIndex((row) => row.isTotal) - 1
+      : found.block.rows.findIndex((row) => row.id === afterRowId);
+  if (afterRowId != null && rowIndex < 0)
+    return unchanged(document, 'row-not-found');
+  const next = copy(document),
+    block = locateTable(next, blockId).block,
+    makeId = options.idFactory || newId;
+  const totalIndex = block.rows.findIndex((row) => row.isTotal),
+    index =
+      afterRowId == null
+        ? totalIndex < 0
+          ? block.rows.length
+          : totalIndex
+        : Math.min(
+            rowIndex + 1,
+            totalIndex < 0 ? block.rows.length : totalIndex,
+          );
+  block.rows.splice(index, 0, {
+    id: options.id || makeId('row'),
+    cells: block.columns.map(() => ({ id: makeId('cell'), runs: [] })),
+  });
   recalculateTableTotals(block);
   return changed(next, { selectedBlockId: blockId, rowIndex: index });
 }
@@ -105,11 +206,17 @@ function insertTableRowOperation(document, blockId, afterRowId = null, options =
 function moveTableRowOperation(document, blockId, rowId, direction) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  const index = found.block.rows.findIndex(row => row.id === rowId);
+  const index = found.block.rows.findIndex((row) => row.id === rowId);
   if (index < 0) return unchanged(document, 'row-not-found');
   const target = index + directionOffset(direction);
-  if (target < 0 || target >= found.block.rows.length || found.block.rows[target].isTotal !== found.block.rows[index].isTotal) return unchanged(document, 'row-cannot-move');
-  const next = copy(document), rows = locateTable(next, blockId).block.rows;
+  if (
+    target < 0 ||
+    target >= found.block.rows.length ||
+    found.block.rows[target].isTotal !== found.block.rows[index].isTotal
+  )
+    return unchanged(document, 'row-cannot-move');
+  const next = copy(document),
+    rows = locateTable(next, blockId).block.rows;
   [rows[index], rows[target]] = [rows[target], rows[index]];
   recalculateTableTotals(locateTable(next, blockId).block);
   return changed(next, { selectedBlockId: blockId, rowIndex: target });
@@ -118,37 +225,80 @@ function moveTableRowOperation(document, blockId, rowId, direction) {
 function deleteTableRowOperation(document, blockId, rowId) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  const index = found.block.rows.findIndex(row => row.id === rowId);
+  const index = found.block.rows.findIndex((row) => row.id === rowId);
   if (index < 0) return unchanged(document, 'row-not-found');
-  const next = copy(document), block = locateTable(next, blockId).block;
-  block.rows.splice(index, 1); recalculateTableTotals(block);
-  return changed(next, { selectedBlockId: blockId, rowIndex: block.rows.length ? Math.min(index, block.rows.length - 1) : null });
+  const next = copy(document),
+    block = locateTable(next, blockId).block;
+  block.rows.splice(index, 1);
+  recalculateTableTotals(block);
+  return changed(next, {
+    selectedBlockId: blockId,
+    rowIndex: block.rows.length ? Math.min(index, block.rows.length - 1) : null,
+  });
 }
 
-function insertTableColumnOperation(document, blockId, afterColumnId = null, options = {}) {
+function insertTableColumnOperation(
+  document,
+  blockId,
+  afterColumnId = null,
+  options = {},
+) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  if (found.block.columns.length >= 8) return unchanged(document, 'column-limit-reached');
-  const previous = afterColumnId == null ? found.block.columns.length - 1 : found.block.columns.findIndex(column => column.id === afterColumnId);
-  if (afterColumnId != null && previous < 0) return unchanged(document, 'column-not-found');
-  const next = copy(document), block = locateTable(next, blockId).block, makeId = options.idFactory || newId, index = previous + 1;
-  block.columns.splice(index, 0, { id: options.id || makeId('column'), headingRuns: [{ text: `Column ${index + 1}` }], width: 100 / (block.columns.length + 1), format: 'text', totalEnabled: false });
-  block.rows.forEach(row => row.cells.splice(index, 0, { id: makeId('cell'), runs: [] }));
-  const widths = normaliseTableWidths(block.columns.map(() => 100 / block.columns.length), block.columns.length);
-  block.columns.forEach((column, columnIndex) => { column.width = widths[columnIndex]; });
+  if (found.block.columns.length >= 8)
+    return unchanged(document, 'column-limit-reached');
+  const previous =
+    afterColumnId == null
+      ? found.block.columns.length - 1
+      : found.block.columns.findIndex((column) => column.id === afterColumnId);
+  if (afterColumnId != null && previous < 0)
+    return unchanged(document, 'column-not-found');
+  const next = copy(document),
+    block = locateTable(next, blockId).block,
+    makeId = options.idFactory || newId,
+    index = previous + 1;
+  block.columns.splice(index, 0, {
+    id: options.id || makeId('column'),
+    headingRuns: [{ text: `Column ${index + 1}` }],
+    width: 100 / (block.columns.length + 1),
+    format: 'text',
+    totalEnabled: false,
+  });
+  block.rows.forEach((row) =>
+    row.cells.splice(index, 0, { id: makeId('cell'), runs: [] }),
+  );
+  const widths = normaliseTableWidths(
+    block.columns.map(() => 100 / block.columns.length),
+    block.columns.length,
+  );
+  block.columns.forEach((column, columnIndex) => {
+    column.width = widths[columnIndex];
+  });
   return changed(next, { selectedBlockId: blockId, columnIndex: index });
 }
 
 function moveTableColumnOperation(document, blockId, columnId, direction) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  const index = found.block.columns.findIndex(column => column.id === columnId);
+  const index = found.block.columns.findIndex(
+    (column) => column.id === columnId,
+  );
   if (index < 0) return unchanged(document, 'column-not-found');
   const target = index + directionOffset(direction);
-  if (target < 0 || target >= found.block.columns.length) return unchanged(document, 'column-cannot-move');
-  const next = copy(document), block = locateTable(next, blockId).block;
-  [block.columns[index], block.columns[target]] = [block.columns[target], block.columns[index]];
-  block.rows.forEach(row => { [row.cells[index], row.cells[target]] = [row.cells[target], row.cells[index]]; });
+  if (target < 0 || target >= found.block.columns.length)
+    return unchanged(document, 'column-cannot-move');
+  const next = copy(document),
+    block = locateTable(next, blockId).block;
+  [block.columns[index], block.columns[target]] = [
+    block.columns[target],
+    block.columns[index],
+  ];
+  block.rows.forEach((row) => {
+    [row.cells[index], row.cells[target]] = [
+      row.cells[target],
+      row.cells[index],
+    ];
+  });
   recalculateTableTotals(block);
   return changed(next, { selectedBlockId: blockId, columnIndex: target });
 }
@@ -156,54 +306,115 @@ function moveTableColumnOperation(document, blockId, columnId, direction) {
 function deleteTableColumnOperation(document, blockId, columnId) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  const index = found.block.columns.findIndex(column => column.id === columnId);
+  const index = found.block.columns.findIndex(
+    (column) => column.id === columnId,
+  );
   if (index < 0) return unchanged(document, 'column-not-found');
-  if (found.block.columns.length <= 1) return unchanged(document, 'column-cannot-delete');
-  const next = copy(document), block = locateTable(next, blockId).block;
-  block.columns.splice(index, 1); block.rows.forEach(row => row.cells.splice(index, 1)); recalculateTableTotals(block);
-  return changed(next, { selectedBlockId: blockId, columnIndex: Math.min(index, block.columns.length - 1) });
+  if (found.block.columns.length <= 1)
+    return unchanged(document, 'column-cannot-delete');
+  const next = copy(document),
+    block = locateTable(next, blockId).block;
+  block.columns.splice(index, 1);
+  block.rows.forEach((row) => row.cells.splice(index, 1));
+  recalculateTableTotals(block);
+  return changed(next, {
+    selectedBlockId: blockId,
+    columnIndex: Math.min(index, block.columns.length - 1),
+  });
 }
 
 function setTableColumnFormatOperation(document, blockId, columnId, format) {
   const found = locateTable(document, blockId);
   if (!found) return unchanged(document, 'table-not-found');
-  const index = found.block.columns.findIndex(column => column.id === columnId);
+  const index = found.block.columns.findIndex(
+    (column) => column.id === columnId,
+  );
   if (index < 0) return unchanged(document, 'column-not-found');
-  if (!['text', 'number', 'gbp'].includes(format)) return unchanged(document, 'column-format-unsupported');
-  if (tableColumnFormat(found.block.columns[index]) === format) return unchanged(document, 'column-format-unchanged');
-  const next = copy(document), block = locateTable(next, blockId).block;
-  block.columns[index].format = format; delete block.columns[index].numeric; recalculateTableTotals(block);
+  if (!['text', 'number', 'gbp'].includes(format))
+    return unchanged(document, 'column-format-unsupported');
+  if (tableColumnFormat(found.block.columns[index]) === format)
+    return unchanged(document, 'column-format-unchanged');
+  const next = copy(document),
+    block = locateTable(next, blockId).block;
+  block.columns[index].format = format;
+  delete block.columns[index].numeric;
+  recalculateTableTotals(block);
   return changed(next, { selectedBlockId: blockId, columnIndex: index });
 }
 
 function setTableColumnTotalOperation(document, blockId, columnId, enabled) {
-  const found=locateTable(document,blockId);
-  if(!found)return unchanged(document,'table-not-found');
-  const index=found.block.columns.findIndex(column=>column.id===columnId);
-  if(index<0)return unchanged(document,'column-not-found');
-  if(tableColumnFormat(found.block.columns[index])==='text')return unchanged(document,'column-total-not-numeric');
-  if(found.block.columns[index].totalEnabled===(enabled===true))return unchanged(document,'column-total-unchanged');
-  const next=copy(document),block=locateTable(next,blockId).block;
-  block.columns[index].totalEnabled=enabled===true;recalculateTableTotals(block);
-  return changed(next,{selectedBlockId:blockId,columnIndex:index});
+  const found = locateTable(document, blockId);
+  if (!found) return unchanged(document, 'table-not-found');
+  const index = found.block.columns.findIndex(
+    (column) => column.id === columnId,
+  );
+  if (index < 0) return unchanged(document, 'column-not-found');
+  if (tableColumnFormat(found.block.columns[index]) === 'text')
+    return unchanged(document, 'column-total-not-numeric');
+  if (found.block.columns[index].totalEnabled === (enabled === true))
+    return unchanged(document, 'column-total-unchanged');
+  const next = copy(document),
+    block = locateTable(next, blockId).block;
+  block.columns[index].totalEnabled = enabled === true;
+  recalculateTableTotals(block);
+  return changed(next, { selectedBlockId: blockId, columnIndex: index });
 }
 
 function convertBlockStyleOperation(document, blockId, style, options = {}) {
   const found = locateBlock(document, blockId);
   if (!found) return unchanged(document, 'block-not-found');
-  if (!['heading', 'paragraph', 'bulletList', 'numberList'].includes(found.block.type)) return unchanged(document, 'block-type-unsupported');
-  const heading = /^heading([1-4])$/.exec(style), type = heading ? 'heading' : style === 'body' ? 'paragraph' : ['bulletList', 'numberList'].includes(style) ? style : null;
+  if (
+    !['heading', 'paragraph', 'bulletList', 'numberList'].includes(
+      found.block.type,
+    )
+  )
+    return unchanged(document, 'block-type-unsupported');
+  const heading = /^heading([1-4])$/.exec(style),
+    type = heading
+      ? 'heading'
+      : style === 'body'
+        ? 'paragraph'
+        : ['bulletList', 'numberList'].includes(style)
+          ? style
+          : null;
   if (!type) return unchanged(document, 'block-style-unsupported');
-  const next = copy(document), block = locateBlock(next, blockId).block, makeId = options.idFactory || newId;
+  const next = copy(document),
+    block = locateBlock(next, blockId).block,
+    makeId = options.idFactory || newId;
   if (type === 'heading' || type === 'paragraph') {
-    block.runs = block.runs || block.items?.flatMap(item => item.runs) || [];
-    delete block.items; block.type = type;
-    if (heading) block.level = Number(heading[1]); else delete block.level;
+    block.runs = block.runs || block.items?.flatMap((item) => item.runs) || [];
+    delete block.items;
+    block.type = type;
+    if (heading) block.level = Number(heading[1]);
+    else delete block.level;
   } else {
-    block.items = block.items || [{ id: makeId('item'), level: 1, runs: block.runs || [] }];
-    delete block.runs; delete block.level; block.type = type;
+    block.items = block.items || [
+      { id: makeId('item'), level: 1, runs: block.runs || [] },
+    ];
+    delete block.runs;
+    delete block.level;
+    block.type = type;
   }
   return changed(next, { selectedBlockId: blockId, selectedBlockType: type });
 }
 
-export { addStepOperation as addStep, moveStepOperation as moveStep, deleteStepOperation as deleteStep, addAppendixOperation as addAppendix, moveAppendixOperation as moveAppendix, deleteAppendixOperation as deleteAppendix, insertBlockOperation as insertBlock, moveBlockOperation as moveBlock, deleteBlockOperation as deleteBlock, insertTableRowOperation as insertTableRow, moveTableRowOperation as moveTableRow, deleteTableRowOperation as deleteTableRow, insertTableColumnOperation as insertTableColumn, moveTableColumnOperation as moveTableColumn, deleteTableColumnOperation as deleteTableColumn, setTableColumnFormatOperation as setTableColumnFormat, setTableColumnTotalOperation as setTableColumnTotal, convertBlockStyleOperation as convertBlockStyle };
+export {
+  addStepOperation as addStep,
+  moveStepOperation as moveStep,
+  deleteStepOperation as deleteStep,
+  addAppendixOperation as addAppendix,
+  moveAppendixOperation as moveAppendix,
+  deleteAppendixOperation as deleteAppendix,
+  insertBlockOperation as insertBlock,
+  moveBlockOperation as moveBlock,
+  deleteBlockOperation as deleteBlock,
+  insertTableRowOperation as insertTableRow,
+  moveTableRowOperation as moveTableRow,
+  deleteTableRowOperation as deleteTableRow,
+  insertTableColumnOperation as insertTableColumn,
+  moveTableColumnOperation as moveTableColumn,
+  deleteTableColumnOperation as deleteTableColumn,
+  setTableColumnFormatOperation as setTableColumnFormat,
+  setTableColumnTotalOperation as setTableColumnTotal,
+  convertBlockStyleOperation as convertBlockStyle,
+};

--- a/UBTA/src/state/excel-model.js
+++ b/UBTA/src/state/excel-model.js
@@ -1,46 +1,237 @@
-const id = prefix => `${prefix}-${globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)}`;
+const id = (prefix) =>
+  `${prefix}-${globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)}`;
 export const TYPES = ['Individual', 'Trust', 'Company'];
 export const MAX_SHAREHOLDERS = 100;
 export const MAX_CLASSES = 100;
-const integer = value => Number.isSafeInteger(value) ? value : 0;
+const integer = (value) => (Number.isSafeInteger(value) ? value : 0);
 
 export function parseShares(value) {
-  if (typeof value === 'number') return Number.isSafeInteger(value) ? value : null;
-  const text = String(value ?? '').trim().replaceAll(',', '');
+  if (typeof value === 'number')
+    return Number.isSafeInteger(value) ? value : null;
+  const text = String(value ?? '')
+    .trim()
+    .replaceAll(',', '');
   if (!text) return 0;
-  const negative = text.match(/^\((\d+)\)$/), candidate = negative ? `-${negative[1]}` : text;
+  const negative = text.match(/^\((\d+)\)$/),
+    candidate = negative ? `-${negative[1]}` : text;
   const number = Number(candidate);
-  return /^-?\d+$/.test(candidate) && Number.isSafeInteger(number) ? number : null;
+  return /^-?\d+$/.test(candidate) && Number.isSafeInteger(number)
+    ? number
+    : null;
 }
-export const formatShares = value => integer(value) < 0 ? `(${Math.abs(integer(value)).toLocaleString('en-GB')})` : integer(value).toLocaleString('en-GB');
+export const formatShares = (value) =>
+  integer(value) < 0
+    ? `(${Math.abs(integer(value)).toLocaleString('en-GB')})`
+    : integer(value).toLocaleString('en-GB');
 export const cellKey = (holderId, classId) => `${holderId}|${classId}`;
-export const valueAt = (values, holderId, classId) => integer(values?.[cellKey(holderId, classId)]);
-export const classesOf = company => company.groups.flatMap(group => group.classes);
+export const valueAt = (values, holderId, classId) =>
+  integer(values?.[cellKey(holderId, classId)]);
+export const classesOf = (company) =>
+  company.groups.flatMap((group) => group.classes);
 
 export function createCompany(name = 'Company 1') {
-  const shareholders = TYPES.map((type, index) => ({ id:id('holder'), name:`Shareholder ${index + 1}`, type }));
-  const groups = ['Ordinary Shares', 'Preference Shares', 'Deferred Shares'].map(name => ({ id:id('group'), name, classes:[{ id:id('class'), label:'' }] }));
-  return { id:id('company'), name, shareholders, groups, opening:{}, movements:{}, collapsed:{} };
+  const shareholders = TYPES.map((type, index) => ({
+    id: id('holder'),
+    name: `Shareholder ${index + 1}`,
+    type,
+  }));
+  const groups = [
+    'Ordinary Shares',
+    'Preference Shares',
+    'Deferred Shares',
+  ].map((name) => ({
+    id: id('group'),
+    name,
+    classes: [{ id: id('class'), label: '' }],
+  }));
+  return {
+    id: id('company'),
+    name,
+    shareholders,
+    groups,
+    opening: {},
+    movements: {},
+    collapsed: {},
+  };
 }
-export function createExcel() { const company=createCompany(); return { schemaVersion:1, companies:[company], selectedCompanyId:company.id, syncedSteps:[] }; }
+export function createExcel() {
+  const company = createCompany();
+  return {
+    schemaVersion: 1,
+    companies: [company],
+    selectedCompanyId: company.id,
+    syncedSteps: [],
+  };
+}
 
 export function normaliseExcel(source, steps = []) {
-  const input = source && Array.isArray(source.companies) ? source : createExcel();
-  const companies = input.companies.map(company => {
-    const shareholders = (Array.isArray(company.shareholders) ? company.shareholders : []).slice(0, 100).map(holder => ({ id:String(holder.id || id('holder')), name:String(holder.name ?? ''), type:TYPES.includes(holder.type) ? holder.type : 'Individual' }));
-    const groups = (Array.isArray(company.groups) ? company.groups : []).map(group => ({ id:String(group.id || id('group')), name:String(group.name ?? ''), classes:(Array.isArray(group.classes) ? group.classes : []).map(item => ({ id:String(item.id || id('class')), label:String(item.label ?? '') })) }));
-    let count=0; for (const group of groups) group.classes=group.classes.filter(() => ++count <= 100);
-    const classIds=new Set(classesOf({groups}).map(item=>item.id)), holderIds=new Set(shareholders.map(holder=>holder.id));
-    const clean = values => Object.fromEntries(Object.entries(values || {}).filter(([key]) => { const [holderId,classId]=key.split('|'); return holderIds.has(holderId)&&classIds.has(classId); }).map(([key,value])=>[key,integer(value)]));
-    const movements={}; for (const step of steps) movements[step.id]=clean(company.movements?.[step.id]);
-    return { id:String(company.id || id('company')), name:String(company.name || 'Untitled company'), shareholders, groups, opening:clean(company.opening), movements, collapsed:Object.fromEntries(steps.map(step=>[step.id,company.collapsed?.[step.id]===true])) };
+  const input =
+    source && Array.isArray(source.companies) ? source : createExcel();
+  const companies = input.companies.map((company) => {
+    const shareholders = (
+      Array.isArray(company.shareholders) ? company.shareholders : []
+    )
+      .slice(0, 100)
+      .map((holder) => ({
+        id: String(holder.id || id('holder')),
+        name: String(holder.name ?? ''),
+        type: TYPES.includes(holder.type) ? holder.type : 'Individual',
+      }));
+    const groups = (Array.isArray(company.groups) ? company.groups : []).map(
+      (group) => ({
+        id: String(group.id || id('group')),
+        name: String(group.name ?? ''),
+        classes: (Array.isArray(group.classes) ? group.classes : []).map(
+          (item) => ({
+            id: String(item.id || id('class')),
+            label: String(item.label ?? ''),
+          }),
+        ),
+      }),
+    );
+    let count = 0;
+    for (const group of groups)
+      group.classes = group.classes.filter(() => ++count <= 100);
+    const classIds = new Set(classesOf({ groups }).map((item) => item.id)),
+      holderIds = new Set(shareholders.map((holder) => holder.id));
+    const clean = (values) =>
+      Object.fromEntries(
+        Object.entries(values || {})
+          .filter(([key]) => {
+            const [holderId, classId] = key.split('|');
+            return holderIds.has(holderId) && classIds.has(classId);
+          })
+          .map(([key, value]) => [key, integer(value)]),
+      );
+    const movements = {};
+    for (const step of steps)
+      movements[step.id] = clean(company.movements?.[step.id]);
+    return {
+      id: String(company.id || id('company')),
+      name: String(company.name || 'Untitled company'),
+      shareholders,
+      groups,
+      opening: clean(company.opening),
+      movements,
+      collapsed: Object.fromEntries(
+        steps.map((step) => [step.id, company.collapsed?.[step.id] === true]),
+      ),
+    };
   });
-  const selectedCompanyId=companies.some(item=>item.id===input.selectedCompanyId)?input.selectedCompanyId:companies[0]?.id||null;
-  return { schemaVersion:1, companies, selectedCompanyId, syncedSteps:steps.map(step=>({id:step.id,label:step.title})) };
+  const selectedCompanyId = companies.some(
+    (item) => item.id === input.selectedCompanyId,
+  )
+    ? input.selectedCompanyId
+    : companies[0]?.id || null;
+  return {
+    schemaVersion: 1,
+    companies,
+    selectedCompanyId,
+    syncedSteps: steps.map((step) => ({ id: step.id, label: step.title })),
+  };
 }
 export const syncSteps = (excel, steps) => normaliseExcel(excel, steps);
-export const stepHasMovements = (excel, stepId) => excel.companies.some(company => Object.values(company.movements?.[stepId] || {}).some(value => value !== 0));
-export function resultingValues(company, steps, throughIndex) { const result={...company.opening}; for(const step of steps.slice(0,throughIndex+1)) for(const holder of company.shareholders) for(const shareClass of classesOf(company)){const key=cellKey(holder.id,shareClass.id);result[key]=integer(result[key])+valueAt(company.movements[step.id],holder.id,shareClass.id);} return result; }
-export function totals(company, values) { const classes=classesOf(company),rows=Object.fromEntries(company.shareholders.map(holder=>[holder.id,classes.reduce((sum,item)=>sum+valueAt(values,holder.id,item.id),0)])),columns=Object.fromEntries(classes.map(item=>[item.id,company.shareholders.reduce((sum,holder)=>sum+valueAt(values,holder.id,item.id),0)]));return {rows,columns,grand:Object.values(columns).reduce((sum,value)=>sum+value,0)}; }
-export function findBlocking(company, classIds=null, holderId=null, steps=[]) { const wanted=new Set(classIds||classesOf(company).map(item=>item.id));for(const holder of company.shareholders)if(!holderId||holder.id===holderId)for(const shareClass of classesOf(company))if(wanted.has(shareClass.id)){if(valueAt(company.opening,holder.id,shareClass.id))return {location:'Opening Position',holder,shareClass};for(const step of steps)if(valueAt(company.movements[step.id],holder.id,shareClass.id))return {location:step.title,holder,shareClass};}return null; }
-export function applyPaste(company, values, startRow, startColumn, range, mode='replace') { const classes=classesOf(company);if(!range.length||range.some(row=>row.length!==range[0].length))throw Error('The copied range must be rectangular.');if(startRow+range.length>company.shareholders.length||startColumn+range[0].length>classes.length)throw Error('The complete pasted range does not fit in the editable table.');const parsed=range.map(row=>row.map(parseShares));if(parsed.flat().some(value=>value===null))throw Error('Every pasted value must be a whole integer.');const output={...values};parsed.forEach((row,ri)=>row.forEach((value,ci)=>{const key=cellKey(company.shareholders[startRow+ri].id,classes[startColumn+ci].id),current=integer(output[key]);output[key]=mode==='negative'?-value:mode==='add'?current+value:mode==='subtract'?current-value:value;}));return output; }
+export const stepHasMovements = (excel, stepId) =>
+  excel.companies.some((company) =>
+    Object.values(company.movements?.[stepId] || {}).some(
+      (value) => value !== 0,
+    ),
+  );
+export function resultingValues(company, steps, throughIndex) {
+  const result = { ...company.opening };
+  for (const step of steps.slice(0, throughIndex + 1))
+    for (const holder of company.shareholders)
+      for (const shareClass of classesOf(company)) {
+        const key = cellKey(holder.id, shareClass.id);
+        result[key] =
+          integer(result[key]) +
+          valueAt(company.movements[step.id], holder.id, shareClass.id);
+      }
+  return result;
+}
+export function totals(company, values) {
+  const classes = classesOf(company),
+    rows = Object.fromEntries(
+      company.shareholders.map((holder) => [
+        holder.id,
+        classes.reduce(
+          (sum, item) => sum + valueAt(values, holder.id, item.id),
+          0,
+        ),
+      ]),
+    ),
+    columns = Object.fromEntries(
+      classes.map((item) => [
+        item.id,
+        company.shareholders.reduce(
+          (sum, holder) => sum + valueAt(values, holder.id, item.id),
+          0,
+        ),
+      ]),
+    );
+  return {
+    rows,
+    columns,
+    grand: Object.values(columns).reduce((sum, value) => sum + value, 0),
+  };
+}
+export function findBlocking(
+  company,
+  classIds = null,
+  holderId = null,
+  steps = [],
+) {
+  const wanted = new Set(classIds || classesOf(company).map((item) => item.id));
+  for (const holder of company.shareholders)
+    if (!holderId || holder.id === holderId)
+      for (const shareClass of classesOf(company))
+        if (wanted.has(shareClass.id)) {
+          if (valueAt(company.opening, holder.id, shareClass.id))
+            return { location: 'Opening Position', holder, shareClass };
+          for (const step of steps)
+            if (valueAt(company.movements[step.id], holder.id, shareClass.id))
+              return { location: step.title, holder, shareClass };
+        }
+  return null;
+}
+export function applyPaste(
+  company,
+  values,
+  startRow,
+  startColumn,
+  range,
+  mode = 'replace',
+) {
+  const classes = classesOf(company);
+  if (!range.length || range.some((row) => row.length !== range[0].length))
+    throw Error('The copied range must be rectangular.');
+  if (
+    startRow + range.length > company.shareholders.length ||
+    startColumn + range[0].length > classes.length
+  )
+    throw Error(
+      'The complete pasted range does not fit in the editable table.',
+    );
+  const parsed = range.map((row) => row.map(parseShares));
+  if (parsed.flat().some((value) => value === null))
+    throw Error('Every pasted value must be a whole integer.');
+  const output = { ...values };
+  parsed.forEach((row, ri) =>
+    row.forEach((value, ci) => {
+      const key = cellKey(
+          company.shareholders[startRow + ri].id,
+          classes[startColumn + ci].id,
+        ),
+        current = integer(output[key]);
+      output[key] =
+        mode === 'negative'
+          ? -value
+          : mode === 'add'
+            ? current + value
+            : mode === 'subtract'
+              ? current - value
+              : value;
+    }),
+  );
+  return output;
+}

--- a/UBTA/src/state/history.js
+++ b/UBTA/src/state/history.js
@@ -1,11 +1,40 @@
 const same = (a, b) => JSON.stringify(a) === JSON.stringify(b);
 export class History {
-  constructor(value) { this.past = []; this.future = []; this.value = structuredClone(value); }
-  checkout() { return structuredClone(this.value); }
-  commit(value) { const next = structuredClone(value); if (same(this.value, next)) return false; this.past.push(structuredClone(this.value)); this.value = next; this.future = []; return true; }
-  replace(value) { this.value = structuredClone(value); }
-  peekUndo() { return this.past.length ? structuredClone(this.past.at(-1)) : null; }
-  peekRedo() { return this.future.length ? structuredClone(this.future.at(-1)) : null; }
-  undo() { if (!this.past.length) return this.value; this.future.push(structuredClone(this.value)); this.value = this.past.pop(); return structuredClone(this.value); }
-  redo() { if (!this.future.length) return this.value; this.past.push(structuredClone(this.value)); this.value = this.future.pop(); return structuredClone(this.value); }
+  constructor(value) {
+    this.past = [];
+    this.future = [];
+    this.value = structuredClone(value);
+  }
+  checkout() {
+    return structuredClone(this.value);
+  }
+  commit(value) {
+    const next = structuredClone(value);
+    if (same(this.value, next)) return false;
+    this.past.push(structuredClone(this.value));
+    this.value = next;
+    this.future = [];
+    return true;
+  }
+  replace(value) {
+    this.value = structuredClone(value);
+  }
+  peekUndo() {
+    return this.past.length ? structuredClone(this.past.at(-1)) : null;
+  }
+  peekRedo() {
+    return this.future.length ? structuredClone(this.future.at(-1)) : null;
+  }
+  undo() {
+    if (!this.past.length) return this.value;
+    this.future.push(structuredClone(this.value));
+    this.value = this.past.pop();
+    return structuredClone(this.value);
+  }
+  redo() {
+    if (!this.future.length) return this.value;
+    this.past.push(structuredClone(this.value));
+    this.value = this.future.pop();
+    return structuredClone(this.value);
+  }
 }

--- a/UBTA/src/state/image-model.js
+++ b/UBTA/src/state/image-model.js
@@ -11,8 +11,10 @@ export function validateImageSource(value) {
     return { ok: false, error: 'malformed-source' };
   }
 
-  if (url.protocol !== 'https:') return { ok: false, error: 'unsupported-protocol' };
-  if (!SUPPORTED_IMAGE_PATH.test(url.pathname)) return { ok: false, error: 'unsupported-extension' };
+  if (url.protocol !== 'https:')
+    return { ok: false, error: 'unsupported-protocol' };
+  if (!SUPPORTED_IMAGE_PATH.test(url.pathname))
+    return { ok: false, error: 'unsupported-extension' };
   return { ok: true, url: url.href };
 }
 

--- a/UBTA/src/state/persistence.js
+++ b/UBTA/src/state/persistence.js
@@ -1,43 +1,99 @@
 import { validateDocument } from './schema.js';
 
 export const STORAGE_VERSION = 1;
-export const STORAGE_KEYS = { draft:'ubta:draft', recovery:'ubta:recovery', versions:'ubta:versions' };
+export const STORAGE_KEYS = {
+  draft: 'ubta:draft',
+  recovery: 'ubta:recovery',
+  versions: 'ubta:versions',
+};
 const VERSION_LIMIT = 20;
-const parse = value => { try { return value ? JSON.parse(value) : null; } catch { return null; } };
-const validRecord = record => record?.storageVersion === STORAGE_VERSION && Number.isInteger(record.revision) && record.revision >= 0 && record.document;
-const checkedDocument = value => validateDocument(value);
+const parse = (value) => {
+  try {
+    return value ? JSON.parse(value) : null;
+  } catch {
+    return null;
+  }
+};
+const validRecord = (record) =>
+  record?.storageVersion === STORAGE_VERSION &&
+  Number.isInteger(record.revision) &&
+  record.revision >= 0 &&
+  record.document;
+const checkedDocument = (value) => validateDocument(value);
 
 export function readDraft(storage = localStorage) {
   const record = parse(storage.getItem(STORAGE_KEYS.draft));
   if (!validRecord(record)) return null;
-  try { return { ...record, document:checkedDocument(record.document) }; } catch { return null; }
+  try {
+    return { ...record, document: checkedDocument(record.document) };
+  } catch {
+    return null;
+  }
 }
 
 /** A save is compare-and-swap: another tab can never have its draft or recovery overwritten. */
-export function saveDraft(document, expectedRevision, storage = localStorage, now = Date.now()) {
-  const current = readDraft(storage), actualRevision = current?.revision ?? 0;
-  if (actualRevision !== expectedRevision) return { ok:false, stale:true, revision:actualRevision };
-  const clean = checkedDocument(document), next = { storageVersion:STORAGE_VERSION, revision:actualRevision + 1, savedAt:now, document:clean };
+export function saveDraft(
+  document,
+  expectedRevision,
+  storage = localStorage,
+  now = Date.now(),
+) {
+  const current = readDraft(storage),
+    actualRevision = current?.revision ?? 0;
+  if (actualRevision !== expectedRevision)
+    return { ok: false, stale: true, revision: actualRevision };
+  const clean = checkedDocument(document),
+    next = {
+      storageVersion: STORAGE_VERSION,
+      revision: actualRevision + 1,
+      savedAt: now,
+      document: clean,
+    };
   // Do not rotate recovery until after the stale-tab check above.
   if (current) storage.setItem(STORAGE_KEYS.recovery, JSON.stringify(current));
   storage.setItem(STORAGE_KEYS.draft, JSON.stringify(next));
-  return { ok:true, stale:false, revision:next.revision, record:next };
+  return { ok: true, stale: false, revision: next.revision, record: next };
 }
 
 export function readRecovery(storage = localStorage) {
   const record = parse(storage.getItem(STORAGE_KEYS.recovery));
   if (!validRecord(record)) return null;
-  try { return { ...record, document:checkedDocument(record.document) }; } catch { return null; }
+  try {
+    return { ...record, document: checkedDocument(record.document) };
+  } catch {
+    return null;
+  }
 }
 
 export function listVersions(storage = localStorage) {
   const records = parse(storage.getItem(STORAGE_KEYS.versions));
   if (!Array.isArray(records)) return [];
-  return records.filter(validRecord).flatMap(record => { try { return [{ ...record, document:checkedDocument(record.document) }]; } catch { return []; } }).slice(0, VERSION_LIMIT);
+  return records
+    .filter(validRecord)
+    .flatMap((record) => {
+      try {
+        return [{ ...record, document: checkedDocument(record.document) }];
+      } catch {
+        return [];
+      }
+    })
+    .slice(0, VERSION_LIMIT);
 }
 
-export function saveVersion(document, label, storage = localStorage, now = Date.now()) {
-  const record = { storageVersion:STORAGE_VERSION, revision:0, id:`version-${now}-${Math.random().toString(36).slice(2)}`, savedAt:now, label:String(label || '').trim() || 'Saved version', document:checkedDocument(document) };
+export function saveVersion(
+  document,
+  label,
+  storage = localStorage,
+  now = Date.now(),
+) {
+  const record = {
+    storageVersion: STORAGE_VERSION,
+    revision: 0,
+    id: `version-${now}-${Math.random().toString(36).slice(2)}`,
+    savedAt: now,
+    label: String(label || '').trim() || 'Saved version',
+    document: checkedDocument(document),
+  };
   const versions = [record, ...listVersions(storage)].slice(0, VERSION_LIMIT);
   storage.setItem(STORAGE_KEYS.versions, JSON.stringify(versions));
   return record;
@@ -46,25 +102,73 @@ export function saveVersion(document, label, storage = localStorage, now = Date.
 export function nextAvailableVersion(currentVersion, versions = []) {
   const current = String(currentVersion || '').trim();
   const match = current.match(/^(.*?)(\d+)([^\d]*)$/);
-  const prefix = match?.[1] ?? 'v', suffix = match?.[3] ?? '';
-  const candidates = [current, ...versions.map(version => version?.document?.meta?.version)];
-  const numbers = candidates.flatMap(value => {
-    const candidate = String(value || '').trim().match(/^(.*?)(\d+)([^\d]*)$/);
-    return candidate && candidate[1] === prefix && candidate[3] === suffix ? [Number(candidate[2])] : [];
+  const prefix = match?.[1] ?? 'v',
+    suffix = match?.[3] ?? '';
+  const candidates = [
+    current,
+    ...versions.map((version) => version?.document?.meta?.version),
+  ];
+  const numbers = candidates.flatMap((value) => {
+    const candidate = String(value || '')
+      .trim()
+      .match(/^(.*?)(\d+)([^\d]*)$/);
+    return candidate && candidate[1] === prefix && candidate[3] === suffix
+      ? [Number(candidate[2])]
+      : [];
   });
   return `${prefix}${Math.max(0, ...numbers) + 1}${suffix}`;
 }
 
 export function deleteVersion(id, storage = localStorage) {
-  storage.setItem(STORAGE_KEYS.versions, JSON.stringify(listVersions(storage).filter(version => version.id !== id)));
+  storage.setItem(
+    STORAGE_KEYS.versions,
+    JSON.stringify(
+      listVersions(storage).filter((version) => version.id !== id),
+    ),
+  );
 }
 
-const toBase64 = text => { const bytes = new TextEncoder().encode(text); let binary=''; bytes.forEach(byte => binary += String.fromCharCode(byte)); return btoa(binary).replace(/\+/g,'-').replace(/\//g,'_').replace(/=+$/,''); };
-const fromBase64 = value => { const base64=value.replace(/-/g,'+').replace(/_/g,'/'); const binary=atob(base64 + '='.repeat((4-base64.length%4)%4)); return new TextDecoder().decode(Uint8Array.from(binary, char => char.charCodeAt(0))); };
-export function encodeSnapshot(document) { return toBase64(JSON.stringify({ snapshotVersion:1, document:checkedDocument(document) })); }
-export function decodeSnapshot(value) {
-  try { const envelope=JSON.parse(fromBase64(value)); if (envelope?.snapshotVersion !== 1) throw Error('Unsupported snapshot version'); return checkedDocument(envelope.document); }
-  catch (error) { throw Error(`Invalid UBTA snapshot: ${error.message}`); }
+const toBase64 = (text) => {
+  const bytes = new TextEncoder().encode(text);
+  let binary = '';
+  bytes.forEach((byte) => (binary += String.fromCharCode(byte)));
+  return btoa(binary)
+    .replace(/\+/g, '-')
+    .replace(/\//g, '_')
+    .replace(/=+$/, '');
+};
+const fromBase64 = (value) => {
+  const base64 = value.replace(/-/g, '+').replace(/_/g, '/');
+  const binary = atob(base64 + '='.repeat((4 - (base64.length % 4)) % 4));
+  return new TextDecoder().decode(
+    Uint8Array.from(binary, (char) => char.charCodeAt(0)),
+  );
+};
+export function encodeSnapshot(document) {
+  return toBase64(
+    JSON.stringify({ snapshotVersion: 1, document: checkedDocument(document) }),
+  );
 }
-export function snapshotFromLocation(location = globalThis.location) { const match=location.hash.match(/^#snapshot=([A-Za-z0-9_-]+)$/); return match ? decodeSnapshot(match[1]) : null; }
-export function updateSnapshotUrl(document, location = globalThis.location, browserHistory = globalThis.history) { const url=`${location.href.split('#')[0]}#snapshot=${encodeSnapshot(document)}`;browserHistory.replaceState(browserHistory.state,'',url);return url; }
+export function decodeSnapshot(value) {
+  try {
+    const envelope = JSON.parse(fromBase64(value));
+    if (envelope?.snapshotVersion !== 1)
+      throw Error('Unsupported snapshot version');
+    return checkedDocument(envelope.document);
+  } catch (error) {
+    throw Error(`Invalid UBTA snapshot: ${error.message}`);
+  }
+}
+export function snapshotFromLocation(location = globalThis.location) {
+  const match = location.hash.match(/^#snapshot=([A-Za-z0-9_-]+)$/);
+  return match ? decodeSnapshot(match[1]) : null;
+}
+export function updateSnapshotUrl(
+  document,
+  location = globalThis.location,
+  browserHistory = globalThis.history,
+) {
+  const url = `${location.href.split('#')[0]}#snapshot=${encodeSnapshot(document)}`;
+  browserHistory.replaceState(browserHistory.state, '', url);
+  return url;
+}

--- a/UBTA/src/state/schema.js
+++ b/UBTA/src/state/schema.js
@@ -1,34 +1,63 @@
 import { recalculateTableTotals, tableColumnFormat } from './table-model.js';
-import { normalizeImageWidth, validateImageInput, validateImageSource } from './image-model.js';
+import {
+  normalizeImageWidth,
+  validateImageInput,
+  validateImageSource,
+} from './image-model.js';
 import { normaliseExcel } from './excel-model.js';
 
 export const SCHEMA_VERSION = 6;
-export const METADATA_KEYS = ['clientName','projectTitle','documentType','date','version','subtitle','adviser','status'];
-export const DOCUMENT_STATUSES = ['Draft','For review','Final'];
+export const METADATA_KEYS = [
+  'clientName',
+  'projectTitle',
+  'documentType',
+  'date',
+  'version',
+  'subtitle',
+  'adviser',
+  'status',
+];
+export const DOCUMENT_STATUSES = ['Draft', 'For review', 'Final'];
 export const TABLE_WIDTH_MIN = 8;
 export const TABLE_WIDTH_MAX = 92;
 const IDENTIFIER = /^[A-Za-z][\w-]*$/;
 
-export const newId = prefix => `${prefix}-${globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)}`;
-const makeId = (value, prefix = 'id') => IDENTIFIER.test(value || '') ? value : newId(prefix);
+export const newId = (prefix) =>
+  `${prefix}-${globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)}`;
+const makeId = (value, prefix = 'id') =>
+  IDENTIFIER.test(value || '') ? value : newId(prefix);
 
-export const safeHref = value => typeof value === 'string' && /^(https?:\/\/|mailto:|#[A-Za-z][\w:.-]*$)/i.test(value) ? value : null;
-export const safeImageSrc = value => {
+export const safeHref = (value) =>
+  typeof value === 'string' &&
+  /^(https?:\/\/|mailto:|#[A-Za-z][\w:.-]*$)/i.test(value)
+    ? value
+    : null;
+export const safeImageSrc = (value) => {
   const result = validateImageSource(value);
   return result.ok ? result.url : null;
 };
 
 export function normaliseRuns(runs) {
-  return (Array.isArray(runs) ? runs : []).map(run => ({
-    text: String(run?.text ?? '').replace(/\r\n?/g, '\n'),
-    highlight: run?.highlight === true,
-    link: safeHref(run?.link?.href) ? { href: safeHref(run.link.href) } : null,
-  })).filter(run => run.text).reduce((out, run) => {
-    const last = out.at(-1);
-    if (last && last.highlight === run.highlight && last.link?.href === run.link?.href) last.text += run.text;
-    else out.push(run);
-    return out;
-  }, []);
+  return (Array.isArray(runs) ? runs : [])
+    .map((run) => ({
+      text: String(run?.text ?? '').replace(/\r\n?/g, '\n'),
+      highlight: run?.highlight === true,
+      link: safeHref(run?.link?.href)
+        ? { href: safeHref(run.link.href) }
+        : null,
+    }))
+    .filter((run) => run.text)
+    .reduce((out, run) => {
+      const last = out.at(-1);
+      if (
+        last &&
+        last.highlight === run.highlight &&
+        last.link?.href === run.link?.href
+      )
+        last.text += run.text;
+      else out.push(run);
+      return out;
+    }, []);
 }
 
 /** Redistribute widths without ever pushing a bounded column outside 8–92%. */
@@ -36,72 +65,348 @@ export function normaliseTableWidths(values, count = values?.length || 1) {
   count = Math.max(1, Math.min(8, Number(count) || 1));
   // More than twelve columns cannot total 100 at the declared minimum. The schema
   // caps tables at eight, but this defines deterministic behaviour for direct use.
-  if (count * TABLE_WIDTH_MIN > 100 || count * TABLE_WIDTH_MAX < 100) return Array(count).fill(100 / count);
+  if (count * TABLE_WIDTH_MIN > 100 || count * TABLE_WIDTH_MAX < 100)
+    return Array(count).fill(100 / count);
   const raw = Array.from({ length: count }, (_, i) => Number(values?.[i]));
-  let widths = raw.map(value => Number.isFinite(value) && value > 0 ? Math.min(TABLE_WIDTH_MAX, Math.max(TABLE_WIDTH_MIN, value)) : 100 / count);
+  let widths = raw.map((value) =>
+    Number.isFinite(value) && value > 0
+      ? Math.min(TABLE_WIDTH_MAX, Math.max(TABLE_WIDTH_MIN, value))
+      : 100 / count,
+  );
   for (let pass = 0; pass < 20; pass++) {
     const remainder = 100 - widths.reduce((a, b) => a + b, 0);
     if (Math.abs(remainder) < 1e-9) break;
-    const candidates = widths.map((width, i) => ({ i, capacity: remainder > 0 ? TABLE_WIDTH_MAX - width : width - TABLE_WIDTH_MIN })).filter(x => x.capacity > 1e-9);
+    const candidates = widths
+      .map((width, i) => ({
+        i,
+        capacity:
+          remainder > 0 ? TABLE_WIDTH_MAX - width : width - TABLE_WIDTH_MIN,
+      }))
+      .filter((x) => x.capacity > 1e-9);
     if (!candidates.length) break;
     const capacity = candidates.reduce((sum, x) => sum + x.capacity, 0);
-    candidates.forEach(x => { widths[x.i] += Math.sign(remainder) * Math.min(x.capacity, Math.abs(remainder) * x.capacity / capacity); });
+    candidates.forEach((x) => {
+      widths[x.i] +=
+        Math.sign(remainder) *
+        Math.min(x.capacity, (Math.abs(remainder) * x.capacity) / capacity);
+    });
   }
-  widths = widths.map(width => Math.round(width * 1000) / 1000);
-  let residue = Math.round((100 - widths.reduce((a, b) => a + b, 0)) * 1000) / 1000;
+  widths = widths.map((width) => Math.round(width * 1000) / 1000);
+  let residue =
+    Math.round((100 - widths.reduce((a, b) => a + b, 0)) * 1000) / 1000;
   for (const width of widths.map((value, i) => ({ value, i }))) {
-    const room = residue > 0 ? TABLE_WIDTH_MAX - width.value : width.value - TABLE_WIDTH_MIN;
+    const room =
+      residue > 0
+        ? TABLE_WIDTH_MAX - width.value
+        : width.value - TABLE_WIDTH_MIN;
     const amount = Math.sign(residue) * Math.min(Math.abs(residue), room);
-    widths[width.i] += amount; residue -= amount;
-    if (Math.abs(residue) < .0005) break;
+    widths[width.i] += amount;
+    residue -= amount;
+    if (Math.abs(residue) < 0.0005) break;
   }
   return widths;
 }
 
-const normaliseCell = (cell, prefix) => ({ id: makeId(cell?.id, prefix), runs: normaliseRuns(cell?.runs) });
+const normaliseCell = (cell, prefix) => ({
+  id: makeId(cell?.id, prefix),
+  runs: normaliseRuns(cell?.runs),
+});
 export function normaliseBlock(block) {
-  const allowed = ['heading', 'paragraph', 'bulletList', 'numberList', 'table', 'image'];
+  const allowed = [
+    'heading',
+    'paragraph',
+    'bulletList',
+    'numberList',
+    'table',
+    'image',
+  ];
   const type = allowed.includes(block?.type) ? block.type : 'paragraph';
   const output = { id: makeId(block?.id, 'block'), type };
-  if (type === 'heading') { output.level = Math.min(4, Math.max(1, Number(block.level) || 1)); output.runs = normaliseRuns(block.runs); }
-  else if (type === 'paragraph') output.runs = normaliseRuns(block.runs);
-  else if (type.endsWith('List')) output.items = (Array.isArray(block.items) && block.items.length ? block.items : [{ runs: [] }]).map(item => ({ id: makeId(item?.id, 'item'), level: Math.min(3, Math.max(1, Number(item?.level) || 1)), runs: normaliseRuns(item?.runs) }));
+  if (type === 'heading') {
+    output.level = Math.min(4, Math.max(1, Number(block.level) || 1));
+    output.runs = normaliseRuns(block.runs);
+  } else if (type === 'paragraph') output.runs = normaliseRuns(block.runs);
+  else if (type.endsWith('List'))
+    output.items = (
+      Array.isArray(block.items) && block.items.length
+        ? block.items
+        : [{ runs: [] }]
+    ).map((item) => ({
+      id: makeId(item?.id, 'item'),
+      level: Math.min(3, Math.max(1, Number(item?.level) || 1)),
+      runs: normaliseRuns(item?.runs),
+    }));
   else if (type === 'table') {
-    const source = Array.isArray(block.columns) ? block.columns.slice(0, 8) : [];
-    const count = Math.max(1, source.length || 2), widths = normaliseTableWidths(source.map(x => x?.width), count);
-    output.captionRuns = normaliseRuns(block.captionRuns || [{ text: block.caption ?? '' }]);
-    output.columns = Array.from({ length: count }, (_, i) => { const format=tableColumnFormat(source[i]); return { id: makeId(source[i]?.id, 'column'), headingRuns: normaliseRuns(source[i]?.headingRuns || [{ text: source[i]?.heading ?? `Column ${i + 1}` }]), width: widths[i], format, totalEnabled: format!=='text' && source[i]?.totalEnabled !== false }; });
-    output.rows = (Array.isArray(block.rows) ? block.rows : []).map((row, ri) => ({ id: makeId(row?.id, 'row'), isTotal: row?.isTotal === true, cells: output.columns.map((column, ci) => normaliseCell(row?.cells?.[ci], `${output.id}-${ri}-${column.id}`)) }));
+    const source = Array.isArray(block.columns)
+      ? block.columns.slice(0, 8)
+      : [];
+    const count = Math.max(1, source.length || 2),
+      widths = normaliseTableWidths(
+        source.map((x) => x?.width),
+        count,
+      );
+    output.captionRuns = normaliseRuns(
+      block.captionRuns || [{ text: block.caption ?? '' }],
+    );
+    output.columns = Array.from({ length: count }, (_, i) => {
+      const format = tableColumnFormat(source[i]);
+      return {
+        id: makeId(source[i]?.id, 'column'),
+        headingRuns: normaliseRuns(
+          source[i]?.headingRuns || [
+            { text: source[i]?.heading ?? `Column ${i + 1}` },
+          ],
+        ),
+        width: widths[i],
+        format,
+        totalEnabled: format !== 'text' && source[i]?.totalEnabled !== false,
+      };
+    });
+    output.rows = (Array.isArray(block.rows) ? block.rows : []).map(
+      (row, ri) => ({
+        id: makeId(row?.id, 'row'),
+        isTotal: row?.isTotal === true,
+        cells: output.columns.map((column, ci) =>
+          normaliseCell(row?.cells?.[ci], `${output.id}-${ri}-${column.id}`),
+        ),
+      }),
+    );
     recalculateTableTotals(output);
   } else {
-    output.src = safeImageSrc(block.src); output.alt = String(block.alt ?? ''); output.captionRuns = normaliseRuns(block.captionRuns || [{ text: block.caption ?? '' }]); output.width = normalizeImageWidth(block.width);
+    output.src = safeImageSrc(block.src);
+    output.alt = String(block.alt ?? '');
+    output.captionRuns = normaliseRuns(
+      block.captionRuns || [{ text: block.caption ?? '' }],
+    );
+    output.width = normalizeImageWidth(block.width);
   }
   return output;
 }
 
-const normaliseGroup = (group, prefix, ensureBlock = false) => ({ id: makeId(group?.id, prefix), title: String(group?.title ?? ''), summary: String(group?.summary ?? ''), blocks: (Array.isArray(group?.blocks) && group.blocks.length ? group.blocks : ensureBlock ? [{ id: newId('block'), type: 'paragraph', runs: [] }] : []).map(normaliseBlock) });
+const normaliseGroup = (group, prefix, ensureBlock = false) => ({
+  id: makeId(group?.id, prefix),
+  title: String(group?.title ?? ''),
+  summary: String(group?.summary ?? ''),
+  blocks: (Array.isArray(group?.blocks) && group.blocks.length
+    ? group.blocks
+    : ensureBlock
+      ? [{ id: newId('block'), type: 'paragraph', runs: [] }]
+      : []
+  ).map(normaliseBlock),
+});
 export function normaliseDocument(document) {
-  const meta = {}; for (const key of METADATA_KEYS) { const value=document?.meta?.[key];meta[key]=['string','number','boolean'].includes(typeof value)?String(value).trim():''; }
-  if(meta.date&&!/^\d{4}-\d{2}-\d{2}$/.test(meta.date))meta.date='';else if(meta.date){const [year,month,day]=meta.date.split('-').map(Number),date=new Date(Date.UTC(year,month-1,day));if(date.getUTCFullYear()!==year||date.getUTCMonth()!==month-1||date.getUTCDate()!==day)meta.date=''}
-  if(meta.status&&!DOCUMENT_STATUSES.includes(meta.status))meta.status='';
-  const steps = (Array.isArray(document?.steps) ? document.steps : []).map(x => normaliseGroup(x, 'step', true));
-  return { schemaVersion: SCHEMA_VERSION, meta, sections: (Array.isArray(document?.sections) ? document.sections : []).map(x => normaliseGroup(x, 'section')), steps, appendices: (Array.isArray(document?.appendices) ? document.appendices : []).map(x => normaliseGroup(x, 'appendix')), excel:normaliseExcel(document?.excel, steps) };
+  const meta = {};
+  for (const key of METADATA_KEYS) {
+    const value = document?.meta?.[key];
+    meta[key] = ['string', 'number', 'boolean'].includes(typeof value)
+      ? String(value).trim()
+      : '';
+  }
+  if (meta.date && !/^\d{4}-\d{2}-\d{2}$/.test(meta.date)) meta.date = '';
+  else if (meta.date) {
+    const [year, month, day] = meta.date.split('-').map(Number),
+      date = new Date(Date.UTC(year, month - 1, day));
+    if (
+      date.getUTCFullYear() !== year ||
+      date.getUTCMonth() !== month - 1 ||
+      date.getUTCDate() !== day
+    )
+      meta.date = '';
+  }
+  if (meta.status && !DOCUMENT_STATUSES.includes(meta.status)) meta.status = '';
+  const steps = (Array.isArray(document?.steps) ? document.steps : []).map(
+    (x) => normaliseGroup(x, 'step', true),
+  );
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    meta,
+    sections: (Array.isArray(document?.sections) ? document.sections : []).map(
+      (x) => normaliseGroup(x, 'section'),
+    ),
+    steps,
+    appendices: (Array.isArray(document?.appendices)
+      ? document.appendices
+      : []
+    ).map((x) => normaliseGroup(x, 'appendix')),
+    excel: normaliseExcel(document?.excel, steps),
+  };
 }
 
-export function *runContainers(group) {
+export function* runContainers(group) {
   for (const block of group?.blocks || []) {
     if (block.runs) yield { block, kind: 'block', runs: block.runs };
-    for (const item of block.items || []) yield { block, item, kind: 'listItem', runs: item.runs };
-    if (block.captionRuns) yield { block, kind: block.type === 'image' ? 'imageCaption' : 'tableCaption', runs: block.captionRuns };
-    for (const column of block.columns || []) yield { block, column, kind: 'tableHeading', runs: column.headingRuns };
-    for (const row of block.rows || []) for (const cell of row.cells || []) yield { block, row, cell, kind: 'tableCell', runs: cell.runs };
+    for (const item of block.items || [])
+      yield { block, item, kind: 'listItem', runs: item.runs };
+    if (block.captionRuns)
+      yield {
+        block,
+        kind: block.type === 'image' ? 'imageCaption' : 'tableCaption',
+        runs: block.captionRuns,
+      };
+    for (const column of block.columns || [])
+      yield { block, column, kind: 'tableHeading', runs: column.headingRuns };
+    for (const row of block.rows || [])
+      for (const cell of row.cells || [])
+        yield { block, row, cell, kind: 'tableCell', runs: cell.runs };
   }
 }
-export const hasReview = group => [...runContainers(group)].some(container => container.runs.some(run => run.highlight));
-export const stableAnchor = entity => `anchor-${entity.id}`;
-export function validateDocument(document) { if (![1,2,3,4,5,SCHEMA_VERSION].includes(document?.schemaVersion)) throw Error('Unsupported schema version'); for (const group of [...(document?.sections || []),...(document?.steps || []),...(document?.appendices || [])]) for (const block of group?.blocks || []) if (block?.type === 'image' && /^data:/i.test(block.src || '')) throw Error('Legacy embedded data-URL images are no longer supported; publish the image over HTTPS and replace its source'); const result = normaliseDocument(document); for (const group of [...result.sections,...result.steps,...result.appendices]) for (const block of group.blocks) if (block.type === 'image' && !validateImageInput({ source: block.src, altText: block.alt, width: block.width }).ok) throw Error('Images require a supported PNG, JPEG, GIF or WebP HTTPS source and alternative text'); return result; }
+export const hasReview = (group) =>
+  [...runContainers(group)].some((container) =>
+    container.runs.some((run) => run.highlight),
+  );
+export const stableAnchor = (entity) => `anchor-${entity.id}`;
+export function validateDocument(document) {
+  if (![1, 2, 3, 4, 5, SCHEMA_VERSION].includes(document?.schemaVersion))
+    throw Error('Unsupported schema version');
+  for (const group of [
+    ...(document?.sections || []),
+    ...(document?.steps || []),
+    ...(document?.appendices || []),
+  ])
+    for (const block of group?.blocks || [])
+      if (block?.type === 'image' && /^data:/i.test(block.src || ''))
+        throw Error(
+          'Legacy embedded data-URL images are no longer supported; publish the image over HTTPS and replace its source',
+        );
+  const result = normaliseDocument(document);
+  for (const group of [
+    ...result.sections,
+    ...result.steps,
+    ...result.appendices,
+  ])
+    for (const block of group.blocks)
+      if (
+        block.type === 'image' &&
+        !validateImageInput({
+          source: block.src,
+          altText: block.alt,
+          width: block.width,
+        }).ok
+      )
+        throw Error(
+          'Images require a supported PNG, JPEG, GIF or WebP HTTPS source and alternative text',
+        );
+  return result;
+}
 
-const eligibleText = step => [...runContainers(step)].filter(x => (x.kind === 'block' && x.block.type === 'paragraph') || ['listItem','tableCaption','imageCaption'].includes(x.kind)).map(x => x.runs.map(r => r.text).join('').trim()).find(Boolean) || '';
-export function transactionProposals(document) { return normaliseDocument(document).steps.map((step, index) => ({ id:`proposal-${step.id}`, stepId:step.id, title:`Step ${index+1}. ${step.title}`, anchor:stableAnchor(step), summary:step.summary.trim() || eligibleText(step) })); }
+const eligibleText = (step) =>
+  [...runContainers(step)]
+    .filter(
+      (x) =>
+        (x.kind === 'block' && x.block.type === 'paragraph') ||
+        ['listItem', 'tableCaption', 'imageCaption'].includes(x.kind),
+    )
+    .map((x) =>
+      x.runs
+        .map((r) => r.text)
+        .join('')
+        .trim(),
+    )
+    .find(Boolean) || '';
+export function transactionProposals(document) {
+  return normaliseDocument(document).steps.map((step, index) => ({
+    id: `proposal-${step.id}`,
+    stepId: step.id,
+    title: `Step ${index + 1}. ${step.title}`,
+    anchor: stableAnchor(step),
+    summary: step.summary.trim() || eligibleText(step),
+  }));
+}
 
-export const seedDocument = normaliseDocument({ schemaVersion: SCHEMA_VERSION, meta:{clientName:'Example Client Ltd',projectTitle:'Corporate Restructure',documentType:'Steps Plan',subtitle:'Detailed Steps Plan',date:'2026-07-25',version:'v1',adviser:'UBTA Accountants Ltd',status:'Draft'}, sections:[{id:'scope',title:'Scope of works',blocks:[{id:'scope-h',type:'heading',level:2,runs:[{text:'Purpose and scope'}]},{id:'scope-p1',type:'paragraph',runs:[{text:'This plan outlines the principal implementation steps for a proposed corporate restructure.'}]}]}], steps:[{id:'share-restructure',title:'Implement the corporate share restructure',blocks:[{id:'step-h',type:'heading',level:2,runs:[{text:'Implementation'}]},{id:'step-p1',type:'paragraph',runs:[{text:'The directors will approve the proposed corporate restructure and authorise the required documentation.'}]},{id:'step-list',type:'numberList',items:[{id:'st1',level:1,runs:[{text:'Prepare board minutes and resolutions.'}]}]},{id:'consideration',type:'table',caption:'Illustrative consideration',columns:[{id:'detail',heading:'Detail',width:70,format:'text'},{id:'amount',heading:'Amount (£)',width:30,format:'gbp'}],rows:[{id:'ordinary-shares',cells:[{runs:[{text:'Ordinary shares'}]},{runs:[{text:'10,000'}]}]},{id:'total',isTotal:true,cells:[{runs:[{text:'Total'}]},{runs:[{text:'10,000'}]}]}]}]}], appendices:[] });
+export const seedDocument = normaliseDocument({
+  schemaVersion: SCHEMA_VERSION,
+  meta: {
+    clientName: 'Example Client Ltd',
+    projectTitle: 'Corporate Restructure',
+    documentType: 'Steps Plan',
+    subtitle: 'Detailed Steps Plan',
+    date: '2026-07-25',
+    version: 'v1',
+    adviser: 'UBTA Accountants Ltd',
+    status: 'Draft',
+  },
+  sections: [
+    {
+      id: 'scope',
+      title: 'Scope of works',
+      blocks: [
+        {
+          id: 'scope-h',
+          type: 'heading',
+          level: 2,
+          runs: [{ text: 'Purpose and scope' }],
+        },
+        {
+          id: 'scope-p1',
+          type: 'paragraph',
+          runs: [
+            {
+              text: 'This plan outlines the principal implementation steps for a proposed corporate restructure.',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  steps: [
+    {
+      id: 'share-restructure',
+      title: 'Implement the corporate share restructure',
+      blocks: [
+        {
+          id: 'step-h',
+          type: 'heading',
+          level: 2,
+          runs: [{ text: 'Implementation' }],
+        },
+        {
+          id: 'step-p1',
+          type: 'paragraph',
+          runs: [
+            {
+              text: 'The directors will approve the proposed corporate restructure and authorise the required documentation.',
+            },
+          ],
+        },
+        {
+          id: 'step-list',
+          type: 'numberList',
+          items: [
+            {
+              id: 'st1',
+              level: 1,
+              runs: [{ text: 'Prepare board minutes and resolutions.' }],
+            },
+          ],
+        },
+        {
+          id: 'consideration',
+          type: 'table',
+          caption: 'Illustrative consideration',
+          columns: [
+            { id: 'detail', heading: 'Detail', width: 70, format: 'text' },
+            { id: 'amount', heading: 'Amount (£)', width: 30, format: 'gbp' },
+          ],
+          rows: [
+            {
+              id: 'ordinary-shares',
+              cells: [
+                { runs: [{ text: 'Ordinary shares' }] },
+                { runs: [{ text: '10,000' }] },
+              ],
+            },
+            {
+              id: 'total',
+              isTotal: true,
+              cells: [
+                { runs: [{ text: 'Total' }] },
+                { runs: [{ text: '10,000' }] },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  appendices: [],
+});

--- a/UBTA/src/state/table-model.js
+++ b/UBTA/src/state/table-model.js
@@ -1,23 +1,35 @@
 const FORMATS = new Set(['text', 'number', 'gbp']);
-const runsText = runs => (runs || []).map(run => run.text || '').join('');
-const plainRuns = text => text === '' ? [] : [{ text, highlight: false, link: null }];
+const runsText = (runs) => (runs || []).map((run) => run.text || '').join('');
+const plainRuns = (text) =>
+  text === '' ? [] : [{ text, highlight: false, link: null }];
 
-export const tableColumnFormat = column => FORMATS.has(column?.format) ? column.format : column?.numeric === true ? 'number' : 'text';
+export const tableColumnFormat = (column) =>
+  FORMATS.has(column?.format)
+    ? column.format
+    : column?.numeric === true
+      ? 'number'
+      : 'text';
 
 /** Blank and invalid values return null; arbitrary text is never coerced to zero. */
 export function parseTableNumber(value) {
   const compact = String(value ?? '').replace(/\s/g, '');
   if (!compact) return null;
-  const match = compact.match(/^(?:£)?([+-]?)(?:£)?((?:\d{1,3}(?:,\d{3})+)|\d+)(\.\d+)?$/);
+  const match = compact.match(
+    /^(?:£)?([+-]?)(?:£)?((?:\d{1,3}(?:,\d{3})+)|\d+)(\.\d+)?$/,
+  );
   if (!match) return null;
-  const number = Number(`${match[1]}${match[2].replaceAll(',', '')}${match[3] || ''}`);
+  const number = Number(
+    `${match[1]}${match[2].replaceAll(',', '')}${match[3] || ''}`,
+  );
   return Number.isFinite(number) ? number : null;
 }
 
 export function formatTableNumber(value, format = 'number') {
   if (!Number.isFinite(value)) return '';
-  if (format === 'gbp') return `${value < 0 ? '-' : ''}£${Math.abs(value).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
-  if (format === 'number') return value.toLocaleString('en-GB', { maximumFractionDigits: 20 });
+  if (format === 'gbp')
+    return `${value < 0 ? '-' : ''}£${Math.abs(value).toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`;
+  if (format === 'number')
+    return value.toLocaleString('en-GB', { maximumFractionDigits: 20 });
   return String(value);
 }
 
@@ -28,26 +40,57 @@ export function recalculateTableTotals(block) {
     block.columns.forEach((column, columnIndex) => {
       const format = tableColumnFormat(column);
       if (format === 'text') return;
-      if (column.totalEnabled === false) { if (row.cells?.[columnIndex]) row.cells[columnIndex].runs=[]; return; }
-      const values = block.rows.slice(0, rowIndex).filter(candidate => !candidate.isTotal).map(candidate => parseTableNumber(runsText(candidate.cells?.[columnIndex]?.runs))).filter(value => value !== null);
+      if (column.totalEnabled === false) {
+        if (row.cells?.[columnIndex]) row.cells[columnIndex].runs = [];
+        return;
+      }
+      const values = block.rows
+        .slice(0, rowIndex)
+        .filter((candidate) => !candidate.isTotal)
+        .map((candidate) =>
+          parseTableNumber(runsText(candidate.cells?.[columnIndex]?.runs)),
+        )
+        .filter((value) => value !== null);
       const total = values.reduce((sum, value) => sum + value, 0);
-      if (row.cells?.[columnIndex]) row.cells[columnIndex].runs = plainRuns(formatTableNumber(total, format));
+      if (row.cells?.[columnIndex])
+        row.cells[columnIndex].runs = plainRuns(
+          formatTableNumber(total, format),
+        );
     });
   });
   return block;
 }
 
 export function moveTableRow(block, index, offset) {
-  const target = index + offset, row = block?.rows?.[index];
-  if (!row || target < 0 || target >= block.rows.length || block.rows[target].isTotal !== row.isTotal) return false;
-  [block.rows[index], block.rows[target]] = [block.rows[target], block.rows[index]];
+  const target = index + offset,
+    row = block?.rows?.[index];
+  if (
+    !row ||
+    target < 0 ||
+    target >= block.rows.length ||
+    block.rows[target].isTotal !== row.isTotal
+  )
+    return false;
+  [block.rows[index], block.rows[target]] = [
+    block.rows[target],
+    block.rows[index],
+  ];
   return target;
 }
 
 export function moveTableColumn(block, index, offset) {
   const target = index + offset;
-  if (!block?.columns?.[index] || target < 0 || target >= block.columns.length) return false;
-  [block.columns[index], block.columns[target]] = [block.columns[target], block.columns[index]];
-  block.rows.forEach(row => { [row.cells[index], row.cells[target]] = [row.cells[target], row.cells[index]]; });
+  if (!block?.columns?.[index] || target < 0 || target >= block.columns.length)
+    return false;
+  [block.columns[index], block.columns[target]] = [
+    block.columns[target],
+    block.columns[index],
+  ];
+  block.rows.forEach((row) => {
+    [row.cells[index], row.cells[target]] = [
+      row.cells[target],
+      row.cells[index],
+    ];
+  });
   return target;
 }

--- a/UBTA/src/vendor/paged.js
+++ b/UBTA/src/vendor/paged.js
@@ -21,7 +21,8 @@
     const body = sheet.querySelector('.document-body');
     if (!body) return false;
     const style = getComputedStyle(sheet);
-    const limit = sheet.getBoundingClientRect().bottom - parseFloat(style.paddingBottom);
+    const limit =
+      sheet.getBoundingClientRect().bottom - parseFloat(style.paddingBottom);
     return body.getBoundingClientRect().bottom > limit + 0.5;
   }
 
@@ -29,18 +30,23 @@
     const sheet = document.createElement(source.tagName);
     sheet.className = source.className;
     sheet.tabIndex = -1;
-    for (const [key, value] of Object.entries(source.dataset)) sheet.dataset[key] = value;
+    for (const [key, value] of Object.entries(source.dataset))
+      sheet.dataset[key] = value;
     if (!continuation && source.id) sheet.id = source.id;
     else if (source.id) sheet.dataset.anchorId = source.id;
     const header = source.querySelector(':scope > .page-header');
     if (header) sheet.append(header.cloneNode(true));
-    const heading = source.querySelector(':scope > .step-heading, :scope > .section-title');
+    const heading = source.querySelector(
+      ':scope > .step-heading, :scope > .section-title',
+    );
     if (heading) {
       if (!continuation) sheet.append(heading.cloneNode(true));
       else {
         const continued = document.createElement('div');
         continued.className = 'continuation-heading';
-        const title = heading.querySelector('.step-title')?.value || heading.textContent.trim();
+        const title =
+          heading.querySelector('.step-title')?.value ||
+          heading.textContent.trim();
         continued.textContent = `${title} — continued`;
         sheet.append(continued);
       }
@@ -52,7 +58,10 @@
   }
 
   function textLength(root) {
-    return [...root.querySelectorAll('[contenteditable=true]')].reduce((n, el) => n + el.textContent.length, 0);
+    return [...root.querySelectorAll('[contenteditable=true]')].reduce(
+      (n, el) => n + el.textContent.length,
+      0,
+    );
   }
 
   function textBoundary(root, offset) {
@@ -79,18 +88,28 @@
     const original = editable.cloneNode(true);
     const text = original.textContent;
     if (text.length < 2) return null;
-    let low = 1, high = text.length - 1, best = 0;
+    let low = 1,
+      high = text.length - 1,
+      best = 0;
     while (low <= high) {
       const middle = (low + high) >> 1;
       editable.replaceChildren(richTextSlice(original, 0, middle));
-      if (fit()) { best = middle; low = middle + 1; } else high = middle - 1;
+      if (fit()) {
+        best = middle;
+        low = middle + 1;
+      } else high = middle - 1;
     }
-    if (!best) { editable.replaceChildren(...original.cloneNode(true).childNodes); return null; }
+    if (!best) {
+      editable.replaceChildren(...original.cloneNode(true).childNodes);
+      return null;
+    }
     const breakAt = text.lastIndexOf(' ', best);
     best = breakAt > best / 2 ? breakAt + 1 : best;
     editable.replaceChildren(richTextSlice(original, 0, best));
     const rest = block.cloneNode(true);
-    rest.querySelector('[contenteditable=true]').replaceChildren(richTextSlice(original, best, text.length));
+    rest
+      .querySelector('[contenteditable=true]')
+      .replaceChildren(richTextSlice(original, best, text.length));
     block.dataset.fragmentPart = 'true';
     rest.dataset.fragmentPart = 'true';
     return rest;
@@ -104,11 +123,14 @@
     let keep = items.length;
     while (keep > 1 && !fit()) items[--keep].remove();
     if (!fit()) {
-      list.replaceChildren(...rest.querySelector(':scope > ol, :scope > ul').cloneNode(true).children);
+      list.replaceChildren(
+        ...rest.querySelector(':scope > ol, :scope > ul').cloneNode(true)
+          .children,
+      );
       return null;
     }
     const restList = rest.querySelector(':scope > ol, :scope > ul');
-    [...restList.children].slice(0, keep).forEach(el => el.remove());
+    [...restList.children].slice(0, keep).forEach((el) => el.remove());
     block.querySelector(':scope > .list-trailing-hit-area')?.remove();
     block.dataset.fragmentPart = rest.dataset.fragmentPart = 'true';
     return rest;
@@ -122,10 +144,14 @@
     while (keep > 1 && !fit()) rows[--keep].remove();
     if (!fit()) {
       const sourceBody = rest.querySelector('tbody');
-      block.querySelector('tbody').replaceChildren(...sourceBody.cloneNode(true).children);
+      block
+        .querySelector('tbody')
+        .replaceChildren(...sourceBody.cloneNode(true).children);
       return null;
     }
-    [...rest.querySelectorAll('tbody > tr')].slice(0, keep).forEach(el => el.remove());
+    [...rest.querySelectorAll('tbody > tr')]
+      .slice(0, keep)
+      .forEach((el) => el.remove());
     block.dataset.fragmentPart = rest.dataset.fragmentPart = 'true';
     return rest;
   }
@@ -138,14 +164,18 @@
   }
 
   function fragmentGroup(source, target) {
-    const blocks = [...source.querySelectorAll(':scope > .document-body > .editable-block')].map(x => x.cloneNode(true));
+    const blocks = [
+      ...source.querySelectorAll(':scope > .document-body > .editable-block'),
+    ].map((x) => x.cloneNode(true));
     let fragment = 0;
     let sheet = cloneShell(source, false);
     let page = pageFor(sheet, target);
     const decorate = () => {
       page.dataset.pageFragment = String(fragment);
       page.dataset.groupId = source.dataset.editableGroupId || '';
-      page.dataset.groupType = source.dataset.groupType || (source.classList.contains('section') ? 'section' : '');
+      page.dataset.groupType =
+        source.dataset.groupType ||
+        (source.classList.contains('section') ? 'section' : '');
       page.dataset.anchorId = source.id || '';
       sheet.dataset.fragmentIndex = String(fragment);
     };
@@ -164,7 +194,11 @@
       if (!overflows(sheet)) continue;
       const hadPrevious = body.children.length > 1;
       if (hadPrevious) {
-        const heading = block.matches('[data-type="paragraph"]') && block.previousElementSibling?.matches('[data-type="heading"]') ? block.previousElementSibling : null;
+        const heading =
+          block.matches('[data-type="paragraph"]') &&
+          block.previousElementSibling?.matches('[data-type="heading"]')
+            ? block.previousElementSibling
+            : null;
         block.remove();
         heading?.remove();
         body = nextPage();
@@ -174,7 +208,8 @@
       if (overflows(sheet)) {
         const rest = fragmentBlock(block, sheet);
         if (rest) blocks.splice(index + 1, 0, rest);
-        else if (block.classList.contains('image-block')) block.classList.add('fit-page');
+        else if (block.classList.contains('image-block'))
+          block.classList.add('fit-page');
       }
     }
   }
@@ -188,7 +223,8 @@
         document.body.append(target);
       }
       for (const source of [...content.children]) {
-        if (source.querySelector(':scope > .document-body')) fragmentGroup(source, target);
+        if (source.querySelector(':scope > .document-body'))
+          fragmentGroup(source, target);
         else pageFor(source.cloneNode(true), target);
       }
       target.classList.remove('pagination-staging');
@@ -198,4 +234,4 @@
   }
 
   window.Paged = { Previewer };
-}());
+})();

--- a/UBTA/tests/build.test.js
+++ b/UBTA/tests/build.test.js
@@ -7,30 +7,39 @@ import { execFileSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 
 const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const compactCss = (css) => css
-  .replace(/\n\s*/g, ' ')
-  .replace(/\s*!important/g, '!important')
-  .replace(/\s*([{}:;,>])\s*/g, '$1')
-  .replace(/;}\s*/g, '}');
+const compactCss = (css) =>
+  css
+    .replace(/\n\s*/g, ' ')
+    .replace(/\s*!important/g, '!important')
+    .replace(/\s*([{}:;,>])\s*/g, '$1')
+    .replace(/;}\s*/g, '}');
 
 test('production bundle includes the blank-space insertion helper before its caller', () => {
   execFileSync(process.execPath, ['scripts/build.mjs'], { cwd: root });
   const html = fs.readFileSync(path.join(root, 'dist/index.html'), 'utf8');
   const definition = html.indexOf('function insertionContextFromPoint(');
-  const caller = html.indexOf('insertionContextFromPoint(group.id');
+  const caller = html.search(/insertionContextFromPoint\(\s*group\.id/);
 
   assert.notEqual(definition, -1, 'insertionContextFromPoint must be bundled');
-  assert.ok(caller > definition, 'the helper must be defined before blankStepClick uses it');
+  assert.ok(
+    caller > definition,
+    'the helper must be defined before blankStepClick uses it',
+  );
 });
 
 test('production bundle includes the editable-link click helper before its caller', () => {
   execFileSync(process.execPath, ['scripts/build.mjs'], { cwd: root });
   const html = fs.readFileSync(path.join(root, 'dist/index.html'), 'utf8');
   const definition = html.indexOf('function handleEditableLinkClick(');
-  const caller = html.indexOf('handleEditableLinkClick(event,openEditorLink)');
+  const caller = html.search(
+    /handleEditableLinkClick\(event,\s*openEditorLink\)/,
+  );
 
   assert.notEqual(definition, -1, 'handleEditableLinkClick must be bundled');
-  assert.ok(caller > definition, 'the helper must be defined before editableLinkClick uses it');
+  assert.ok(
+    caller > definition,
+    'the helper must be defined before editableLinkClick uses it',
+  );
 });
 
 test('production bundle defines navigation history before creating it', () => {
@@ -40,17 +49,23 @@ test('production bundle defines navigation history before creating it', () => {
   const construction = html.indexOf('new NavigationHistory()');
 
   assert.notEqual(definition, -1, 'NavigationHistory must be bundled');
-  assert.ok(construction > definition, 'NavigationHistory must be defined before it is constructed');
+  assert.ok(
+    construction > definition,
+    'NavigationHistory must be defined before it is constructed',
+  );
 });
 
 test('production bundle defines Excel normalisation before document initialisation', () => {
   execFileSync(process.execPath, ['scripts/build.mjs'], { cwd: root });
   const html = fs.readFileSync(path.join(root, 'dist/index.html'), 'utf8');
   const definition = html.indexOf('function normaliseExcel(');
-  const documentNormalisation = html.indexOf('excel:normaliseExcel(');
+  const documentNormalisation = html.search(/excel:\s*normaliseExcel\(/);
 
   assert.notEqual(definition, -1, 'normaliseExcel must be bundled');
-  assert.ok(documentNormalisation > definition, 'normaliseExcel must be defined before normaliseDocument uses it');
+  assert.ok(
+    documentNormalisation > definition,
+    'normaliseExcel must be defined before normaliseDocument uses it',
+  );
 });
 
 test('production bundle defines ExcelEditor before creating it', () => {
@@ -60,15 +75,18 @@ test('production bundle defines ExcelEditor before creating it', () => {
   const construction = html.indexOf('new ExcelEditor(');
 
   assert.notEqual(definition, -1, 'ExcelEditor must be bundled');
-  assert.ok(construction > definition, 'ExcelEditor must be defined before it is constructed');
+  assert.ok(
+    construction > definition,
+    'ExcelEditor must be defined before it is constructed',
+  );
 });
 
 test('Excel Shares keeps the main toolbar and hides the Steps Plan preview', () => {
   const source = fs.readFileSync(path.join(root, 'src/main.js'), 'utf8');
   const css = fs.readFileSync(path.join(root, 'src/styles/app.css'), 'utf8');
 
-  assert.match(source, /\$\('#preview'\)\.hidden=excel/);
-  assert.doesNotMatch(source, /\$\('#steps-toolbar'\)\.hidden=excel/);
+  assert.match(source, /\$\('#preview'\)\.hidden\s*=\s*excel/);
+  assert.doesNotMatch(source, /\$\('#steps-toolbar'\)\.hidden\s*=\s*excel/);
   assert.match(compactCss(css), /#preview\[hidden\]\{display:none!important\}/);
 });
 
@@ -79,16 +97,27 @@ test('production bundle contains valid JavaScript and resolves table re-exports'
   const source = scripts.at(-1)?.[1];
 
   assert.ok(source, 'the production bundle must contain an inline script');
-  assert.doesNotMatch(source, /\}\s+from\s+['"]\.\/table-values\.js['"]/, 're-export syntax must not be partially stripped');
-  assert.ok(source.indexOf('function parseTableNumber(') < source.indexOf('parseTableNumber(value)'), 'table helpers must be bundled before their callers');
-  assert.doesNotThrow(() => new vm.Script(source), 'the production bundle must parse as classic JavaScript');
+  assert.doesNotMatch(
+    source,
+    /\}\s+from\s+['"]\.\/table-values\.js['"]/,
+    're-export syntax must not be partially stripped',
+  );
+  assert.ok(
+    source.indexOf('function parseTableNumber(') <
+      source.indexOf('parseTableNumber(value)'),
+    'table helpers must be bundled before their callers',
+  );
+  assert.doesNotThrow(
+    () => new vm.Script(source),
+    'the production bundle must parse as classic JavaScript',
+  );
 });
 
 test('standalone template unlock has embedded ciphertext and performs no runtime fetch', () => {
   execFileSync(process.execPath, ['scripts/build.mjs'], { cwd: root });
   const html = fs.readFileSync(path.join(root, 'dist/index.html'), 'utf8');
-  assert.match(html, /const defaultTemplateEnvelope=/);
-  assert.match(html, /ciphertext:'VgziFV2P5dlF/);
+  assert.match(html, /const defaultTemplateEnvelope\s*=/);
+  assert.match(html, /ciphertext:\s*'VgziFV2P5dlF/);
   assert.doesNotMatch(html, /fetch\(['"]\.\.\/\.\.\/encrypted-files/);
 });
 
@@ -100,31 +129,60 @@ test('standalone build contains the complete print feature', () => {
   assert.match(html, /window\.print\(\)/);
   assert.match(html, /Print preparation failed:/);
   assert.match(html, /@media print/);
-  assert.match(compactCss(html), /width:297mm!important;height:210mm!important/);
+  assert.match(
+    compactCss(html),
+    /width:297mm!important;height:210mm!important/,
+  );
   assert.match(compactCss(html), /\.pagedjs_page:last-child\{break-after:auto/);
   assert.match(compactCss(html), /\.step-title-print\{display:none/);
 });
 
 test('heading titles use exactly one normal-flow representation in screen and print', () => {
-  const css = compactCss(fs.readFileSync(path.join(root, 'src/styles/document.css'), 'utf8'));
+  const css = compactCss(
+    fs.readFileSync(path.join(root, 'src/styles/document.css'), 'utf8'),
+  );
   assert.match(css, /\.step-heading\{display:block\}/);
   assert.match(css, /\.step-title-print\{display:none;/);
-  assert.match(css, /\.step-heading>\.step-title\{display:block;position:static\}/);
-  assert.doesNotMatch(css, /\.step-heading>\.step-title\{[^}]*position:absolute/);
+  assert.match(
+    css,
+    /\.step-heading>\.step-title\{display:block;position:static\}/,
+  );
+  assert.doesNotMatch(
+    css,
+    /\.step-heading>\.step-title\{[^}]*position:absolute/,
+  );
   assert.doesNotMatch(css, /\.step-heading>\.step-title\{[^}]*bottom:/);
-  assert.match(css, /@media print\{[\s\S]*\.step-title\{display:none!important\}[\s\S]*\.step-title-print\{display:block\}/);
+  assert.match(
+    css,
+    /@media print\{[\s\S]*\.step-title\{display:none!important\}[\s\S]*\.step-title-print\{display:block\}/,
+  );
   assert.match(css, /white-space:normal;overflow-wrap:anywhere/);
-  assert.match(css, /\.sheet-source:is\(\.step,\.appendix\)\.is-selected \.step-heading\{border-left:0;padding-left:0\}/);
+  assert.match(
+    css,
+    /\.sheet-source:is\(\.step,\.appendix\)\.is-selected \.step-heading\{border-left:0;padding-left:0\}/,
+  );
 });
 
 test('A4 print wrappers override responsive preview scaling consistently', () => {
   const css = fs.readFileSync(path.join(root, 'src/styles/app.css'), 'utf8');
   const print = compactCss(css.slice(css.indexOf('@media print')));
   assert.match(print, /@page\{size:A4 landscape;margin:0\}/);
-  assert.match(print, /html,body\{width:297mm!important;min-width:297mm!important[^}]*zoom:1!important;transform:none!important/);
-  assert.match(print, /#preview \.pagedjs_pagebox,#preview \.sheet-source\{width:297mm!important;height:210mm!important/);
-  assert.match(print, /\.pagedjs_pages\{display:block!important;width:297mm!important[^}]*zoom:1!important;transform:none!important/);
-  assert.match(print, /#preview \.pagedjs_page:last-child\{break-after:auto;page-break-after:auto\}/);
+  assert.match(
+    print,
+    /html,body\{width:297mm!important;min-width:297mm!important[^}]*zoom:1!important;transform:none!important/,
+  );
+  assert.match(
+    print,
+    /#preview \.pagedjs_pagebox,#preview \.sheet-source\{width:297mm!important;height:210mm!important/,
+  );
+  assert.match(
+    print,
+    /\.pagedjs_pages\{display:block!important;width:297mm!important[^}]*zoom:1!important;transform:none!important/,
+  );
+  assert.match(
+    print,
+    /#preview \.pagedjs_page:last-child\{break-after:auto;page-break-after:auto\}/,
+  );
 });
 
 test('source and standalone toolbars omit global insertion controls but retain contextual insertion', () => {
@@ -132,17 +190,57 @@ test('source and standalone toolbars omit global insertion controls but retain c
   execFileSync(process.execPath, ['scripts/build.mjs'], { cwd: root });
   const built = fs.readFileSync(path.join(root, 'dist/index.html'), 'utf8');
 
-  for (const [name, html] of [['source', source], ['standalone build', built]]) {
-    assert.doesNotMatch(html, /class="[^"]*insert-group/, `${name} must not render the Insert toolbar group`);
-    for (const command of ['addParagraph', 'addHeading', 'addBulletList', 'addNumberList', 'addTable', 'addImage']) {
-      assert.doesNotMatch(html, new RegExp(`<button[^>]+data-command="${command}"[^>]*data-requires-group`), `${name} must not render the ${command} toolbar button`);
+  for (const [name, html] of [
+    ['source', source],
+    ['standalone build', built],
+  ]) {
+    assert.doesNotMatch(
+      html,
+      /class="[^"]*insert-group/,
+      `${name} must not render the Insert toolbar group`,
+    );
+    for (const command of [
+      'addParagraph',
+      'addHeading',
+      'addBulletList',
+      'addNumberList',
+      'addTable',
+      'addImage',
+    ]) {
+      assert.doesNotMatch(
+        html,
+        new RegExp(
+          `<button[^>]+data-command="${command}"[^>]*data-requires-group`,
+        ),
+        `${name} must not render the ${command} toolbar button`,
+      );
     }
-    assert.match(html, /<dialog\s+id="insertion-chooser"/, `${name} must retain the contextual insertion chooser`);
+    assert.match(
+      html,
+      /<dialog\s+id="insertion-chooser"/,
+      `${name} must retain the contextual insertion chooser`,
+    );
     for (const group of ['document', 'text', 'step', 'appendix', 'table']) {
-      assert.match(html, new RegExp(`class="toolbar-group ${group}-group"`), `${name} must render the ${group} toolbar group`);
+      assert.match(
+        html,
+        new RegExp(`class="toolbar-group ${group}-group"`),
+        `${name} must render the ${group} toolbar group`,
+      );
     }
-    assert.match(html, /<nav class="nav" aria-label="Page navigation">/, `${name} must render page navigation`);
-    assert.doesNotMatch(html, /class="toolbar-group history-group"/, `${name} must place history actions in Document`);
-    assert.doesNotMatch(html, /id="page-select"/, `${name} must omit the visible Go to selector`);
+    assert.match(
+      html,
+      /<nav class="nav" aria-label="Page navigation">/,
+      `${name} must render page navigation`,
+    );
+    assert.doesNotMatch(
+      html,
+      /class="toolbar-group history-group"/,
+      `${name} must place history actions in Document`,
+    );
+    assert.doesNotMatch(
+      html,
+      /id="page-select"/,
+      `${name} must omit the visible Go to selector`,
+    );
   }
 });


### PR DESCRIPTION
### Motivation
- Make every JavaScript module under `UBTA/src` consistently human-readable and maintainable using Prettier and MDN JavaScript style guidance.
- Ensure the standalone bundler and build assertions are robust against Prettier's multiline imports/exports and minor whitespace changes.
- Add a repeatable, repo-local formatting workflow so formatting is checkable in CI and by contributors.

### Description
- Add a shared Prettier configuration file (`UBTA/.prettierrc.json`), new `format` / `format:check` npm scripts, and declare Prettier in `devDependencies` in `UBTA/package.json`.
- Reformat all JavaScript sources under `UBTA/src` (and the vendored `paged.js`) with Prettier; the changes expand and normalise whitespace, break long expressions, and make control flow and object literals readable.
- Update the standalone bundler (`UBTA/scripts/build.mjs`) to tolerate and strip multiline `import` / `export` forms emitted by Prettier and to produce a stable `dist/index.html` bundle.
- Tweak build-time tests (`UBTA/tests/build.test.js`) to use whitespace-tolerant regexes and minor sanity fixes, and regenerate the standalone bundle (`UBTA/dist/index.html`) to reflect the updated formatting.

### Testing
- Ran `npm run format:check` in `UBTA` and confirmed: All matched files use Prettier code style.
- Ran `npm test` (which executes `test:schema`, `test:editor`, and `test:build`) and confirmed the suites passed after fixes; schema, editor interaction, and build assertions succeeded.
- Verified `git diff --check` / `git status` after formatting and the changes were committed as a single refactor commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69f86b42f08324b98703b6c8a30d20)