### PR TITLE
Add UBTA wordmark and refine print/document styling

### DIFF
--- a/UBTA/dist/index.html
+++ b/UBTA/dist/index.html
@@ -2,12 +2,12 @@
   --lav: #8d8eb1;
   --coral: #f79097;
   --grey: #808080;
-  --paper: #fffefa;
-  --review: #ffe985;
-  --ink: #343444;
+  --paper: #fff;
+  --review: #fff500;
+  --ink: #111;
   --toolbar-blue: #17365d;
   --toolbar-yellow: #ffd966;
-  --font: "Century Gothic", "Futura", "Aptos", "Segoe UI", sans-serif;
+  --font: Arial, "Helvetica Neue", sans-serif;
 }
 * {
   box-sizing: border-box;
@@ -705,7 +705,7 @@ dialog label {
   width: 297mm;
   height: 210mm;
   position: relative;
-  padding: 42mm 24mm 18mm;
+  padding: 36mm 20mm 18mm;
   background: var(--paper);
   overflow: hidden;
 }
@@ -714,18 +714,40 @@ dialog label {
   top: 9mm;
   left: 20mm;
   right: 20mm;
-  height: 25mm;
+  height: 18mm;
   display: flex;
   align-items: center;
-  border-bottom: 0.4mm solid #8d8eb155;
-  padding-bottom: 3mm;
 }
 .header-brand {
-  font-size: 22pt;
+  display: inline-flex;
+  align-items: center;
+  gap: 2.5mm;
+  font-size: 25pt;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: -0.04em;
   color: var(--lav);
 }
+.brand-mark {
+  position: relative;
+  width: 12mm;
+  height: 12mm;
+}
+.brand-mark i {
+  position: absolute;
+  left: 5mm;
+  top: 0;
+  width: 2mm;
+  height: 4mm;
+  background: var(--coral);
+  transform-origin: 1mm 6mm;
+}
+.brand-mark i:nth-child(2) { transform: rotate(45deg); }
+.brand-mark i:nth-child(3) { transform: rotate(90deg); }
+.brand-mark i:nth-child(4) { transform: rotate(135deg); }
+.brand-mark i:nth-child(5) { transform: rotate(180deg); }
+.brand-mark i:nth-child(6) { transform: rotate(225deg); }
+.brand-mark i:nth-child(7) { transform: rotate(270deg); }
+.brand-mark i:nth-child(8) { transform: rotate(315deg); }
 .header-details {
   margin-left: auto;
   color: var(--grey);
@@ -742,28 +764,32 @@ dialog label {
   right: 20mm;
   text-align: center;
   color: var(--grey);
-  font-size: 9pt;
+  font-size: 8.5pt;
 }
 .cover {
-  padding-top: 48mm;
-}
-.cover-kicker {
-  color: var(--coral);
-  text-transform: uppercase;
-  letter-spacing: 0.15em;
-  font-size: 11pt;
+  padding-top: 28mm;
 }
 .cover h1 {
-  font-size: 30pt;
-  line-height: 1.08;
-  color: var(--lav);
-  margin: 5mm 0 2mm;
-  max-width: 190mm;
-}
-.cover h2 {
-  font-size: 18pt;
+  display: grid;
+  gap: 3mm;
+  margin: 13mm 0 0;
+  max-width: 245mm;
+  color: #000;
+  font-size: 25pt;
   font-weight: 400;
-  margin: 0 0 12mm;
+  line-height: 1.12;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+}
+.cover-subtitle {
+  margin-top: 12mm;
+}
+.cover-date {
+  position: absolute;
+  left: 20mm;
+  bottom: 44mm;
+  margin: 0;
+  font-size: 12pt;
 }
 .meta-grid {
   display: grid;
@@ -780,19 +806,18 @@ dialog label {
   margin: 0;
 }
 .doc-title {
-  font-size: 23pt;
-  color: var(--lav);
-  margin: 0 0 9mm;
+  font-size: 12pt;
+  color: #000;
+  margin: 0 0 1mm;
 }
 .section-title,
 .step-title {
-  font: 700 18pt var(--font);
-  color: var(--lav);
+  font: 700 11pt var(--font);
+  color: #000;
   border: 0;
-  border-bottom: 0.5mm solid var(--coral);
   background: transparent;
-  padding: 0 0 3mm;
-  margin: 0 0 7mm;
+  padding: 0;
+  margin: 0;
   width: 100%;
 }
 .step-title:focus {
@@ -800,15 +825,14 @@ dialog label {
   background: #fff;
 }
 .step-label {
-  color: var(--coral);
+  color: #000;
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin-bottom: 2mm;
+  white-space: nowrap;
 }
 .document-body {
-  font-size: 10.5pt;
-  line-height: 1.48;
+  margin-top: 8mm;
+  font-size: 9.5pt;
+  line-height: 1.38;
 }
 .editable-block {
   margin: 0 0 4mm;
@@ -889,7 +913,7 @@ a {
 .toc li {
   display: flex;
   align-items: baseline;
-  margin: 5mm 0;
+  margin: 2.2mm 0;
 }
 .toc a {
   color: var(--ink);
@@ -904,7 +928,7 @@ a {
   font-variant-numeric: tabular-nums;
 }
 .toc-step {
-  padding-left: 9mm;
+  padding-left: 4mm;
 }
 .table-block table {
   width: 100%;
@@ -919,12 +943,12 @@ a {
 .table-block th,
 .table-block td {
   position: relative;
-  border: 1px solid #bcbcca;
-  padding: 2mm;
+  border: 1px solid #111;
+  padding: 1mm 2mm;
   vertical-align: top;
 }
 .table-block th {
-  background: #ececf3;
+  background: #fff;
   text-align: left;
 }
 .table-block :is(.format-number, .format-gbp) {
@@ -1004,17 +1028,19 @@ h4,
   padding-left: 3mm;
 }
 .step-heading {
-  display: block;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  align-items: baseline;
+  gap: 10mm;
 }
 .step-title-print {
   display: none;
-  font: 700 18pt var(--font);
-  color: var(--lav);
+  font: 700 11pt var(--font);
+  color: #000;
   border: 0;
-  border-bottom: 0.5mm solid var(--coral);
   background: transparent;
-  padding: 0 0 3mm;
-  margin: 0 0 7mm;
+  padding: 0;
+  margin: 0;
   width: 100%;
   min-height: 0;
   white-space: normal;
@@ -4400,10 +4426,13 @@ const selectedEditableGroup = () =>
   ).find((x) => x.id === editorSelection.activeGroupId);
 const appendixLabel = (index) => `Appendix ${String.fromCharCode(65 + index)}`;
 
+function brandHTML() {
+  return `<span class="brand-mark" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></span><span class="brand-wordmark">UBTA</span>`;
+}
 function header() {
   const x = document.createElement('header');
   x.className = 'page-header';
-  x.innerHTML = `<span class="header-brand">UBTA</span><span class="header-details">${esc(state.meta.clientName)} · ${esc(state.meta.projectTitle)} · ${esc(state.meta.version)}</span>`;
+  x.innerHTML = `<span class="header-brand">${brandHTML()}</span>`;
   return x;
 }
 function sheet(kind) {
@@ -4476,7 +4505,7 @@ function groupSheet(group, title, kind) {
 }
 function cover() {
   const x = sheet('cover');
-  x.innerHTML += `<div class="cover-kicker">${esc(state.meta.documentType)} · ${esc(state.meta.status)}</div><h1>${esc(state.meta.clientName)}</h1><h2>${esc(state.meta.projectTitle)}</h2><p>${esc(state.meta.subtitle)}</p><p>${esc(state.meta.date)} · ${esc(state.meta.adviser)} · ${esc(state.meta.version)}</p>`;
+  x.innerHTML += `<h1><span>${esc(state.meta.clientName)}</span><span>${esc(state.meta.projectTitle)}</span></h1><p class="cover-subtitle">${esc(state.meta.subtitle)}</p><p class="cover-date">${esc(state.meta.date)}</p>`;
   return x;
 }
 function contentsEntries() {

--- a/UBTA/src/main.js
+++ b/UBTA/src/main.js
@@ -166,10 +166,13 @@ const selectedEditableGroup = () =>
   ).find((x) => x.id === editorSelection.activeGroupId);
 const appendixLabel = (index) => `Appendix ${String.fromCharCode(65 + index)}`;
 
+function brandHTML() {
+  return `<span class="brand-mark" aria-hidden="true"><i></i><i></i><i></i><i></i><i></i><i></i><i></i><i></i></span><span class="brand-wordmark">UBTA</span>`;
+}
 function header() {
   const x = document.createElement('header');
   x.className = 'page-header';
-  x.innerHTML = `<span class="header-brand">UBTA</span><span class="header-details">${esc(state.meta.clientName)} · ${esc(state.meta.projectTitle)} · ${esc(state.meta.version)}</span>`;
+  x.innerHTML = `<span class="header-brand">${brandHTML()}</span>`;
   return x;
 }
 function sheet(kind) {
@@ -242,7 +245,7 @@ function groupSheet(group, title, kind) {
 }
 function cover() {
   const x = sheet('cover');
-  x.innerHTML += `<div class="cover-kicker">${esc(state.meta.documentType)} · ${esc(state.meta.status)}</div><h1>${esc(state.meta.clientName)}</h1><h2>${esc(state.meta.projectTitle)}</h2><p>${esc(state.meta.subtitle)}</p><p>${esc(state.meta.date)} · ${esc(state.meta.adviser)} · ${esc(state.meta.version)}</p>`;
+  x.innerHTML += `<h1><span>${esc(state.meta.clientName)}</span><span>${esc(state.meta.projectTitle)}</span></h1><p class="cover-subtitle">${esc(state.meta.subtitle)}</p><p class="cover-date">${esc(state.meta.date)}</p>`;
   return x;
 }
 function contentsEntries() {

--- a/UBTA/src/styles/app.css
+++ b/UBTA/src/styles/app.css
@@ -2,12 +2,12 @@
   --lav: #8d8eb1;
   --coral: #f79097;
   --grey: #808080;
-  --paper: #fffefa;
-  --review: #ffe985;
-  --ink: #343444;
+  --paper: #fff;
+  --review: #fff500;
+  --ink: #111;
   --toolbar-blue: #17365d;
   --toolbar-yellow: #ffd966;
-  --font: "Century Gothic", "Futura", "Aptos", "Segoe UI", sans-serif;
+  --font: Arial, "Helvetica Neue", sans-serif;
 }
 * {
   box-sizing: border-box;

--- a/UBTA/src/styles/document.css
+++ b/UBTA/src/styles/document.css
@@ -2,7 +2,7 @@
   width: 297mm;
   height: 210mm;
   position: relative;
-  padding: 42mm 24mm 18mm;
+  padding: 36mm 20mm 18mm;
   background: var(--paper);
   overflow: hidden;
 }
@@ -11,18 +11,40 @@
   top: 9mm;
   left: 20mm;
   right: 20mm;
-  height: 25mm;
+  height: 18mm;
   display: flex;
   align-items: center;
-  border-bottom: 0.4mm solid #8d8eb155;
-  padding-bottom: 3mm;
 }
 .header-brand {
-  font-size: 22pt;
+  display: inline-flex;
+  align-items: center;
+  gap: 2.5mm;
+  font-size: 25pt;
   font-weight: 700;
-  letter-spacing: 0.04em;
+  letter-spacing: -0.04em;
   color: var(--lav);
 }
+.brand-mark {
+  position: relative;
+  width: 12mm;
+  height: 12mm;
+}
+.brand-mark i {
+  position: absolute;
+  left: 5mm;
+  top: 0;
+  width: 2mm;
+  height: 4mm;
+  background: var(--coral);
+  transform-origin: 1mm 6mm;
+}
+.brand-mark i:nth-child(2) { transform: rotate(45deg); }
+.brand-mark i:nth-child(3) { transform: rotate(90deg); }
+.brand-mark i:nth-child(4) { transform: rotate(135deg); }
+.brand-mark i:nth-child(5) { transform: rotate(180deg); }
+.brand-mark i:nth-child(6) { transform: rotate(225deg); }
+.brand-mark i:nth-child(7) { transform: rotate(270deg); }
+.brand-mark i:nth-child(8) { transform: rotate(315deg); }
 .header-details {
   margin-left: auto;
   color: var(--grey);
@@ -39,28 +61,32 @@
   right: 20mm;
   text-align: center;
   color: var(--grey);
-  font-size: 9pt;
+  font-size: 8.5pt;
 }
 .cover {
-  padding-top: 48mm;
-}
-.cover-kicker {
-  color: var(--coral);
-  text-transform: uppercase;
-  letter-spacing: 0.15em;
-  font-size: 11pt;
+  padding-top: 28mm;
 }
 .cover h1 {
-  font-size: 30pt;
-  line-height: 1.08;
-  color: var(--lav);
-  margin: 5mm 0 2mm;
-  max-width: 190mm;
-}
-.cover h2 {
-  font-size: 18pt;
+  display: grid;
+  gap: 3mm;
+  margin: 13mm 0 0;
+  max-width: 245mm;
+  color: #000;
+  font-size: 25pt;
   font-weight: 400;
-  margin: 0 0 12mm;
+  line-height: 1.12;
+  letter-spacing: 0.01em;
+  text-transform: uppercase;
+}
+.cover-subtitle {
+  margin-top: 12mm;
+}
+.cover-date {
+  position: absolute;
+  left: 20mm;
+  bottom: 44mm;
+  margin: 0;
+  font-size: 12pt;
 }
 .meta-grid {
   display: grid;
@@ -77,19 +103,18 @@
   margin: 0;
 }
 .doc-title {
-  font-size: 23pt;
-  color: var(--lav);
-  margin: 0 0 9mm;
+  font-size: 12pt;
+  color: #000;
+  margin: 0 0 1mm;
 }
 .section-title,
 .step-title {
-  font: 700 18pt var(--font);
-  color: var(--lav);
+  font: 700 11pt var(--font);
+  color: #000;
   border: 0;
-  border-bottom: 0.5mm solid var(--coral);
   background: transparent;
-  padding: 0 0 3mm;
-  margin: 0 0 7mm;
+  padding: 0;
+  margin: 0;
   width: 100%;
 }
 .step-title:focus {
@@ -97,15 +122,14 @@
   background: #fff;
 }
 .step-label {
-  color: var(--coral);
+  color: #000;
   font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  margin-bottom: 2mm;
+  white-space: nowrap;
 }
 .document-body {
-  font-size: 10.5pt;
-  line-height: 1.48;
+  margin-top: 8mm;
+  font-size: 9.5pt;
+  line-height: 1.38;
 }
 .editable-block {
   margin: 0 0 4mm;
@@ -186,7 +210,7 @@ a {
 .toc li {
   display: flex;
   align-items: baseline;
-  margin: 5mm 0;
+  margin: 2.2mm 0;
 }
 .toc a {
   color: var(--ink);
@@ -201,7 +225,7 @@ a {
   font-variant-numeric: tabular-nums;
 }
 .toc-step {
-  padding-left: 9mm;
+  padding-left: 4mm;
 }
 .table-block table {
   width: 100%;
@@ -216,12 +240,12 @@ a {
 .table-block th,
 .table-block td {
   position: relative;
-  border: 1px solid #bcbcca;
-  padding: 2mm;
+  border: 1px solid #111;
+  padding: 1mm 2mm;
   vertical-align: top;
 }
 .table-block th {
-  background: #ececf3;
+  background: #fff;
   text-align: left;
 }
 .table-block :is(.format-number, .format-gbp) {
@@ -301,17 +325,19 @@ h4,
   padding-left: 3mm;
 }
 .step-heading {
-  display: block;
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  align-items: baseline;
+  gap: 10mm;
 }
 .step-title-print {
   display: none;
-  font: 700 18pt var(--font);
-  color: var(--lav);
+  font: 700 11pt var(--font);
+  color: #000;
   border: 0;
-  border-bottom: 0.5mm solid var(--coral);
   background: transparent;
-  padding: 0 0 3mm;
-  margin: 0 0 7mm;
+  padding: 0;
+  margin: 0;
   width: 100%;
   min-height: 0;
   white-space: normal;

--- a/UBTA/tests/build.test.js
+++ b/UBTA/tests/build.test.js
@@ -14,6 +14,16 @@ const compactCss = (css) =>
     .replace(/\s*([{}:;,>])\s*/g, '$1')
     .replace(/;}\s*/g, '}');
 
+test('document bundle includes the UBTA report wordmark and print layout', () => {
+  execFileSync(process.execPath, ['scripts/build.mjs'], { cwd: root });
+  const html = fs.readFileSync(path.join(root, 'dist/index.html'), 'utf8');
+
+  assert.match(html, /class="brand-mark"/);
+  assert.match(html, /class="brand-wordmark">UBTA/);
+  assert.match(compactCss(html), /\.step-heading\{display:grid;grid-template-columns:max-content 1fr/);
+  assert.match(compactCss(html), /\.cover-date\{position:absolute/);
+});
+
 test('production bundle includes the blank-space insertion helper before its caller', () => {
   execFileSync(process.execPath, ['scripts/build.mjs'], { cwd: root });
   const html = fs.readFileSync(path.join(root, 'dist/index.html'), 'utf8');
@@ -141,7 +151,10 @@ test('heading titles use exactly one normal-flow representation in screen and pr
   const css = compactCss(
     fs.readFileSync(path.join(root, 'src/styles/document.css'), 'utf8'),
   );
-  assert.match(css, /\.step-heading\{display:block\}/);
+  assert.match(
+    css,
+    /\.step-heading\{display:grid;grid-template-columns:max-content 1fr/,
+  );
   assert.match(css, /\.step-title-print\{display:none;/);
   assert.match(
     css,


### PR DESCRIPTION
### Motivation
- Add the UBTA report wordmark to page headers and unify the document print styling for A4 output. 
- Improve typography, spacing and visual contrast for printed documents and the cover page. 
- Ensure the production bundle contains the new wordmark markup and that print-related CSS rules are present and applied in the build.

### Description
- Introduce a CSS-driven brand mark (`.brand-mark`) and a `brandHTML()` helper, and replace the plain text header with the composed wordmark in `src/main.js`, `src/styles/*.css`, and the generated `dist/index.html`.
- Revise print layout and document styles: adjust sheet padding, header height, cover layout, cover date placement, step heading layout (switch `.step-heading` to `display: grid` with `grid-template-columns`), font stack (to `Arial, "Helvetica Neue", sans-serif`), color tokens, table borders, padding and other spacing tweaks across `document.css` and `app.css`.
- Simplify cover markup and move metadata into structured elements (`.cover h1`, `.cover-subtitle`, `.cover-date`).
- Update `tests/build.test.js` to assert the presence of the new `brand-mark` and `brand-wordmark` output and to expect the adjusted CSS rules in the built `dist/index.html`.

### Testing
- Ran the automated build-and-test cycle invoked by the repository tests which execute the build via `scripts/build.mjs` and run the test suite in `tests/build.test.js`.
- Verified production bundle assertions including presence of `class="brand-mark"`, `class="brand-wordmark">UBTA`, and updated print/CSS patterns; all modified tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a69f96d9e208324bf7860d3cdf7d6a6)